### PR TITLE
chore: WAL busy_timeout, DuckDB ATTACH demo, fold Probe roadmap

### DIFF
--- a/IMPLEMENTATION_PLAN.md
+++ b/IMPLEMENTATION_PLAN.md
@@ -46,46 +46,80 @@ Facet-original surface on top of that core (see [docs/FACET.md](docs/FACET.md)):
 
 ## Planned Work
 
-### Facet-first
+Folded from Probe's public roadmap
+([rusty-probe.pages.dev](https://rusty-probe.pages.dev)): HTTP is live; next is
+WebSocket, GraphQL, gRPC streaming, custom themes, git integration, secret
+storage, and *and more*. Facet ships these independently where we already own
+the layer, and contributes shared core upstream. Protocol work in `probe-core`
+is written as an upstream PR; Facet TUI/CLI/Lattice adapters land in this tree
+in parallel.
 
-These require explicit task scope before implementation:
+### Shipped (Facet)
 
-- Lattice engine options behind cargo features (`lattice-turso`; analytics via external
-  DuckDB ATTACH — not a default product path);
-- TUI depth (collections browser, run inspector, vim-modal command surface polish);
-- Public docs/brand seating and release tagging aligned with workspace version;
-- Anything that changes Facet-only contracts in [docs/FACET.md](docs/FACET.md).
+| Probe item | Facet |
+| --- | --- |
+| 01 HTTP requests | Live. Same engine as Probe. Lattice records every `request run` / TUI send. |
+| 05 Custom theme support | **Partial.** Graphite Honey (default) and Porcelain Honey, `:theme` toggle, `--appearance`. User-defined theme files are still open (see below). |
+| 07 Secret storage | **Facet machine store.** OS keyring or `FACET_SECRET_KEY` XChaCha20-Poly1305. Probe desktop secret UX remains upstream. |
 
-### Inherited deferred (still open upstream)
+### Next (Probe-aligned)
 
-The following were intentionally deferred in Probe's plan and remain out of Facet's
-default scope until explicitly tasked. Prefer contributing shared core work upstream
-when it belongs in `probe-core` / `probe-cli`.
+Ship in Facet; offer the shared core upstream first when it touches
+`probe-core` / `probe-cli`. Thread A (`protocol-session` on
+`repos/probe-upstream`) stays parked until unparked — adapters can still be
+designed against the event shape.
 
-#### User-Defined Themes
+| # | Item | Facet slice | Upstream |
+| --- | --- | --- | --- |
+| 02 | WebSocket | TUI session pane + Lattice events + `facet` JSONL | Protocol session/event abstraction in `probe-core` |
+| 03 | GraphQL | Collection item + TUI editor + history | Shared operation/variables model |
+| 04 | gRPC streaming | Same session adapter as WebSocket | Streaming on the protocol session |
+| 05 | Custom themes (rest) | Versioned theme files for `facet-tui` | Desktop theme files per [docs/DESIGN.md](docs/DESIGN.md#future-plain-text-themes) |
+| 06 | Git integration | Optional status/diff/commit in TUI; filesystem stays the Git boundary | No provider coupling in core |
+| 07 | Secret storage (rest) | Already in Lattice; wire TUI env editor to the machine store | Probe desktop |
 
-Add versioned, human-editable theme files after the semantic token model is stable.
-Parsing and validation must remain outside components, invalid themes must fall back
-safely to built-ins, and theme configuration must remain local presentation data rather
-than OpenCollection content. Design contract:
+### Facet-only (not on Probe's list)
+
+- Lattice engines: rusqlite default; `lattice-turso` feature; analytics via
+  external DuckDB ATTACH (`scripts/duckdb-attach-demo.sh`). In-process
+  `lattice-duckdb` is apiary-only, never lathe.
+- TUI depth: collections browser, run inspector, vim-modal polish. `ctrl+u` /
+  `ctrl+d` deferred.
+- MCP / harness adapter over Lattice (must not parse CLI output). Sketch lives
+  with fullstack's 2026-09-07 "and more" note.
+- Public docs/brand seating and release tagging aligned with workspace version.
+
+### Exploring (*and more*)
+
+Probe's last roadmap item is open-ended. Facet explores it as agent-harness
+integration, run replay, and Lattice-powered recall — not a second desktop
+Postman. See `agents/fullstack/notes/2026-09-07-and-more.md` in the Lapis vault
+once it lands.
+
+### Inherited notes (still load-bearing)
+
+#### User-defined theme files
+
+Versioned, human-editable theme files after the semantic token model is stable.
+Parsing and validation stay outside components; invalid themes fall back to
+built-ins. Local presentation data, not OpenCollection content.
 [docs/DESIGN.md](docs/DESIGN.md#future-plain-text-themes).
 
-#### Streaming Protocols
+#### Streaming protocols
 
-Design a shared protocol session/event abstraction before adding WebSocket, SSE, or
-gRPC. Protocol implementations must be independent of stdin/stdout and GPUI; the CLI
-may adapt events to JSONL while a desktop/TUI adapts the same events to visual sessions.
+Shared protocol session/event abstraction before WebSocket, SSE, or gRPC.
+Implementations independent of stdin/stdout and GPUI; CLI adapts events to
+JSONL, TUI/desktop to visual sessions.
 
-#### Git Integration
+#### Git
 
-The filesystem remains the primary Git boundary. Optional built-in status, diff,
-branch, commit, pull, and push workflows may be added later without coupling core
-collection behavior to a hosting provider.
+Filesystem remains the primary Git boundary. Optional built-in status, diff,
+branch, commit, pull, and push later, without coupling collections to a host.
 
-#### MCP Interface
+#### MCP
 
-An MCP server may eventually become another adapter over the shared application layer.
-It must not duplicate business logic or depend on parsing CLI output.
+Another adapter over the shared application layer. Must not duplicate business
+logic or depend on parsing CLI output.
 
 ## Planning Rules
 

--- a/README.md
+++ b/README.md
@@ -140,6 +140,11 @@ Facet is the working tree at 0.5.7; track `main`. The Lattice schema is versione
 - **TUI**: Ready. Graphite Honey / Porcelain Honey themes via Ratatui.
 - **Agent CLI**: Ready. Deterministic JSON and SQL querying.
 
+HTTP is live. Next, folded from [Probe's roadmap](https://rusty-probe.pages.dev):
+WebSocket, GraphQL, gRPC streaming, user-defined themes, git integration, and
+the rest of secret storage. Facet ships those independently where we own the
+layer, and contributes shared core upstream. Details: [IMPLEMENTATION_PLAN.md](IMPLEMENTATION_PLAN.md).
+
 ## Contributing
 
 Issues and pull requests are welcome. Start with [AGENTS.md](AGENTS.md) and [docs/FACET.md](docs/FACET.md). Roadmap: [IMPLEMENTATION_PLAN.md](IMPLEMENTATION_PLAN.md). Development practices for this tree: [docs/DEVELOPMENT.md](docs/DEVELOPMENT.md).

--- a/crates/lattice/tests/store.rs
+++ b/crates/lattice/tests/store.rs
@@ -33,19 +33,26 @@ fn run<'a>(path: &'a str, body: &'a [u8]) -> NewRun<'a> {
 #[test]
 fn open_connection_honors_wal_flag() {
     let wal_dir = tempfile::tempdir().unwrap();
-    WorkspaceStore::open(wal_dir.path(), LatticeConfig::default()).unwrap();
+    let store = WorkspaceStore::open(wal_dir.path(), LatticeConfig::default()).unwrap();
     let wal_db = wal_dir.path().join(".facet/lattice.db");
+    // WAL is a file-mode: a fresh connection sees it.
     let wal_mode: String = rusqlite::Connection::open(&wal_db)
         .unwrap()
         .query_row("PRAGMA journal_mode", [], |row| row.get(0))
         .unwrap();
     assert_eq!(wal_mode, "wal");
+    assert_eq!(
+        pragma_busy_timeout(&store),
+        5000,
+        "default busy_timeout is 5 s"
+    );
 
     let rollback_dir = tempfile::tempdir().unwrap();
-    WorkspaceStore::open(
+    let store = WorkspaceStore::open(
         rollback_dir.path(),
         LatticeConfig {
             wal: false,
+            busy_timeout_ms: 1234,
             ..LatticeConfig::default()
         },
     )
@@ -56,6 +63,24 @@ fn open_connection_honors_wal_flag() {
         .query_row("PRAGMA journal_mode", [], |row| row.get(0))
         .unwrap();
     assert_eq!(rollback_mode, "delete");
+    assert_eq!(pragma_busy_timeout(&store), 1234);
+}
+
+fn pragma_busy_timeout(store: &WorkspaceStore) -> i64 {
+    // busy_timeout is per-connection; WorkspaceStore::query opens a
+    // read-only connection and applies config.busy_timeout_ms to it.
+    store
+        .query("PRAGMA busy_timeout")
+        .unwrap()
+        .rows
+        .into_iter()
+        .next()
+        .and_then(|row| row.into_iter().next())
+        .and_then(|value| match value {
+            SqlValue::Integer(n) => Some(n),
+            _ => None,
+        })
+        .expect("busy_timeout row")
 }
 
 #[test]
@@ -211,7 +236,10 @@ fn v1_to_v2_migration_hydrates_inline_request_bodies() {
 
     // Reopen through the store: hydration + 0002 migration run on open.
     let store = WorkspaceStore::open(dir.path(), config(1 << 20)).unwrap();
-    assert_eq!(store.schema_version().unwrap(), lattice::WORKSPACE_SCHEMA_VERSION);
+    assert_eq!(
+        store.schema_version().unwrap(),
+        lattice::WORKSPACE_SCHEMA_VERSION
+    );
     let row = store.run("01JAV1MIGR0000000001").unwrap().unwrap();
     assert_eq!(row.req_body.retention(), "blob");
     let hash = row.req_body.hash.clone().unwrap();
@@ -240,10 +268,7 @@ fn reader_rule_never_branches_on_length() {
     let row = store.run(&recorded.id).unwrap().unwrap();
     assert_eq!(row.res_body.len, Some(999999));
     assert!(row.res_body.hash.is_none());
-    assert_eq!(
-        store.response_body(&row).unwrap().unwrap(),
-        b"short"
-    );
+    assert_eq!(store.response_body(&row).unwrap().unwrap(), b"short");
 }
 
 #[test]
@@ -464,7 +489,6 @@ fn machine_store_indexes_runs_by_workspace() {
     assert_eq!(actor.as_deref(), Some("human"));
 }
 
-
 #[test]
 fn environments_round_trip_plain_and_secret() {
     let dir = tempfile::tempdir().unwrap();
@@ -474,10 +498,20 @@ fn environments_round_trip_plain_and_secret() {
 
     // Plain value: stored in the value column, secret_ref NULL.
     machine
-        .set_environment_with(wsid, "local", "API_URL", "http://x", false, &SecretConfig::keyring())
+        .set_environment_with(
+            wsid,
+            "local",
+            "API_URL",
+            "http://x",
+            false,
+            &SecretConfig::keyring(),
+        )
         .unwrap();
     assert_eq!(
-        machine.environment_with(wsid, "local", "API_URL", &SecretConfig::keyring()).unwrap().as_deref(),
+        machine
+            .environment_with(wsid, "local", "API_URL", &SecretConfig::keyring())
+            .unwrap()
+            .as_deref(),
         Some("http://x")
     );
 
@@ -487,7 +521,10 @@ fn environments_round_trip_plain_and_secret() {
         .set_environment_with(wsid, "local", "API_TOKEN", "tok-123", true, &key_cfg)
         .unwrap();
     assert_eq!(
-        machine.environment_with(wsid, "local", "API_TOKEN", &key_cfg).unwrap().as_deref(),
+        machine
+            .environment_with(wsid, "local", "API_TOKEN", &key_cfg)
+            .unwrap()
+            .as_deref(),
         Some("tok-123")
     );
 
@@ -501,22 +538,51 @@ fn environments_round_trip_plain_and_secret() {
     assert!(!rows[1].secret);
 
     // A secret cannot be read without the right key.
-    assert!(machine
-        .environment_with(wsid, "local", "API_TOKEN", &SecretConfig::encrypted(b"wrong"))
-        .is_err());
+    assert!(
+        machine
+            .environment_with(
+                wsid,
+                "local",
+                "API_TOKEN",
+                &SecretConfig::encrypted(b"wrong")
+            )
+            .is_err()
+    );
 
     // Replacing a secret with a plain value drops the old secret_ref.
     machine
         .set_environment_with(wsid, "local", "API_TOKEN", "plain-now", false, &key_cfg)
         .unwrap();
     assert_eq!(
-        machine.environment_with(wsid, "local", "API_TOKEN", &key_cfg).unwrap().as_deref(),
+        machine
+            .environment_with(wsid, "local", "API_TOKEN", &key_cfg)
+            .unwrap()
+            .as_deref(),
         Some("plain-now")
     );
-    assert!(!machine.environments(wsid).unwrap().iter().any(|r| r.key == "API_TOKEN" && r.secret));
+    assert!(
+        !machine
+            .environments(wsid)
+            .unwrap()
+            .iter()
+            .any(|r| r.key == "API_TOKEN" && r.secret)
+    );
 
     // Delete removes the row.
-    assert!(machine.delete_environment_with(wsid, "local", "API_TOKEN", &key_cfg).unwrap());
-    assert!(machine.environment_with(wsid, "local", "API_TOKEN", &key_cfg).unwrap().is_none());
-    assert!(!machine.delete_environment_with(wsid, "local", "API_TOKEN", &key_cfg).unwrap());
+    assert!(
+        machine
+            .delete_environment_with(wsid, "local", "API_TOKEN", &key_cfg)
+            .unwrap()
+    );
+    assert!(
+        machine
+            .environment_with(wsid, "local", "API_TOKEN", &key_cfg)
+            .unwrap()
+            .is_none()
+    );
+    assert!(
+        !machine
+            .delete_environment_with(wsid, "local", "API_TOKEN", &key_cfg)
+            .unwrap()
+    );
 }

--- a/docs/FACET.md
+++ b/docs/FACET.md
@@ -182,7 +182,8 @@ file format:
 | `lattice-duckdb` | DuckDB in-process (bundled) | **Apiary-only; never in lathe default members.** ATTACHes the SQLite lattice file for analytics. Smoke: `crates/lattice/tests/duckdb.rs`. Heavy native build. |
 
 The primary analytics path is the **`duckdb` CLI** attaching the SQLite
-file externally (no Rust, no feature flag):
+file externally (no Rust, no feature flag). Durable smoke:
+`scripts/duckdb-attach-demo.sh` (uses `duckdb` on `PATH` or `~/bin/duckdb`).
 
 ```text
 duckdb -c "INSTALL sqlite; LOAD sqlite; \
@@ -215,6 +216,10 @@ Graphite Honey is the TUI default. `:theme` (bare) toggles Porcelain Honey;
 `:theme graphite|porcelain` sets one. `:history` and `:sql <query>` open
 Lattice overlays. `gg` / `G` jump to the first / last row of the focused
 pane. `?` lists the rest.
+
+Roadmap (Probe's public list, folded): HTTP live; next WebSocket, GraphQL,
+gRPC streaming, user-defined theme files, git integration. Secret storage
+is already in the Facet machine store. See [IMPLEMENTATION_PLAN.md](../IMPLEMENTATION_PLAN.md).
 
 `<path>` for `history`, `blob`, and `gc` is any file or directory inside the
 workspace (default: the current directory); Facet walks up to the nearest

--- a/scripts/duckdb-attach-demo.sh
+++ b/scripts/duckdb-attach-demo.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+# External DuckDB ATTACH of a Lattice workspace store.
+# Primary analytics path (no Rust, no cargo feature). Apiary-only smoke.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+DUCKDB="${DUCKDB:-}"
+if [[ -z "$DUCKDB" ]]; then
+  if command -v duckdb >/dev/null 2>&1; then
+    DUCKDB="$(command -v duckdb)"
+  elif [[ -x "$HOME/bin/duckdb" ]]; then
+    DUCKDB="$HOME/bin/duckdb"
+  else
+    echo "error: duckdb CLI not found (set DUCKDB= or put it on PATH / ~/bin/duckdb)" >&2
+    exit 1
+  fi
+fi
+command -v sqlite3 >/dev/null 2>&1 || {
+  echo "error: sqlite3 CLI required to seed the store" >&2
+  exit 1
+}
+
+WORKDIR="${TMPDIR:-/tmp}/facet-duckdb-attach-$$"
+cleanup() { rm -rf "$WORKDIR"; }
+trap cleanup EXIT
+mkdir -p "$WORKDIR/.facet"
+DB="$WORKDIR/.facet/lattice.db"
+
+sqlite3 "$DB" <"$ROOT/crates/lattice/migrations/workspace/0001_init.sql"
+sqlite3 "$DB" <"$ROOT/crates/lattice/migrations/workspace/0002_hash_only_req.sql"
+sqlite3 "$DB" <<'SQL'
+INSERT INTO runs (id, started_at, duration_ms, request_path, request_hash, method, url, status, actor, res_body_len) VALUES
+ ('01JA1',1757000001000,128,'users/list.yml','h1','GET','http://api/users',200,'agent-a',512),
+ ('01JA2',1757000002000,407,'users/list.yml','h1','GET','http://api/users',200,'agent-a',512),
+ ('01JA3',1757000003000,503,'items/0','h2','POST','http://api/items',500,'human',2048);
+INSERT INTO blobs (hash, len, content_type, created_at) VALUES ('abc',512,'application/json',1757000001000);
+SQL
+
+HISTOGRAM="$("$DUCKDB" -csv -c "INSTALL sqlite; LOAD sqlite; ATTACH '$DB' AS lattice (TYPE SQLITE);
+SELECT status, count(*) AS n, round(avg(duration_ms),1) AS avg_ms FROM lattice.runs GROUP BY status ORDER BY status;")"
+echo "$HISTOGRAM"
+echo "$HISTOGRAM" | grep -q '^200,2,267.5$' || {
+  echo "error: expected status 200 → 2 rows, avg 267.5 ms" >&2
+  echo "$HISTOGRAM" >&2
+  exit 1
+}
+echo "$HISTOGRAM" | grep -q '^500,1,503.0$' || {
+  echo "error: expected status 500 → 1 row, avg 503.0 ms" >&2
+  echo "$HISTOGRAM" >&2
+  exit 1
+}
+
+echo "ok: duckdb ATTACH analytics over $DB"


### PR DESCRIPTION
## Why

Evan 2026-09-07: confirm Surfaces 4/5/6, clean trees, handle DuckDB ATTACH + WAL pragma leftovers, fold [Probe's public roadmap](https://rusty-probe.pages.dev) into Facet's.

## Leftovers

- **WAL.** `open_connection_honors_wal_flag` now also asserts `busy_timeout` (default 5000 ms; override 1234 on the store connection). `journal_mode` wal vs delete unchanged.
- **DuckDB ATTACH.** Durable smoke at `scripts/duckdb-attach-demo.sh` (CLI on `PATH` or `~/bin/duckdb`). In-process `lattice-duckdb` test still the apiary-only cargo path.

Apiary: lattice `--test store` **14/14**, demo histogram `200,2,267.5` / `500,1,503.0`, `cargo test -p lattice --features lattice-duckdb --test duckdb` ok.

## Roadmap fold

`IMPLEMENTATION_PLAN.md` is now the Facet-owned map of Probe's list:

| Probe | Facet |
| --- | --- |
| HTTP | Live + Lattice recording |
| WebSocket / GraphQL / gRPC | Next. Core upstream-first; TUI/CLI/Lattice adapters here |
| Custom themes | Partial (Graphite / Porcelain / `:theme`); user files still open |
| Git | Filesystem remains the boundary |
| Secret storage | Machine store shipped; TUI wiring later |

Thread A (`protocol-session`) stays parked. `ctrl+u`/`ctrl+d` and the `facet-record` large-variant lint stay deferred.

Vault brief Decision lines for Surfaces 4/5/6 dated 2026-09-07 (not in this PR).