### PR TITLE
docs: Facet-owned roadmap + README restraint

### DIFF
--- a/IMPLEMENTATION_PLAN.md
+++ b/IMPLEMENTATION_PLAN.md
@@ -1,13 +1,18 @@
 # Implementation Status and Roadmap
 
-This document records current scope and future product work. It is not required
-reading for ordinary implementation tasks; use the task-specific references in
-[AGENTS.md](AGENTS.md) and the [documentation index](docs/README.md).
+This document records Facet's current scope and future product work. It is not
+required reading for ordinary implementation tasks; use the task-specific
+references in [AGENTS.md](AGENTS.md) and the [documentation index](docs/README.md).
+
+Upstream Probe's planning history informed the inherited core; this file is the
+Facet-owned roadmap going forward.
 
 ## Current Foundation
 
-Probe currently has the product foundation originally planned for the first desktop
-release:
+### Inherited core (Probe)
+
+The workspace still carries the product foundation Probe established for the first
+desktop release:
 
 - a Rust workspace with separate core, OpenCollection, HTTP, CLI, desktop, Postman,
   and Yaak crates;
@@ -19,43 +24,65 @@ release:
   response handling;
 - a deterministic, non-interactive CLI with versioned JSON, stable exit codes, request
   and workspace editing, and Postman and Yaak import;
-- a GPUI desktop application with native workspace navigation, request editing,
-  execution, response inspection, session restoration, filesystem synchronization,
-  environment management, and keyboard-accessible tree editing;
 - performance fixtures and benchmarks for workspaces up to 10,000 requests.
 
-The public CLI contract is documented in [docs/CLI.md](docs/CLI.md). Current
-architecture and desktop behavior are documented in
-[docs/ARCHITECTURE.md](docs/ARCHITECTURE.md) and
-[docs/DESIGN.md](docs/DESIGN.md). Code and tests remain authoritative when a document
-falls behind.
+The public CLI contract is documented in [docs/CLI.md](docs/CLI.md). Shared
+architecture and upstream desktop design remain in
+[docs/ARCHITECTURE.md](docs/ARCHITECTURE.md) and [docs/DESIGN.md](docs/DESIGN.md).
+Code and tests remain authoritative when a document falls behind.
+
+### Facet today
+
+Facet-original surface on top of that core (see [docs/FACET.md](docs/FACET.md)):
+
+- the `facet` binary beside `probe` on `PATH` (packages `facet-cli` / `probe-cli`);
+- **Lattice** — workspace `.facet/lattice.db` plus a machine store for run history,
+  bodies, sessions, and cross-workspace index;
+- agent CLI: `history`, `blob`, `gc`, and recording on `request run`;
+- Ratatui TUI (`facet tui`) with Graphite Honey / Porcelain Honey; vim-modal keys
+  (default); `probe-desktop` remains a workspace member but is out of the default build;
+- Facet-original crates (`facet`, `lattice`, `facet-tui`) under MIT; upstream-derived
+  crates remain Apache-2.0.
 
 ## Planned Work
 
-The following capabilities are intentionally deferred. They require explicit task
-scope before implementation.
+### Facet-first
 
-### User-Defined Themes
+These require explicit task scope before implementation:
+
+- Lattice engine options behind cargo features (`lattice-turso`; analytics via external
+  DuckDB ATTACH — not a default product path);
+- TUI depth (collections browser, run inspector, vim-modal command surface polish);
+- Public docs/brand seating and release tagging aligned with workspace version;
+- Anything that changes Facet-only contracts in [docs/FACET.md](docs/FACET.md).
+
+### Inherited deferred (still open upstream)
+
+The following were intentionally deferred in Probe's plan and remain out of Facet's
+default scope until explicitly tasked. Prefer contributing shared core work upstream
+when it belongs in `probe-core` / `probe-cli`.
+
+#### User-Defined Themes
 
 Add versioned, human-editable theme files after the semantic token model is stable.
 Parsing and validation must remain outside components, invalid themes must fall back
 safely to built-ins, and theme configuration must remain local presentation data rather
