### PR TITLE
docs(lattice): catch up next-slice write-up onto main

### DIFF
--- a/IMPLEMENTATION_PLAN.md
+++ b/IMPLEMENTATION_PLAN.md
@@ -78,23 +78,35 @@ designed against the event shape.
 | 06 | Git integration | Optional status/diff/commit in TUI; filesystem stays the Git boundary | No provider coupling in core |
 | 07 | Secret storage (rest) | Already in Lattice; wire TUI env editor to the machine store | Probe desktop |
 
-### Facet-only (not on Probe's list)
+### Facet-only — next slice (*and more*)
 
-- Lattice engines: rusqlite default; `lattice-turso` feature; analytics via
-  external DuckDB ATTACH (`scripts/duckdb-attach-demo.sh`). In-process
-  `lattice-duckdb` is apiary-only, never lathe.
-- TUI depth: collections browser, run inspector, vim-modal polish. `ctrl+u` /
-  `ctrl+d` deferred.
-- MCP / harness adapter over Lattice (must not parse CLI output). Sketch lives
-  with fullstack's 2026-09-07 "and more" note.
-- Public docs/brand seating and release tagging aligned with workspace version.
+Probe's last public item is open-ended. Facet's is Lattice doing work:
+send → see → compare → send again, with a ULID an agent can hold. Canonical
+write-up: [docs/FACET.md](docs/FACET.md#next-slice). Product note:
+`agents/fullstack/notes/2026-09-07-and-more.md` in the Lapis vault.
 
-### Exploring (*and more*)
+**Ship next** (ranked):
 
-Probe's last roadmap item is open-ended. Facet explores it as agent-harness
-integration, run replay, and Lattice-powered recall — not a second desktop
-Postman. See `agents/fullstack/notes/2026-09-07-and-more.md` in the Lapis vault
-once it lands.
+1. Session lifecycle — `facet session start/end`, mint-if-missing, `history --session`
+2. Recall — `history --id` plus `--session/--environment/--tag/--hash`; TUI history grid hydrates the response pane
+3. Replay — current YAML at the recorded env; warn on hash change; `--frozen` refuses
+4. Hash-first diff — `facet diff <a> <b>`; exit 1 on mismatch
+5. Secret hydration — Lattice env as `--var` before resolve
+6. Dry-run + `--expect` — upstream-first; `--expect` is exit 6 `expect_failed`
+
+**Load-bearing picks** for that slice (recommended): replay = current YAML;
+overlay secrets now; `--expect` = exit 6; MCP after 1–6; git HEAD stamp skip
+or 0003 column, not a blocker.
+
+MCP / harness adapter over Lattice must not parse CLI output. Engines stay
+rusqlite default; DuckDB ATTACH is `scripts/duckdb-attach-demo.sh`. TUI
+`ctrl+u` / `ctrl+d` deferred.
+
+### Facet-only (later)
+
+- TUI depth: collections browser, run inspector, vim-modal polish
+- Public docs/brand seating and release tagging aligned with workspace version
+- `history --follow --jsonl`, fixtures from blobs, watch, FTS5
 
 ### Inherited notes (still load-bearing)
 

--- a/IMPLEMENTATION_PLAN.md
+++ b/IMPLEMENTATION_PLAN.md
@@ -94,9 +94,10 @@ write-up: [docs/FACET.md](docs/FACET.md#next-slice). Product note:
 5. Secret hydration — Lattice env as `--var` before resolve
 6. Dry-run + `--expect` — upstream-first; `--expect` is exit 6 `expect_failed`
 
-**Load-bearing picks** for that slice (recommended): replay = current YAML;
-overlay secrets now; `--expect` = exit 6; MCP after 1–6; git HEAD stamp skip
-or 0003 column, not a blocker.
+**Load-bearing picks** for that slice: replay = current YAML; overlay secrets
+now; MCP after 1–6. Still open: `--expect` exit **6 vs 1** (explore pass
+argues 1 so agents do not retry assertion misses); git HEAD skip / auto-tag
+rather than 0003.
 
 MCP / harness adapter over Lattice must not parse CLI output. Engines stay
 rusqlite default; DuckDB ATTACH is `scripts/duckdb-attach-demo.sh`. TUI

--- a/crates/lattice/src/lib.rs
+++ b/crates/lattice/src/lib.rs
@@ -12,8 +12,14 @@
 //!   environments, preferences.
 //!
 //! Decisions and defaults come from `FACET_HANDOFF_BRIEF.md` (Surfaces 1,
-//! 3, 4, 5). Engine order: bundled SQLite now, Turso behind a feature later,
-//! never DuckDB in the binary.
+//! 3, 4, 5). Engine order: bundled SQLite now, Turso behind a feature later.
+//! DuckDB ATTACHes the SQLite file out of process (`scripts/duckdb-attach-demo.sh`);
+//! the in-process `lattice-duckdb` feature is apiary-only, never lathe.
+//!
+//! **Next slice** (sessions, recall, replay, hash-diff, secret hydration,
+//! `--expect`): `docs/FACET.md` § Next slice. The `sessions` table and
+//! [`WorkspaceStore::run`] exist; they have no CLI yet. `FACET_SESSION` is
+//! written onto the run row without minting a parent session.
 
 #![forbid(unsafe_code)]
 

--- a/docs/FACET.md
+++ b/docs/FACET.md
@@ -121,6 +121,43 @@ in the output means the run is recorded but not indexed).
 Environment: `FACET_ACTOR` names the actor (default `human`);
 `FACET_SESSION` sets `sessionId`; `FACET_NO_RECORD=1` disables recording.
 
+`FACET_SESSION` is written onto the run row today. The machine-store
+`sessions` table has no API yet; a session id with no parent row is a
+dangling FK (acceptable until the next slice mints-if-missing).
+
+### Next slice
+
+Lattice already records more than the CLI and TUI expose. `:history` is a
+dump (no run id, cannot hydrate). `WorkspaceStore::run(id)` exists and has
+no command. Secrets sit in the machine store and are never joined at
+resolve time. The next Facet-only train fills that gap — **faster loops,
+better recall** — not protocols and not a Postman clone.
+
+Ranked (fullstack, 2026-09-07). Smallest vertical slice first.
+
+| # | Item | Smallest slice | Belonging |
+| --- | --- | --- | --- |
+| 1 | **Session lifecycle** | `facet session start/end`; mint-if-missing when `FACET_SESSION` is set; `history --session` | Facet-only (`lattice` + `facet` + `facet-record`) |
+| 2 | **Recall** | `history --id <ulid>`; filters `--session/--environment/--tag/--hash`; TUI grid hydrates the response pane | Facet-only |
+| 3 | **Replay** | `facet replay <runId>` re-resolves **current** YAML at the recorded env; warn on `request_hash` change; `--frozen` refuses | Facet command; Probe engine untouched |
+| 4 | **Hash-first diff** | `facet diff <a> <b>`: hashes equal ⇒ bodies equal; exit 1 on mismatch, 9 if a run is missing | Facet-only |
+| 5 | **Secret hydration** | Overlay Lattice env as `--var` before resolve on `request run` / TUI send. `--var` still wins | Facet overlay now; secret-provider hook upstream later |
+| 6 | **Dry-run + `--expect`** | `--expect 200,201` after a real run; miss → exit **6** `expect_failed`; Lattice still records. `--dry-run` second | **Upstream-first** on `request run` |
+
+CLI is the harness contract. MCP wraps the same functions later and must
+not parse stdout. Sketch: `agents/fullstack/notes/2026-09-07-and-more.md`
+in the Lapis vault.
+
+**Load-bearing picks** (Evan, next slice — recommended in italics):
+
+1. *Replay truth = current YAML + recorded env.* `--frozen` is opt-in refuse-on-hash-change. Frozen stored bytes are a trap (secrets redacted; auth is scheme-only in the hash).
+2. *Overlay secrets now,* do not wait for an upstream provider hook. Missing Lattice secret + OpenCollection `Secret` → `secret_variable_unavailable` (exit 5), never empty substitution.
+3. *`--expect` is exit 6* (`expect_failed`). Do not renumber 0–9; do not invent 10.
+4. *MCP after items 1–6.* Shell-out is enough for week 1.
+5. *Git HEAD stamp: skip this train, or 0003 column if it rides along.* Auto-tag `git:<sha>` needs no migration but is worse to query. Not a blocker for 1–6.
+
+Not this train: Thread A protocols, `ctrl+u`/`ctrl+d`, collection-in-Lattice, a writer daemon, kitchen-sink MCP, a JS test runner.
+
 ### Configuration
 
 ```toml

--- a/docs/FACET.md
+++ b/docs/FACET.md
@@ -152,9 +152,9 @@ in the Lapis vault.
 
 1. *Replay truth = current YAML + recorded env.* `--frozen` is opt-in refuse-on-hash-change. Frozen stored bytes are a trap (secrets redacted; auth is scheme-only in the hash).
 2. *Overlay secrets now,* do not wait for an upstream provider hook. Missing Lattice secret + OpenCollection `Secret` → `secret_variable_unavailable` (exit 5), never empty substitution.
-3. *`--expect` is exit 6* (`expect_failed`). Do not renumber 0–9; do not invent 10.
-4. *MCP after items 1–6.* Shell-out is enough for week 1.
-5. *Git HEAD stamp: skip this train, or 0003 column if it rides along.* Auto-tag `git:<sha>` needs no migration but is worse to query. Not a blocker for 1–6.
+3. *`--expect` exit code.* First pass: **6** (`expect_failed`). Explore pass: **1**, so agents do not retry assertion misses (6 stays network/timeout). Do not invent 10; do not renumber 0–5 / 7–9.
+4. *MCP after items 1–6.* Shell-out is enough for week 1. Teach harnesses with skill/rule files before freezing MCP tools.
+5. *Git HEAD stamp: skip this train.* Explore pass: auto-tag `git:<sha>` rather than 0003; spend 0003 on `replayed_from` + `var_names` if anything.
 
 Not this train: Thread A protocols, `ctrl+u`/`ctrl+d`, collection-in-Lattice, a writer daemon, kitchen-sink MCP, a JS test runner.
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -11,7 +11,7 @@ apply to every code change and routes task-specific work here.
 | [Development](DEVELOPMENT.md) | Rust ownership, async work, dependencies, pinned GPUI guidance, tests, and completion checks | Implementing code or changing dependencies |
 | [Errors and logging](ERRORS_AND_LOGGING.md) | Typed-error ownership and interface logging boundaries | Adding or mapping failures and diagnostics |
 | [Performance](PERFORMANCE.md) | Benchmark commands, fixtures, measurement policy, and reference results | Measuring or optimizing performance |
-| [Facet](FACET.md) | Facet fork: the `facet` binary, Lattice run history, `history`/`blob`/`gc` contracts, exit code 9, upstream boundary and license | Working on any Facet-only command or crate |
+| [Facet](FACET.md) | Facet fork: the `facet` binary, Lattice run history, `history`/`blob`/`gc` contracts, exit code 9, upstream boundary and license. Next slice (sessions, recall, replay, diff, secret hydration, `--expect`) is under [Next slice](FACET.md#next-slice) | Working on any Facet-only command or crate |
 | [Roadmap](../IMPLEMENTATION_PLAN.md) | Implemented foundation and explicitly deferred product work | Planning scope or starting a deferred feature |
 
 [README.md](../README.md) is the user-facing product, installation, and development


### PR DESCRIPTION
## Why

PR #6 merged at `aa8a9cb`. Two follow-up docs commits were pushed to the same branch after that merge and never landed on `main`:

- next-slice ranking (sessions → recall → replay → diff → secrets → `--expect`)
- explore-pass split (`--expect` 6 vs 1; git HEAD skip/auto-tag)

Fresh Halo sessions should read this from `docs/FACET.md` § Next slice.

Docs only. No code.