-than OpenCollection content. The design contract lives in
+than OpenCollection content. Design contract:
 [docs/DESIGN.md](docs/DESIGN.md#future-plain-text-themes).
 
-### Streaming Protocols
+#### Streaming Protocols
 
 Design a shared protocol session/event abstraction before adding WebSocket, SSE, or
 gRPC. Protocol implementations must be independent of stdin/stdout and GPUI; the CLI
-may adapt events to JSONL while the desktop adapts the same events to visual sessions.
+may adapt events to JSONL while a desktop/TUI adapts the same events to visual sessions.
 
-### Git Integration
+#### Git Integration
 
 The filesystem remains the primary Git boundary. Optional built-in status, diff,
 branch, commit, pull, and push workflows may be added later without coupling core
 collection behavior to a hosting provider.
 
-### MCP Interface
+#### MCP Interface
 
 An MCP server may eventually become another adapter over the shared application layer.
 It must not duplicate business logic or depend on parsing CLI output.
@@ -70,3 +97,4 @@ It must not duplicate business logic or depend on parsing CLI output.
   and affected architectural boundaries.
 - Keep speculative provider integrations, cloud services, accounts, telemetry,
   analytics, plugins, and unsupported protocols out of scope until explicitly approved.
+- Facet-only work stays in Facet crates; shared-core fixes are offered upstream first.

--- a/README.md
+++ b/README.md
@@ -24,24 +24,23 @@
   <a href="#what-you-get">What you get</a> ·
   <a href="#how-it-works">How it works</a> ·
   <a href="#status">Status</a> ·
+  <a href="IMPLEMENTATION_PLAN.md">Roadmap</a> ·
   <a href="#contributing">Contributing</a>
 </p>
 
 <p align="center">
-  Built by <a href="https://hedronite.com">Hedronite</a>'s <a href="https://x.com/Hedronite">VirtualMachinist</a>.
-  Core engine by <a href="https://github.com/crizant/probe">Probe</a>. Not affiliated with Probe or crizant.<br>
+  Built by <a href="https://hedronite.com">Hedronite</a>'s <a href="https://github.com/VirtualMachinist">VirtualMachinist</a>.
+  Fork of <a href="https://github.com/crizant/probe">Probe</a>.
   <em>The Facet mark is the graphite honey hex lattice.</em>
 </p>
 
 ---
 
-Facet is a fast, native API client that keeps your collections in plain OpenCollection YAML files. It is Hedronite's terminal-optimized fork of [Probe](https://github.com/crizant/probe). The core engine and CLI contracts are identical, but Facet adds a Ratatui interface and **Lattice**, a local SQLite store that remembers every run.
+Facet is a fast, native, local-first API client. Collections stay OpenCollection YAML on disk; Git stays the sync layer. **Lattice** remembers what surrounds them — runs, bodies, timings, sessions — in local SQLite. A Ratatui TUI and an agent-friendly CLI sit on the same core.
 
-It exists for **developers and agents who want a persistent terminal workflow**: deterministic JSON outputs, content-addressed blobs, and a run history that survives the session. If you love Probe's filesystem-first approach but need to query your request history with SQL or pipe responses into agent workflows, this is the way in.
+It is for people who want a durable terminal workflow: deterministic JSON, content-addressed blobs, and SQL over history, without an account or hosted control plane. The `facet` binary coexists with `probe` on `PATH`.
 
-Facet is not a competing standard and not a rewrite. It is Probe's own core, vendored into a workspace and driven by terminal-first adapters. We are members of the Probe community, and we send core fixes upstream.
-
-**0.5.7** release · **100%** OpenCollection YAML compatible · **1** Ratatui TUI · **SQLite** default engine
+**0.5.7** · OpenCollection YAML · Ratatui TUI · SQLite Lattice
 
 ## Quick start
 
@@ -106,7 +105,7 @@ Facet rebuilds the terminal and history layers. The core domain and HTTP executi
 
 ## How it works
 
-One rule drives the whole design: **if it's core business logic, it goes upstream. If it's terminal UI or run history, it's Facet.** Nothing the user touches gets rewritten in Facet if Probe already models it.
+One rule drives the design: **YAML holds the collection; Lattice holds the history.** Terminal UI and run memory are Facet; shared core stays cherry-pickable.
 
 - The `facet` binary coexists with `probe` on `PATH`. Collection files stay YAML; Git stays the sync layer. Lattice never holds the collection itself.
 - **Lattice** uses SQLite beside the YAML (`.facet/lattice.db`) plus a machine store for secrets, sessions, and a cross-workspace run index.
@@ -143,15 +142,13 @@ Facet is the working tree at 0.5.7; track `main`. The Lattice schema is versione
 
 ## Contributing
 
-Issues and pull requests are welcome. Start with [AGENTS.md](AGENTS.md) and [docs/FACET.md](docs/FACET.md) for the rules the tree already follows. Two of them matter most: core logic belongs in Probe, and Facet-only crates are strictly separated.
-
-When something we fix turns out to be a Probe bug rather than a terminal-ism, it goes upstream. Being a good citizen of the Probe community is part of the job.
+Issues and pull requests are welcome. Start with [AGENTS.md](AGENTS.md) and [docs/FACET.md](docs/FACET.md). Roadmap: [IMPLEMENTATION_PLAN.md](IMPLEMENTATION_PLAN.md). Development practices for this tree: [docs/DEVELOPMENT.md](docs/DEVELOPMENT.md).
 
 ## Credits and license
 
-Facet is built and maintained by [Hedronite](https://hedronite.com). The core engine is [Probe](https://github.com/crizant/probe) by crizant.
+Facet is built and maintained by [Hedronite](https://hedronite.com). Upstream lineage: [Probe](https://github.com/crizant/probe).
 
 - **Facet-original crates** (`facet`, `lattice`, `facet-tui`): MIT License, Copyright 2026 Hedronite.
 - **Upstream-derived crates and files**: Apache License 2.0 (Probe).
 
-See [LICENSE](LICENSE) and [NOTICE](NOTICE) for the fork relationship and full terms. The Facet mark is Hedronite's.
+See [LICENSE](LICENSE) and [NOTICE](NOTICE). The Facet mark is Hedronite's.


### PR DESCRIPTION
- Rewrite \`IMPLEMENTATION_PLAN.md\` as Facet-owned roadmap (inherited core + Facet today + Facet-first plans + inherited deferred).
- Tighten root README: product-first prose, short Probe credit, no community membership essay; Contributing points at in-repo AGENTS/FACET/DEVELOPMENT/roadmap (not upstream Probe docs as primary).
- Roadmap link in TOC.