### PR TITLE
feat: sessions + recall CLI (Goal 1, commit 1)

### DIFF
--- a/crates/facet-record/src/lib.rs
+++ b/crates/facet-record/src/lib.rs
@@ -295,12 +295,21 @@ pub fn record(req: &RecordRequest<'_>) -> Recording {
 }
 
 /// Best-effort pointer row in the machine store. The workspace store is the
-/// record of truth; the index is a convenience and never fails the run.
+/// record of truth; the index is a convenience and never fails the run. As
+/// part of the same machine-store write, when the run carries a session id
+/// the parent session row is minted if missing (`ensure_session`), also best
+/// effort. The mint outcome is not surfaced in the `request run` envelope;
+/// see `FACET_HANDOFF_BRIEF` §1.2 (envelope stays) vs §1.7 (`session_created`).
 fn index_run(store: &WorkspaceStore, run: &RunRow) -> Result<(), String> {
     let machine = MachineStore::open(store.config()).map_err(|error| error.to_string())?;
     machine
         .touch_workspace(store.workspace_id(), store.root(), None, now_ms())
         .map_err(|error| error.to_string())?;
+    // Mint-if-missing: when the run carries a session id, ensure a parent
+    // session row exists. Best effort, never fails the run.
+    if let Some(session_id) = run.session_id.as_deref() {
+        let _ = machine.ensure_session(session_id, &run.actor, now_ms());
+    }
     machine
         .index_run(run, store.workspace_id())
         .map_err(|error| error.to_string())

--- a/crates/facet-record/src/lib.rs
+++ b/crates/facet-record/src/lib.rs
@@ -94,6 +94,12 @@ pub enum Recording {
         workspace_id: String,
         /// Whether the machine-store pointer row was written.
         indexed: Result<(), String>,
+        /// Whether the run's session was minted in the machine store by the
+        /// mint-if-missing path. `false` when no session was set, when the
+        /// session already existed, or when the best-effort write failed.
+        /// Not part of the `request run` envelope (it stays still; the
+        /// session is visible through `facet session show`).
+        session_created: bool,
     },
     /// Recording was not attempted (`disabled`, `stdin_workspace`).
     Skipped(&'static str),
@@ -110,6 +116,7 @@ impl Recording {
                 run,
                 workspace_id,
                 indexed,
+                ..
             } => json!({
                 "recorded": true,
                 "runId": run.id,
@@ -283,36 +290,45 @@ pub fn record(req: &RecordRequest<'_>) -> Recording {
 
     match store.record_run(&new_run) {
         Ok(run) => {
-            let indexed = index_run(&store, &run);
+            let (indexed, session_created) = index_run(&store, &run);
             Recording::Recorded {
                 run,
                 workspace_id: store.workspace_id().to_owned(),
                 indexed,
+                session_created,
             }
         }
         Err(error) => Recording::Failed(error.to_string()),
     }
 }
 
-/// Best-effort pointer row in the machine store. The workspace store is the
-/// record of truth; the index is a convenience and never fails the run. As
-/// part of the same machine-store write, when the run carries a session id
-/// the parent session row is minted if missing (`ensure_session`), also best
-/// effort. The mint outcome is not surfaced in the `request run` envelope;
-/// see `FACET_HANDOFF_BRIEF` §1.2 (envelope stays) vs §1.7 (`session_created`).
-fn index_run(store: &WorkspaceStore, run: &RunRow) -> Result<(), String> {
-    let machine = MachineStore::open(store.config()).map_err(|error| error.to_string())?;
-    machine
-        .touch_workspace(store.workspace_id(), store.root(), None, now_ms())
-        .map_err(|error| error.to_string())?;
+/// Best-effort pointer row in the machine store, plus the mint-if-missing
+/// session write. The workspace store is the record of truth; both the
+/// index and the session mint are conveniences and never fail the run.
+/// Returns `(indexed, session_created)` where `session_created` is `false`
+/// when no session was set, when the session already existed, or when the
+/// best-effort write failed.
+fn index_run(store: &WorkspaceStore, run: &RunRow) -> (Result<(), String>, bool) {
+    let machine = match MachineStore::open(store.config()) {
+        Ok(machine) => machine,
+        Err(error) => return (Err(error.to_string()), false),
+    };
+    if let Err(error) = machine.touch_workspace(store.workspace_id(), store.root(), None, now_ms())
+    {
+        return (Err(error.to_string()), false);
+    }
     // Mint-if-missing: when the run carries a session id, ensure a parent
     // session row exists. Best effort, never fails the run.
-    if let Some(session_id) = run.session_id.as_deref() {
-        let _ = machine.ensure_session(session_id, &run.actor, now_ms());
-    }
-    machine
+    let session_created = match run.session_id.as_deref() {
+        Some(session_id) => machine
+            .ensure_session(session_id, &run.actor, now_ms())
+            .unwrap_or(false),
+        None => false,
+    };
+    let indexed = machine
         .index_run(run, store.workspace_id())
-        .map_err(|error| error.to_string())
+        .map_err(|error| error.to_string());
+    (indexed, session_created)
 }
 
 fn request_body_bytes(request: &HttpRequest) -> Option<Vec<u8>> {

--- a/crates/facet/src/error.rs
+++ b/crates/facet/src/error.rs
@@ -1,6 +1,7 @@
 //! Facet error contract. Categories and exit codes for delegated behavior
 //! mirror `probe-cli`'s `error.rs` exactly; Facet adds `lattice_*`,
-//! `blob_not_found`, `invalid_sql`, and `sql_read_only`.
+//! `blob_not_found`, `run_not_found`, `session_not_found`, `session_not_set`,
+//! `invalid_sql`, and `sql_read_only`.
 
 use lattice::LatticeError;
 use probe_core::EnvironmentResolutionError;
@@ -63,6 +64,36 @@ impl FacetError {
             "blob_not_found",
             format!("blob not found: {hash}"),
             REQUEST_NOT_FOUND_EXIT_CODE,
+        )
+    }
+
+    /// `history --id` with an unknown run id. Extends "not found" (exit 4)
+    /// the same way `blob_not_found` does.
+    pub(crate) fn run_not_found(id: &str) -> Self {
+        Self::new(
+            "run_not_found",
+            format!("run not found: {id}"),
+            REQUEST_NOT_FOUND_EXIT_CODE,
+        )
+    }
+
+    /// `session end|show <id>` with an unknown session id (exit 4).
+    pub(crate) fn session_not_found(id: &str) -> Self {
+        Self::new(
+            "session_not_found",
+            format!("session not found: {id}"),
+            REQUEST_NOT_FOUND_EXIT_CODE,
+        )
+    }
+
+    /// `--session current` or `session end` with no `FACET_SESSION` in the
+    /// environment. Configuration family (exit 5): the caller fixes inputs.
+    pub(crate) fn session_not_set() -> Self {
+        Self::new(
+            "session_not_set",
+            "FACET_SESSION is not set; run `export FACET_SESSION=$(facet session start)` \
+             or pass an explicit session id",
+            CONFIGURATION_EXIT_CODE,
         )
     }
 

--- a/crates/facet/src/history.rs
+++ b/crates/facet/src/history.rs
@@ -56,6 +56,10 @@ pub(crate) fn history(args: &[String]) -> Result<CommandOutput, FacetError> {
         status: parsed.parsed_value::<i64>("--status", "an HTTP status code")?,
         actor: parsed.value("--actor")?.map(str::to_owned),
         since: parsed.parsed_value::<i64>("--since", "Unix milliseconds")?,
+        // session_id / environment / tags / hash filters are wired by the
+        // fullstack CLI slice; default to no filter here so the struct stays
+        // constructible until then.
+        ..HistoryQuery::default()
     };
     if query.limit == 0 {
         return Err(FacetError::invalid_arguments("--limit must be at least 1"));

--- a/crates/facet/src/history.rs
+++ b/crates/facet/src/history.rs
@@ -1,6 +1,7 @@
 //! `facet history`, `facet blob`, and `facet gc`: the agent-facing reads and
 //! the one maintenance command over the workspace Lattice store.
 //! Metadata is cheap and returned by default; payloads are explicit pulls.
+//! `history --id <ulid>` is the recall seam replay and diff stand on.
 
 use std::{fs, path::PathBuf};
 
@@ -11,35 +12,53 @@ use serde_json::{Value, json};
 use crate::{
     CommandOutput, FacetError, args,
     presentation::{format_utc, human_size, stored_body_json},
+    session::resolve_session_id,
     workspace::{ConfigOverrides, locate_root, open_store, overrides_from_parsed},
 };
 
 const DEFAULT_LIMIT: usize = 50;
 
+/// Query-side filters. `--id` and `--sql` are each exclusive with all of them.
+const HISTORY_FILTER_FLAGS: &[&str] = &[
+    "--limit",
+    "--request",
+    "--status",
+    "--actor",
+    "--since",
+    "--session",
+    "--environment",
+    "--tag",
+    "--hash",
+];
 const HISTORY_VALUE_FLAGS: &[&str] = &[
     "--limit",
     "--request",
     "--status",
     "--actor",
     "--since",
+    "--session",
+    "--environment",
+    "--tag",
+    "--hash",
+    "--id",
     "--sql",
 ];
 const HISTORY_SWITCH_FLAGS: &[&str] = &["--bodies"];
+const HISTORY_HEADER: &str = "ID\tSTARTED\tSTATUS\tMS\tMETHOD\tREQUEST\tSIZE\tACTOR";
 
 pub(crate) fn history(args: &[String]) -> Result<CommandOutput, FacetError> {
     let parsed = args::parse(args, HISTORY_VALUE_FLAGS, HISTORY_SWITCH_FLAGS)?;
     let path = single_optional_path(parsed.positionals(), "history")?;
     let (start, root) = locate_root(path);
+    let has_filters = HISTORY_FILTER_FLAGS
+        .iter()
+        .any(|flag| !parsed.values(flag).is_empty());
+    let include_bodies = parsed.switch("--bodies");
 
     if let Some(sql) = parsed.value("--sql")? {
-        let filters = ["--limit", "--request", "--status", "--actor", "--since"];
-        if filters
-            .iter()
-            .any(|flag| parsed.value(flag).ok().flatten().is_some())
-            || parsed.switch("--bodies")
-        {
+        if has_filters || include_bodies || parsed.value("--id")?.is_some() {
             return Err(FacetError::invalid_arguments(
-                "--sql cannot be combined with history filters or --bodies",
+                "--sql cannot be combined with history filters, --id, or --bodies",
             ));
         }
         let root = root.ok_or_else(|| FacetError::lattice_not_found(&start))?;
@@ -48,6 +67,31 @@ pub(crate) fn history(args: &[String]) -> Result<CommandOutput, FacetError> {
         return Ok(sql_output(&store, result));
     }
 
+    if let Some(id) = parsed.value("--id")? {
+        if has_filters {
+            return Err(FacetError::invalid_arguments(
+                "--id cannot be combined with history filters",
+            ));
+        }
+        // No store means the run cannot exist: same answer as an unknown id.
+        let root = root.ok_or_else(|| FacetError::run_not_found(id))?;
+        let store = open_store(&root, &ConfigOverrides::default())?;
+        let row = store
+            .run(id)
+            .map_err(FacetError::lattice)?
+            .ok_or_else(|| FacetError::run_not_found(id))?;
+        return Ok(CommandOutput::new(
+            format!("{HISTORY_HEADER}\n{}\n", history_line(&row)),
+            json!({
+                "workspace": workspace_json(&store),
+                "run": run_json(&store, &row, include_bodies)?,
+            }),
+        ));
+    }
+
+    let hash = parsed
+        .value("--hash")?
+        .map(|value| value.trim().to_ascii_lowercase());
     let query = HistoryQuery {
         limit: parsed
             .parsed_value::<usize>("--limit", "a positive number")?
@@ -56,15 +100,21 @@ pub(crate) fn history(args: &[String]) -> Result<CommandOutput, FacetError> {
         status: parsed.parsed_value::<i64>("--status", "an HTTP status code")?,
         actor: parsed.value("--actor")?.map(str::to_owned),
         since: parsed.parsed_value::<i64>("--since", "Unix milliseconds")?,
-        // session_id / environment / tags / hash filters are wired by the
-        // fullstack CLI slice; default to no filter here so the struct stays
-        // constructible until then.
-        ..HistoryQuery::default()
+        session_id: parsed
+            .value("--session")?
+            .map(resolve_session_id)
+            .transpose()?,
+        environment: parsed.value("--environment")?.map(str::to_owned),
+        tags: parsed
+            .values("--tag")
+            .into_iter()
+            .map(str::to_owned)
+            .collect(),
+        hash: hash.clone(),
     };
     if query.limit == 0 {
         return Err(FacetError::invalid_arguments("--limit must be at least 1"));
     }
-    let include_bodies = parsed.switch("--bodies");
 
     let Some(root) = root else {
         return Ok(CommandOutput::new(
@@ -75,30 +125,54 @@ pub(crate) fn history(args: &[String]) -> Result<CommandOutput, FacetError> {
     let store = open_store(&root, &ConfigOverrides::default())?;
     let rows = store.history(&query).map_err(FacetError::lattice)?;
 
-    let mut lines = vec!["ID\tSTARTED\tSTATUS\tMS\tMETHOD\tREQUEST\tSIZE\tACTOR".to_owned()];
+    let mut lines = vec![HISTORY_HEADER.to_owned()];
     let mut runs = Vec::with_capacity(rows.len());
     for row in &rows {
-        lines.push(format!(
-            "{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}",
-            row.id,
-            format_utc(row.started_at),
-            row.status
-                .map_or_else(|| "ERR".to_owned(), |status| status.to_string()),
-            row.duration_ms
-                .map_or_else(|| "-".to_owned(), |ms| ms.to_string()),
-            row.method,
-            row.request_path,
-            row.res_body
-                .len
-                .map_or_else(|| "-".to_owned(), |len| human_size(len as usize)),
-            row.actor,
-        ));
-        runs.push(run_json(&store, row, include_bodies)?);
+        lines.push(history_line(row));
+        let mut run = run_json(&store, row, include_bodies)?;
+        if let Some(hash) = &hash {
+            run["matchedHash"] = matched_hash(row, hash);
+        }
+        runs.push(run);
     }
     Ok(CommandOutput::new(
         format!("{}\n", lines.join("\n")),
         json!({ "workspace": workspace_json(&store), "runs": runs }),
     ))
+}
+
+/// One human table row (columns follow [`HISTORY_HEADER`]).
+fn history_line(row: &RunRow) -> String {
+    format!(
+        "{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}",
+        row.id,
+        format_utc(row.started_at),
+        row.status
+            .map_or_else(|| "ERR".to_owned(), |status| status.to_string()),
+        row.duration_ms
+            .map_or_else(|| "-".to_owned(), |ms| ms.to_string()),
+        row.method,
+        row.request_path,
+        row.res_body
+            .len
+            .map_or_else(|| "-".to_owned(), |len| human_size(len as usize)),
+        row.actor,
+    )
+}
+
+/// Which hash column `--hash` hit, computed here rather than in SQL so the
+/// store stays column-agnostic. `null` only if the filter and the row
+/// disagree, which the query prevents.
+fn matched_hash(row: &RunRow, hash: &str) -> Value {
+    if row.request_hash == hash {
+        json!("request")
+    } else if row.req_body.hash.as_deref() == Some(hash) {
+        json!("requestBody")
+    } else if row.res_body.hash.as_deref() == Some(hash) {
+        json!("responseBody")
+    } else {
+        Value::Null
+    }
 }
 
 pub(crate) fn blob(args: &[String]) -> Result<CommandOutput, FacetError> {

--- a/crates/facet/src/lib.rs
+++ b/crates/facet/src/lib.rs
@@ -7,6 +7,7 @@
 //! - `request run` executes through the same core and HTTP engine as Probe,
 //!   then records the run in the workspace Lattice store.
 //! - `history`, `blob`, and `gc` read and maintain that store.
+//! - `session` starts, ends, lists, and shows agent sessions in the machine store.
 //! - `tui` opens the terminal UI.
 //!
 //! Contract details for the Facet-only commands live in `docs/FACET.md`.
@@ -22,6 +23,7 @@ mod error;
 mod history;
 mod presentation;
 mod run;
+mod session;
 mod tui;
 mod workspace;
 
@@ -138,22 +140,33 @@ pub const fn help() -> &'static str {
         "Commands:\n",
         "  request run <path> <selector>       Execute an HTTP request and record it in Lattice\n",
         "  history [<path>]                    List recorded runs, newest first (metadata only)\n",
+        "  history [<path>] --id <ulid>        Show one recorded run by id\n",
         "  history [<path>] --sql <query>      Run read-only SQL against the workspace store\n",
+        "  session start                       Start a session; prints its ULID (use with FACET_SESSION)\n",
+        "  session end [<id>|current]          End a session (default: $FACET_SESSION); idempotent\n",
+        "  session list                        List sessions, newest first\n",
+        "  session show <id>|current           Show one session\n",
         "  blob <hash> [<path>]                Fetch one stored body by SHA-256\n",
         "  gc [<path>] [--yes]                 Expire old runs and sweep orphaned blobs\n",
         "  tui [<path>]                        Open the terminal UI\n",
         "\n",
         "Options:\n",
         "      --no-record             Execute without writing to Lattice\n",
-        "      --tag <tag>             Tag the recorded run; may be repeated\n",
+        "      --tag <tag>             Tag the recorded run, or filter history by tag (AND); may be repeated\n",
         "      --inline-body-max <n>   Inline bodies at or under this size (e.g. 64KiB)\n",
         "      --history-retention <r> Retention window for gc (unlimited or e.g. 30d)\n",
         "      --limit <n>             Maximum history rows (default 50)\n",
         "      --request <selector>    Only history for one request\n",
         "      --status <code>         Only history with one HTTP status\n",
-        "      --actor <name>          Only history by one actor\n",
+        "      --actor <name>          Only history or sessions by one actor; session start actor\n",
         "      --since <unix-ms>       Only history started at or after this time\n",
+        "      --session <id>|current  Only history recorded in one session\n",
+        "      --environment <name>    Only history resolved with one environment\n",
+        "      --hash <sha256>         Only history whose request, request body, or response body hash matches\n",
+        "      --id <ulid>             One run by id (exclusive with the filters above)\n",
         "      --bodies                Include inline bodies in history JSON\n",
+        "      --meta <json>           Session metadata object (session start)\n",
+        "      --open                  Only sessions still open (session list)\n",
         "      --output <file>         Write a blob to a file instead of stdout\n",
         "      --yes                   Apply gc deletions (default is a dry run)\n",
         "      --appearance <name>     TUI appearance: graphite or porcelain\n",
@@ -198,7 +211,9 @@ where
 
     let owned = match args.first().map(String::as_str) {
         None => true,
-        Some("history" | "blob" | "gc" | "tui" | "-V" | "--version" | "-h" | "--help") => true,
+        Some(
+            "history" | "session" | "blob" | "gc" | "tui" | "-V" | "--version" | "-h" | "--help",
+        ) => true,
         Some("request") => args.get(1).map(String::as_str) == Some("run"),
         Some(_) => false,
     };
@@ -241,6 +256,7 @@ where
     let result = match args[0].as_str() {
         "request" => run::run(&args[2..], stdin),
         "history" => history::history(&args[1..]),
+        "session" => session::session(&args[1..]),
         "blob" => history::blob(&args[1..]),
         "gc" => history::gc(&args[1..]),
         "tui" => Err(FacetError::invalid_arguments(

--- a/crates/facet/src/session.rs
+++ b/crates/facet/src/session.rs
@@ -1,0 +1,277 @@
+//! `facet session start|end|list|show`: agent sessions in the machine store.
+//!
+//! A session is the unit a harness turns on and off around a run of work.
+//! `session start` prints a bare ULID in human mode so
+//! `export FACET_SESSION=$(facet session start)` works without `jq`;
+//! `request run` stamps that id on every recorded run (and mints the session
+//! row if the harness invented the id itself, see `facet-record`). Sessions
+//! are cross-workspace, so they live in the machine store only; the `runs`
+//! count is taken from the workspace store discovered from the current
+//! directory and omitted when there is none.
+
+use std::env;
+
+use facet_record::{actor_from_env, session_from_env};
+use lattice::{
+    CONFIG_FILE, HistoryQuery, LatticeConfig, LatticeError, MachineStore, SessionQuery, SessionRow,
+    WorkspaceStore, machine_config_dir, now_ms,
+};
+use serde_json::{Map, Value, json};
+
+use crate::{
+    CommandOutput, FacetError, args,
+    presentation::format_utc,
+    workspace::{ConfigOverrides, locate_root, open_store},
+};
+
+const DEFAULT_LIMIT: usize = 50;
+
+/// The `current` alias resolves `FACET_SESSION` wherever an id is accepted.
+pub(crate) const CURRENT: &str = "current";
+
+pub(crate) fn session(args: &[String]) -> Result<CommandOutput, FacetError> {
+    let Some((verb, rest)) = args.split_first() else {
+        return Err(FacetError::invalid_arguments(
+            "session requires a subcommand: start, end, list, or show",
+        ));
+    };
+    match verb.as_str() {
+        "start" => start(rest),
+        "end" => end(rest),
+        "list" => list(rest),
+        "show" => show(rest),
+        other => Err(FacetError::invalid_arguments(format!(
+            "unknown session subcommand: {other} (expected start, end, list, or show)"
+        ))),
+    }
+}
+
+/// Resolves `current` to `FACET_SESSION`; any other value is returned as is.
+pub(crate) fn resolve_session_id(value: &str) -> Result<String, FacetError> {
+    if value == CURRENT {
+        session_from_env().ok_or_else(FacetError::session_not_set)
+    } else {
+        Ok(value.to_owned())
+    }
+}
+
+fn start(args: &[String]) -> Result<CommandOutput, FacetError> {
+    let parsed = args::parse(args, &["--actor", "--meta"], &[])?;
+    if !parsed.positionals().is_empty() {
+        return Err(FacetError::invalid_arguments(
+            "session start takes no positional arguments",
+        ));
+    }
+    let actor = parsed
+        .value("--actor")?
+        .map_or_else(actor_from_env, str::to_owned);
+    let meta = build_meta(parsed.value("--meta")?)?;
+    let machine = open_machine()?;
+    let row = machine
+        .start_session(&actor, Some(&meta), now_ms())
+        .map_err(FacetError::lattice)?;
+    let runs = count_runs(workspace_from_cwd().as_ref(), &row.id)?;
+    Ok(CommandOutput::new(
+        format!("{}\n", row.id),
+        json!({ "session": session_json(&row, runs) }),
+    ))
+}
+
+fn end(args: &[String]) -> Result<CommandOutput, FacetError> {
+    let parsed = args::parse(args, &[], &[])?;
+    let id = match parsed.positionals() {
+        [] => session_from_env().ok_or_else(FacetError::session_not_set)?,
+        [id] => resolve_session_id(id)?,
+        _ => {
+            return Err(FacetError::invalid_arguments(
+                "session end accepts at most one <id>",
+            ));
+        }
+    };
+    let machine = open_machine()?;
+    let before = machine
+        .session(&id)
+        .map_err(FacetError::lattice)?
+        .ok_or_else(|| FacetError::session_not_found(&id))?;
+    let already_ended = before.ended_at.is_some();
+    let row = if already_ended {
+        before
+    } else {
+        machine
+            .end_session(&id, now_ms())
+            .map_err(FacetError::lattice)?
+            .ok_or_else(|| FacetError::session_not_found(&id))?
+    };
+    let ended_at = row.ended_at.map_or_else(|| "-".to_owned(), format_utc);
+    let human = if already_ended {
+        format!("session {} already ended at {ended_at}\n", row.id)
+    } else {
+        format!("session {} ended at {ended_at}\n", row.id)
+    };
+    let runs = count_runs(workspace_from_cwd().as_ref(), &row.id)?;
+    Ok(CommandOutput::new(
+        human,
+        json!({ "session": session_json(&row, runs), "alreadyEnded": already_ended }),
+    ))
+}
+
+fn show(args: &[String]) -> Result<CommandOutput, FacetError> {
+    let parsed = args::parse(args, &[], &[])?;
+    let [id] = parsed.positionals() else {
+        return Err(FacetError::invalid_arguments(
+            "session show requires exactly one <id> (or `current`)",
+        ));
+    };
+    let id = resolve_session_id(id)?;
+    let machine = open_machine()?;
+    let row = machine
+        .session(&id)
+        .map_err(FacetError::lattice)?
+        .ok_or_else(|| FacetError::session_not_found(&id))?;
+    let runs = count_runs(workspace_from_cwd().as_ref(), &row.id)?;
+    let mut human = format!(
+        "ID\t{}\nACTOR\t{}\nSTARTED\t{}\nENDED\t{}\n",
+        row.id,
+        row.actor,
+        format_utc(row.started_at),
+        row.ended_at.map_or_else(|| "-".to_owned(), format_utc),
+    );
+    if let Some(runs) = runs {
+        human.push_str(&format!("RUNS\t{runs}\n"));
+    }
+    if let Some(meta) = &row.meta {
+        human.push_str(&format!("META\t{meta}\n"));
+    }
+    Ok(CommandOutput::new(
+        human,
+        json!({ "session": session_json(&row, runs) }),
+    ))
+}
+
+fn list(args: &[String]) -> Result<CommandOutput, FacetError> {
+    let parsed = args::parse(args, &["--limit", "--actor"], &["--open"])?;
+    if !parsed.positionals().is_empty() {
+        return Err(FacetError::invalid_arguments(
+            "session list takes no positional arguments",
+        ));
+    }
+    let query = SessionQuery {
+        limit: parsed
+            .parsed_value::<usize>("--limit", "a positive number")?
+            .unwrap_or(DEFAULT_LIMIT),
+        actor: parsed.value("--actor")?.map(str::to_owned),
+        open_only: parsed.switch("--open"),
+    };
+    if query.limit == 0 {
+        return Err(FacetError::invalid_arguments("--limit must be at least 1"));
+    }
+    let machine = open_machine()?;
+    let rows = machine.sessions(&query).map_err(FacetError::lattice)?;
+    let workspace = workspace_from_cwd();
+
+    let mut lines = vec!["ID\tACTOR\tSTARTED\tENDED\tRUNS".to_owned()];
+    let mut sessions = Vec::with_capacity(rows.len());
+    for row in &rows {
+        let runs = count_runs(workspace.as_ref(), &row.id)?;
+        lines.push(format!(
+            "{}\t{}\t{}\t{}\t{}",
+            row.id,
+            row.actor,
+            format_utc(row.started_at),
+            row.ended_at.map_or_else(|| "-".to_owned(), format_utc),
+            runs.map_or_else(|| "-".to_owned(), |runs| runs.to_string()),
+        ));
+        sessions.push(session_json(row, runs));
+    }
+    Ok(CommandOutput::new(
+        format!("{}\n", lines.join("\n")),
+        json!({ "sessions": sessions }),
+    ))
+}
+
+/// Opens the machine store with the machine-level configuration only.
+/// Sessions are cross-workspace, so no workspace file applies.
+fn open_machine() -> Result<MachineStore, FacetError> {
+    let mut config = LatticeConfig::default();
+    if let Some(dir) = machine_config_dir() {
+        config
+            .apply_file(&dir.join(CONFIG_FILE))
+            .map_err(|error| FacetError::lattice(LatticeError::Config(error)))?;
+    }
+    MachineStore::open(&config).map_err(FacetError::lattice)
+}
+
+/// The workspace store discovered from the current directory, if any. Used
+/// only to count a session's runs; a missing store just omits the count.
+fn workspace_from_cwd() -> Option<WorkspaceStore> {
+    let (_, root) = locate_root(None);
+    open_store(&root?, &ConfigOverrides::default()).ok()
+}
+
+fn count_runs(store: Option<&WorkspaceStore>, session_id: &str) -> Result<Option<i64>, FacetError> {
+    let Some(store) = store else {
+        return Ok(None);
+    };
+    let query = HistoryQuery {
+        limit: usize::MAX,
+        session_id: Some(session_id.to_owned()),
+        ..HistoryQuery::default()
+    };
+    let rows = store.history(&query).map_err(FacetError::lattice)?;
+    Ok(Some(i64::try_from(rows.len()).unwrap_or(i64::MAX)))
+}
+
+/// Session metadata: Herdr ids from the environment when present, the
+/// current directory, then the caller's `--meta` object on top (it wins on
+/// key collisions). Pointers only; never transcripts or secrets.
+fn build_meta(explicit: Option<&str>) -> Result<String, FacetError> {
+    let mut meta = Map::new();
+    let mut herdr = Map::new();
+    for (variable, key) in [
+        ("HERDR_WORKSPACE_ID", "workspace"),
+        ("HERDR_TAB_ID", "tab"),
+        ("HERDR_PANE_ID", "pane"),
+    ] {
+        if let Ok(value) = env::var(variable)
+            && !value.is_empty()
+        {
+            herdr.insert(key.to_owned(), json!(value));
+        }
+    }
+    if !herdr.is_empty() {
+        meta.insert("herdr".to_owned(), Value::Object(herdr));
+    }
+    if let Ok(cwd) = env::current_dir() {
+        meta.insert("cwd".to_owned(), json!(cwd.to_string_lossy()));
+    }
+    if let Some(text) = explicit {
+        let value: Value = serde_json::from_str(text).map_err(|error| {
+            FacetError::invalid_arguments(format!("--meta expects a JSON object: {error}"))
+        })?;
+        let Value::Object(user) = value else {
+            return Err(FacetError::invalid_arguments(
+                "--meta expects a JSON object",
+            ));
+        };
+        meta.extend(user);
+    }
+    Ok(Value::Object(meta).to_string())
+}
+
+fn session_json(row: &SessionRow, runs: Option<i64>) -> Value {
+    let mut value = json!({
+        "id": row.id,
+        "actor": row.actor,
+        "startedAt": row.started_at,
+        "endedAt": row.ended_at,
+        "meta": row
+            .meta
+            .as_deref()
+            .and_then(|text| serde_json::from_str::<Value>(text).ok())
+            .unwrap_or(Value::Null),
+    });
+    if let Some(runs) = runs {
+        value["runs"] = json!(runs);
+    }
+    value
+}

--- a/crates/facet/tests/common/mod.rs
+++ b/crates/facet/tests/common/mod.rs
@@ -42,8 +42,40 @@ impl Sandbox {
             .env("FACET_CONFIG_DIR", self.root().join("config"))
             .env_remove("FACET_ACTOR")
             .env_remove("FACET_SESSION")
-            .env_remove("FACET_NO_RECORD");
+            .env_remove("FACET_NO_RECORD")
+            // Session metadata picks these up when present; goldens must not.
+            .env_remove("HERDR_WORKSPACE_ID")
+            .env_remove("HERDR_TAB_ID")
+            .env_remove("HERDR_PANE_ID")
+            // Session commands count runs from the workspace store discovered
+            // from the current directory.
+            .current_dir(self.root());
         command
+    }
+
+    /// [`Self::facet`] with `FACET_SESSION` set, as a harness would run it.
+    pub(crate) fn facet_in_session(&self, session: &str) -> Command {
+        let mut command = self.facet();
+        command.env("FACET_SESSION", session);
+        command
+    }
+
+    /// Runs `facet … --json` inside a session and returns parsed stdout.
+    pub(crate) fn run_json_in_session(&self, session: &str, arguments: &[&str]) -> Value {
+        let output = self
+            .facet_in_session(session)
+            .args(arguments)
+            .arg("--json")
+            .output()
+            .expect("facet should run");
+        assert!(
+            output.status.success(),
+            "exit {:?}\nstdout: {}\nstderr: {}",
+            output.status.code(),
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr)
+        );
+        serde_json::from_slice(&output.stdout).expect("stdout should be JSON")
     }
 
     pub(crate) fn run_json(&self, arguments: &[&str]) -> Value {
@@ -170,10 +202,12 @@ pub(crate) fn normalize(value: Value) -> Value {
                     let replaced = match key.as_str() {
                         "version" | "probeVersion" => json!("<version>"),
                         "id" | "runId" | "workspaceId" => json!("<ulid>"),
+                        "sessionId" if value.is_string() => json!("<ulid>"),
                         "startedAt" | "durationMs" => json!("<int>"),
+                        "endedAt" if value.is_number() => json!("<int>"),
                         "requestHash" => json!("<sha256>"),
                         "hash" if value.is_string() => json!("<sha256>"),
-                        "path" | "outputPath" if value.is_string() => json!("<path>"),
+                        "path" | "outputPath" | "cwd" if value.is_string() => json!("<path>"),
                         "url" if value.is_string() => json!("<url>"),
                         _ => normalize(value),
                     };

--- a/crates/facet/tests/facet_commands.rs
+++ b/crates/facet/tests/facet_commands.rs
@@ -10,6 +10,12 @@ use common::*;
 const ECHO_BODY: &[u8] = br#"{"users":[]}"#;
 
 fn record_one_run(sandbox: &Sandbox, extra: &[&str]) -> Value {
+    record_run_with(sandbox, &[], extra)
+}
+
+/// `request run … --json` against a one-shot echo server, with extra
+/// environment variables (`FACET_SESSION`, `FACET_ACTOR`) as a harness sets them.
+fn record_run_with(sandbox: &Sandbox, env: &[(&str, &str)], extra: &[&str]) -> Value {
     let (url, server) = serve_once(ECHO_BODY.to_vec(), "application/json");
     let workspace = sandbox.workspace(&url);
     let mut arguments = vec![
@@ -21,11 +27,37 @@ fn record_one_run(sandbox: &Sandbox, extra: &[&str]) -> Value {
         "local",
     ];
     arguments.extend_from_slice(extra);
-    let value = sandbox.run_json(&arguments);
+    let mut command = sandbox.facet();
+    for (name, value) in env {
+        command.env(name, value);
+    }
+    let output = command.args(&arguments).arg("--json").output().unwrap();
     let sent = server.join().unwrap();
     assert_eq!(sent, br#"{"source":"cli"}"#);
-    value
+    assert!(
+        output.status.success(),
+        "exit {:?}\nstdout: {}\nstderr: {}",
+        output.status.code(),
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(
+        output.stderr.is_empty(),
+        "unexpected stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    serde_json::from_slice(&output.stdout).expect("stdout should be JSON")
 }
+
+fn run_count(sandbox: &Sandbox, arguments: &[&str]) -> usize {
+    sandbox.run_json(arguments)["runs"]
+        .as_array()
+        .expect("runs array")
+        .len()
+}
+
+/// A well-formed ULID no store has ever minted.
+const UNKNOWN_ULID: &str = "01ARZ3NDEKTSV4RRFFQ69G5FAV";
 
 #[test]
 fn version_json_is_golden_and_names_probe() {
@@ -425,4 +457,308 @@ fn delegated_commands_are_untouched() {
     assert_eq!(value["schemaVersion"], 1);
     assert_eq!(value["requests"][0]["selector"], "items/0");
     assert!(!sandbox.root().join(".facet").exists());
+}
+
+#[test]
+fn session_lifecycle_is_golden_and_start_prints_a_bare_ulid() {
+    let sandbox = Sandbox::new();
+
+    // Human mode prints the id alone so `$(facet session start)` needs no jq.
+    let output = sandbox.facet().args(["session", "start"]).output().unwrap();
+    assert!(output.status.success());
+    assert!(output.stderr.is_empty());
+    let bare = String::from_utf8(output.stdout).unwrap();
+    assert!(bare.ends_with('\n'));
+    let bare_id = bare.trim().to_owned();
+    assert!(lattice::is_ulid(&bare_id), "not a ULID: {bare_id:?}");
+
+    let started = sandbox.run_json(&[
+        "session",
+        "start",
+        "--actor",
+        "halo-qa",
+        "--meta",
+        r#"{"note":"golden"}"#,
+    ]);
+    let session = &started["session"];
+    assert!(lattice::is_ulid(session["id"].as_str().unwrap()));
+    assert_eq!(session["actor"], "halo-qa");
+    assert!(session["startedAt"].is_number());
+    assert!(session["endedAt"].is_null());
+    assert_eq!(session["meta"]["note"], "golden");
+    assert!(session["meta"]["cwd"].is_string());
+    assert!(session["meta"].get("herdr").is_none(), "env is scrubbed");
+    assert!(session.get("runs").is_none(), "no workspace store yet");
+    assert_golden("session_start.json", &normalize(started.clone()));
+    let id = session["id"].as_str().unwrap().to_owned();
+
+    let shown = sandbox.run_json(&["session", "show", &id]);
+    assert_eq!(shown["session"], started["session"]);
+    let current = sandbox.run_json_in_session(&id, &["session", "show", "current"]);
+    assert_eq!(current["session"]["id"], id);
+
+    let open = sandbox.run_json(&["session", "list", "--open"]);
+    let open_ids: Vec<&str> = open["sessions"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|row| row["id"].as_str().unwrap())
+        .collect();
+    assert_eq!(open_ids.len(), 2);
+    assert!(open_ids.contains(&id.as_str()) && open_ids.contains(&bare_id.as_str()));
+    let by_actor = sandbox.run_json(&["session", "list", "--actor", "halo-qa"]);
+    assert_eq!(by_actor["sessions"].as_array().unwrap().len(), 1);
+    assert_eq!(by_actor["sessions"][0]["id"], id);
+    assert_golden("session_list.json", &normalize(by_actor));
+
+    let ended = sandbox.run_json(&["session", "end", &id]);
+    assert_eq!(ended["alreadyEnded"], false);
+    assert!(ended["session"]["endedAt"].is_number());
+    assert_golden("session_end.json", &normalize(ended.clone()));
+    // Idempotent: the second end changes nothing and says so.
+    let again = sandbox.run_json(&["session", "end", &id]);
+    assert_eq!(again["alreadyEnded"], true);
+    assert_eq!(again["session"]["endedAt"], ended["session"]["endedAt"]);
+    // No id: FACET_SESSION.
+    let from_env = sandbox.run_json_in_session(&bare_id, &["session", "end"]);
+    assert_eq!(from_env["session"]["id"], bare_id);
+    assert_eq!(from_env["alreadyEnded"], false);
+    let none_open = sandbox.run_json(&["session", "list", "--open"]);
+    assert_eq!(none_open["sessions"], json!([]));
+    assert_eq!(
+        sandbox.run_json(&["session", "list"])["sessions"]
+            .as_array()
+            .unwrap()
+            .len(),
+        2
+    );
+
+    let (code, error) = sandbox.run_error_json(&["session", "end"]);
+    assert_eq!(code, 5);
+    assert_eq!(error["error"]["category"], "session_not_set");
+    let (code, error) = sandbox.run_error_json(&["session", "show", UNKNOWN_ULID]);
+    assert_eq!(code, 4);
+    assert_eq!(error["error"]["category"], "session_not_found");
+    assert_golden("error_session_not_found.json", &normalize_error(error));
+    let (code, error) = sandbox.run_error_json(&["session", "end", UNKNOWN_ULID]);
+    assert_eq!(code, 4);
+    assert_eq!(error["error"]["category"], "session_not_found");
+    let (code, error) = sandbox.run_error_json(&["session", "start", "--meta", "[1]"]);
+    assert_eq!(code, 2);
+    assert_eq!(error["error"]["category"], "invalid_arguments");
+    let (code, _) = sandbox.run_error_json(&["session", "frobnicate"]);
+    assert_eq!(code, 2);
+}
+
+#[test]
+fn history_id_is_golden_and_exclusive_with_filters() {
+    let sandbox = Sandbox::new();
+    let run = record_one_run(&sandbox, &[]);
+    let run_id = run["lattice"]["runId"].as_str().unwrap();
+    let root = sandbox.root().to_str().unwrap();
+
+    let one = sandbox.run_json(&["history", root, "--id", run_id]);
+    assert!(one.get("runs").is_none(), "--id is one object, not a list");
+    assert_eq!(one["run"]["id"], run_id);
+    assert_eq!(one["run"]["requestPath"], "items/0");
+    assert_eq!(one["workspace"]["id"], run["lattice"]["workspaceId"]);
+    assert!(one["run"]["response"]["body"].get("content").is_none());
+    assert_golden("history_id.json", &normalize(one));
+
+    // --bodies behaves exactly as on the list.
+    let with_bodies = sandbox.run_json(&["history", root, "--id", run_id, "--bodies"]);
+    assert_eq!(
+        with_bodies["run"]["response"]["body"]["content"],
+        r#"{"users":[]}"#
+    );
+
+    let human = sandbox
+        .facet()
+        .args(["history", root, "--id", run_id])
+        .output()
+        .unwrap();
+    assert!(human.status.success());
+    let text = String::from_utf8(human.stdout).unwrap();
+    assert_eq!(text.lines().count(), 2, "header plus one row");
+    assert!(text.lines().nth(1).unwrap().starts_with(run_id));
+
+    let (code, error) = sandbox.run_error_json(&["history", root, "--id", UNKNOWN_ULID]);
+    assert_eq!(code, 4);
+    assert_eq!(error["error"]["category"], "run_not_found");
+    assert_golden("error_run_not_found.json", &normalize_error(error));
+
+    let (code, error) =
+        sandbox.run_error_json(&["history", root, "--id", run_id, "--status", "200"]);
+    assert_eq!(code, 2);
+    assert_eq!(error["error"]["category"], "invalid_arguments");
+    let (code, _) = sandbox.run_error_json(&["history", root, "--id", run_id, "--tag", "x"]);
+    assert_eq!(code, 2);
+    let (code, _) = sandbox.run_error_json(&["history", root, "--id", run_id, "--sql", "SELECT 1"]);
+    assert_eq!(code, 2);
+
+    // No store at all: the run cannot exist.
+    let empty = Sandbox::new();
+    let (code, error) =
+        empty.run_error_json(&["history", empty.root().to_str().unwrap(), "--id", run_id]);
+    assert_eq!(code, 4);
+    assert_eq!(error["error"]["category"], "run_not_found");
+}
+
+#[test]
+fn history_session_filter_and_mint_if_missing() {
+    let sandbox = Sandbox::new();
+    let root = sandbox.root().to_str().unwrap();
+    let started = sandbox.run_json(&["session", "start", "--actor", "claude.halo-fullstack"]);
+    let id = started["session"]["id"].as_str().unwrap().to_owned();
+
+    let first = record_run_with(&sandbox, &[("FACET_SESSION", &id)], &[]);
+    let second = record_run_with(&sandbox, &[("FACET_SESSION", &id)], &["--tag", "smoke"]);
+    let outside = record_one_run(&sandbox, &[]);
+    assert_eq!(run_count(&sandbox, &["history", root]), 3);
+
+    let in_session = sandbox.run_json(&["history", root, "--session", &id]);
+    let rows = in_session["runs"].as_array().unwrap();
+    assert_eq!(rows.len(), 2);
+    assert!(rows.iter().all(|row| row["sessionId"] == id));
+    let ids: Vec<&Value> = rows.iter().map(|row| &row["id"]).collect();
+    assert!(ids.contains(&&first["lattice"]["runId"]));
+    assert!(ids.contains(&&second["lattice"]["runId"]));
+    assert!(!ids.contains(&&outside["lattice"]["runId"]));
+    assert_golden("history_session.json", &normalize(in_session));
+
+    // `current` reads FACET_SESSION; without it the agent gets a clear exit 5.
+    let current = sandbox.run_json_in_session(&id, &["history", root, "--session", "current"]);
+    assert_eq!(current["runs"].as_array().unwrap().len(), 2);
+    let (code, error) = sandbox.run_error_json(&["history", root, "--session", "current"]);
+    assert_eq!(code, 5);
+    assert_eq!(error["error"]["category"], "session_not_set");
+    assert_golden("error_session_not_set.json", &normalize_error(error));
+
+    // With a workspace store under the cwd, sessions report their run count.
+    let shown = sandbox.run_json(&["session", "show", &id]);
+    assert_eq!(shown["session"]["runs"], 2);
+    let listed = sandbox.run_json(&["session", "list"]);
+    assert_eq!(listed["sessions"][0]["runs"], 2);
+
+    // Mint-if-missing: a harness that invents its own FACET_SESSION gets a
+    // session row on the first recorded run, owned by that run's actor.
+    let (code, error) = sandbox.run_error_json(&["session", "show", UNKNOWN_ULID]);
+    assert_eq!(code, 4);
+    assert_eq!(error["error"]["category"], "session_not_found");
+    record_run_with(
+        &sandbox,
+        &[("FACET_SESSION", UNKNOWN_ULID), ("FACET_ACTOR", "halo-qa")],
+        &[],
+    );
+    let minted = sandbox.run_json(&["session", "show", UNKNOWN_ULID]);
+    assert_eq!(minted["session"]["id"], UNKNOWN_ULID);
+    assert_eq!(minted["session"]["actor"], "halo-qa");
+    assert!(minted["session"]["endedAt"].is_null());
+    assert!(minted["session"]["meta"].is_null());
+    assert_eq!(minted["session"]["runs"], 1);
+    // A later run under the same id does not rewrite the row.
+    record_run_with(
+        &sandbox,
+        &[
+            ("FACET_SESSION", UNKNOWN_ULID),
+            ("FACET_ACTOR", "someone-else"),
+        ],
+        &[],
+    );
+    let again = sandbox.run_json(&["session", "show", UNKNOWN_ULID]);
+    assert_eq!(again["session"]["actor"], "halo-qa");
+    assert_eq!(
+        again["session"]["startedAt"],
+        minted["session"]["startedAt"]
+    );
+    assert_eq!(again["session"]["runs"], 2);
+    assert_golden("session_show.json", &normalize(again));
+    assert_eq!(
+        run_count(&sandbox, &["history", root, "--session", UNKNOWN_ULID]),
+        2
+    );
+}
+
+#[test]
+fn history_environment_tag_and_hash_filters() {
+    let sandbox = Sandbox::new();
+    let tagged = record_one_run(
+        &sandbox,
+        &[
+            "--tag",
+            "smoke",
+            "--tag",
+            "golden",
+            "--inline-body-max",
+            "0",
+        ],
+    );
+    record_one_run(&sandbox, &[]);
+    let root = sandbox.root().to_str().unwrap();
+    let tagged_id = tagged["lattice"]["runId"].as_str().unwrap();
+    let response_hash = tagged["lattice"]["responseBody"]["hash"].as_str().unwrap();
+    let request_hash = tagged["lattice"]["requestHash"].as_str().unwrap();
+
+    assert_eq!(
+        run_count(&sandbox, &["history", root, "--environment", "local"]),
+        2
+    );
+    assert_eq!(
+        run_count(&sandbox, &["history", root, "--environment", "prod"]),
+        0
+    );
+
+    // --tag repeats and ANDs; untagged runs never match.
+    assert_eq!(run_count(&sandbox, &["history", root, "--tag", "smoke"]), 1);
+    assert_eq!(
+        run_count(
+            &sandbox,
+            &["history", root, "--tag", "smoke", "--tag", "golden"]
+        ),
+        1
+    );
+    assert_eq!(
+        run_count(
+            &sandbox,
+            &["history", root, "--tag", "smoke", "--tag", "nope"]
+        ),
+        0
+    );
+
+    // --hash is column-agnostic; the row says which column hit.
+    let by_response =
+        sandbox.run_json(&["history", root, "--tag", "smoke", "--hash", response_hash]);
+    assert_eq!(by_response["runs"].as_array().unwrap().len(), 1);
+    assert_eq!(by_response["runs"][0]["id"], tagged_id);
+    assert_eq!(by_response["runs"][0]["matchedHash"], "responseBody");
+    assert_golden("history_tag_hash.json", &normalize(by_response));
+
+    // Each run hit a fresh mock server (different port, different URL), so
+    // the resolved-request hash is unique per run; the request body bytes
+    // are identical, so the request-body hash hits both.
+    let by_request = sandbox.run_json(&["history", root, "--hash", request_hash]);
+    let rows = by_request["runs"].as_array().unwrap();
+    assert_eq!(rows.len(), 1);
+    assert_eq!(rows[0]["id"], tagged_id);
+    assert_eq!(rows[0]["matchedHash"], "request");
+    let request_body_hash = rows[0]["request"]["body"]["hash"].as_str().unwrap();
+    let by_request_body = sandbox.run_json(&["history", root, "--hash", request_body_hash]);
+    let rows = by_request_body["runs"].as_array().unwrap();
+    assert_eq!(rows.len(), 2);
+    assert!(rows.iter().all(|row| row["matchedHash"] == "requestBody"));
+
+    // Hashes compare case-insensitively, like `blob`.
+    let upper = sandbox.run_json(&["history", root, "--hash", &response_hash.to_uppercase()]);
+    assert_eq!(upper["runs"].as_array().unwrap().len(), 1);
+    let (code, _) =
+        sandbox.run_error_json(&["history", root, "--hash", "nope", "--sql", "SELECT 1"]);
+    assert_eq!(code, 2);
+
+    // Without --hash the row shape is unchanged.
+    let plain = sandbox.run_json(&["history", root]);
+    assert!(plain["runs"][0].get("matchedHash").is_none());
+    assert_eq!(
+        run_count(&sandbox, &["history", root, "--hash", &"0".repeat(64)]),
+        0
+    );
 }

--- a/crates/facet/tests/golden/error_run_not_found.json
+++ b/crates/facet/tests/golden/error_run_not_found.json
@@ -1,0 +1,8 @@
+{
+  "error": {
+    "category": "run_not_found",
+    "exitCode": 4,
+    "message": "<message>"
+  },
+  "schemaVersion": 1
+}

--- a/crates/facet/tests/golden/error_session_not_found.json
+++ b/crates/facet/tests/golden/error_session_not_found.json
@@ -1,0 +1,8 @@
+{
+  "error": {
+    "category": "session_not_found",
+    "exitCode": 4,
+    "message": "<message>"
+  },
+  "schemaVersion": 1
+}

--- a/crates/facet/tests/golden/error_session_not_set.json
+++ b/crates/facet/tests/golden/error_session_not_set.json
@@ -1,0 +1,8 @@
+{
+  "error": {
+    "category": "session_not_set",
+    "exitCode": 5,
+    "message": "<message>"
+  },
+  "schemaVersion": 1
+}

--- a/crates/facet/tests/golden/history_id.json
+++ b/crates/facet/tests/golden/history_id.json
@@ -1,0 +1,58 @@
+{
+  "run": {
+    "actor": "human",
+    "durationMs": "<int>",
+    "environment": "local",
+    "error": null,
+    "id": "<ulid>",
+    "method": "POST",
+    "request": {
+      "body": {
+        "hash": "<sha256>",
+        "retention": "blob",
+        "sizeBytes": 16
+      },
+      "headers": [
+        {
+          "disabled": false,
+          "name": "X-Probe",
+          "value": "phase-five"
+        }
+      ]
+    },
+    "requestHash": "<sha256>",
+    "requestPath": "items/0",
+    "response": {
+      "body": {
+        "hash": null,
+        "retention": "inline",
+        "sizeBytes": 12
+      },
+      "contentType": "application/json",
+      "headers": [
+        {
+          "name": "connection",
+          "value": "close"
+        },
+        {
+          "name": "content-length",
+          "value": "12"
+        },
+        {
+          "name": "content-type",
+          "value": "application/json"
+        }
+      ]
+    },
+    "sessionId": null,
+    "startedAt": "<int>",
+    "status": 200,
+    "tags": [],
+    "url": "<url>"
+  },
+  "schemaVersion": 1,
+  "workspace": {
+    "id": "<ulid>",
+    "path": "<path>"
+  }
+}

--- a/crates/facet/tests/golden/history_session.json
+++ b/crates/facet/tests/golden/history_session.json
@@ -1,0 +1,113 @@
+{
+  "runs": [
+    {
+      "actor": "human",
+      "durationMs": "<int>",
+      "environment": "local",
+      "error": null,
+      "id": "<ulid>",
+      "method": "POST",
+      "request": {
+        "body": {
+          "hash": "<sha256>",
+          "retention": "blob",
+          "sizeBytes": 16
+        },
+        "headers": [
+          {
+            "disabled": false,
+            "name": "X-Probe",
+            "value": "phase-five"
+          }
+        ]
+      },
+      "requestHash": "<sha256>",
+      "requestPath": "items/0",
+      "response": {
+        "body": {
+          "hash": null,
+          "retention": "inline",
+          "sizeBytes": 12
+        },
+        "contentType": "application/json",
+        "headers": [
+          {
+            "name": "connection",
+            "value": "close"
+          },
+          {
+            "name": "content-length",
+            "value": "12"
+          },
+          {
+            "name": "content-type",
+            "value": "application/json"
+          }
+        ]
+      },
+      "sessionId": "<ulid>",
+      "startedAt": "<int>",
+      "status": 200,
+      "tags": [
+        "smoke"
+      ],
+      "url": "<url>"
+    },
+    {
+      "actor": "human",
+      "durationMs": "<int>",
+      "environment": "local",
+      "error": null,
+      "id": "<ulid>",
+      "method": "POST",
+      "request": {
+        "body": {
+          "hash": "<sha256>",
+          "retention": "blob",
+          "sizeBytes": 16
+        },
+        "headers": [
+          {
+            "disabled": false,
+            "name": "X-Probe",
+            "value": "phase-five"
+          }
+        ]
+      },
+      "requestHash": "<sha256>",
+      "requestPath": "items/0",
+      "response": {
+        "body": {
+          "hash": null,
+          "retention": "inline",
+          "sizeBytes": 12
+        },
+        "contentType": "application/json",
+        "headers": [
+          {
+            "name": "connection",
+            "value": "close"
+          },
+          {
+            "name": "content-length",
+            "value": "12"
+          },
+          {
+            "name": "content-type",
+            "value": "application/json"
+          }
+        ]
+      },
+      "sessionId": "<ulid>",
+      "startedAt": "<int>",
+      "status": 200,
+      "tags": [],
+      "url": "<url>"
+    }
+  ],
+  "schemaVersion": 1,
+  "workspace": {
+    "id": "<ulid>",
+    "path": "<path>"
+  }
+}

--- a/crates/facet/tests/golden/history_tag_hash.json
+++ b/crates/facet/tests/golden/history_tag_hash.json
@@ -1,0 +1,64 @@
+{
+  "runs": [
+    {
+      "actor": "human",
+      "durationMs": "<int>",
+      "environment": "local",
+      "error": null,
+      "id": "<ulid>",
+      "matchedHash": "responseBody",
+      "method": "POST",
+      "request": {
+        "body": {
+          "hash": "<sha256>",
+          "retention": "blob",
+          "sizeBytes": 16
+        },
+        "headers": [
+          {
+            "disabled": false,
+            "name": "X-Probe",
+            "value": "phase-five"
+          }
+        ]
+      },
+      "requestHash": "<sha256>",
+      "requestPath": "items/0",
+      "response": {
+        "body": {
+          "hash": "<sha256>",
+          "retention": "blob",
+          "sizeBytes": 12
+        },
+        "contentType": "application/json",
+        "headers": [
+          {
+            "name": "connection",
+            "value": "close"
+          },
+          {
+            "name": "content-length",
+            "value": "12"
+          },
+          {
+            "name": "content-type",
+            "value": "application/json"
+          }
+        ]
+      },
+      "sessionId": null,
+      "startedAt": "<int>",
+      "status": 200,
+      "tags": [
+        "smoke",
+        "golden"
+      ],
+      "url": "<url>"
+    }
+  ],
+  "schemaVersion": 1,
+  "workspace": {
+    "id": "<ulid>",
+    "path": "<path>"
+  }
+}

--- a/crates/facet/tests/golden/session_end.json
+++ b/crates/facet/tests/golden/session_end.json
@@ -1,0 +1,14 @@
+{
+  "alreadyEnded": false,
+  "schemaVersion": 1,
+  "session": {
+    "actor": "halo-qa",
+    "endedAt": "<int>",
+    "id": "<ulid>",
+    "meta": {
+      "cwd": "<path>",
+      "note": "golden"
+    },
+    "startedAt": "<int>"
+  }
+}

--- a/crates/facet/tests/golden/session_list.json
+++ b/crates/facet/tests/golden/session_list.json
@@ -1,0 +1,15 @@
+{
+  "schemaVersion": 1,
+  "sessions": [
+    {
+      "actor": "halo-qa",
+      "endedAt": null,
+      "id": "<ulid>",
+      "meta": {
+        "cwd": "<path>",
+        "note": "golden"
+      },
+      "startedAt": "<int>"
+    }
+  ]
+}

--- a/crates/facet/tests/golden/session_show.json
+++ b/crates/facet/tests/golden/session_show.json
@@ -1,0 +1,11 @@
+{
+  "schemaVersion": 1,
+  "session": {
+    "actor": "halo-qa",
+    "endedAt": null,
+    "id": "<ulid>",
+    "meta": null,
+    "runs": 2,
+    "startedAt": "<int>"
+  }
+}

--- a/crates/facet/tests/golden/session_start.json
+++ b/crates/facet/tests/golden/session_start.json
@@ -1,0 +1,13 @@
+{
+  "schemaVersion": 1,
+  "session": {
+    "actor": "halo-qa",
+    "endedAt": null,
+    "id": "<ulid>",
+    "meta": {
+      "cwd": "<path>",
+      "note": "golden"
+    },
+    "startedAt": "<int>"
+  }
+}

--- a/crates/lattice/src/lib.rs
+++ b/crates/lattice/src/lib.rs
@@ -127,13 +127,13 @@ impl LatticeError {
     #[must_use]
     pub fn is_query_error(&self) -> bool {
         match self {
-        Self::ReadOnlyQuery => true,
-        Self::Sqlite(rusqlite::Error::SqliteFailure(failure, _)) => {
-            failure.code == rusqlite::ErrorCode::Unknown
-                || failure.code == rusqlite::ErrorCode::ReadOnly
-        }
-        Self::Sqlite(rusqlite::Error::SqlInputError { .. }) => true,
-        Self::Sqlite(rusqlite::Error::MultipleStatement) => true,
+            Self::ReadOnlyQuery => true,
+            Self::Sqlite(rusqlite::Error::SqliteFailure(failure, _)) => {
+                failure.code == rusqlite::ErrorCode::Unknown
+                    || failure.code == rusqlite::ErrorCode::ReadOnly
+            }
+            Self::Sqlite(rusqlite::Error::SqlInputError { .. }) => true,
+            Self::Sqlite(rusqlite::Error::MultipleStatement) => true,
             _ => false,
         }
     }

--- a/crates/lattice/src/lib.rs
+++ b/crates/lattice/src/lib.rs
@@ -29,7 +29,7 @@ use std::{fmt, io, path::PathBuf};
 pub use blobs::{BodyInput, StoredBody, sha256_hex};
 pub use config::{ConfigError, LatticeConfig, Retention, parse_byte_size, parse_retention};
 pub use machine::{
-    EnvironmentRow, MachineStore, machine_config_dir, machine_data_dir,
+    EnvironmentRow, MachineStore, SessionQuery, SessionRow, machine_config_dir, machine_data_dir,
 };
 pub use rusqlite::types::Value as SqlValue;
 pub use secrets::{

--- a/crates/lattice/src/machine.rs
+++ b/crates/lattice/src/machine.rs
@@ -5,7 +5,7 @@ use std::{
     path::{Path, PathBuf},
 };
 
-use rusqlite::{Connection, params};
+use rusqlite::{Connection, params, types::Value};
 
 use crate::{
     DB_FILE, LatticeConfig, LatticeError, RunRow, io_error,
@@ -50,6 +50,32 @@ pub struct WorkspaceRow {
     pub name: Option<String>,
     /// Last time a run was indexed.
     pub last_seen: i64,
+}
+
+/// One row of `sessions` (cross-workspace, machine store only).
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct SessionRow {
+    /// ULID.
+    pub id: String,
+    /// `human` or an agent name.
+    pub actor: String,
+    /// Unix milliseconds UTC.
+    pub started_at: i64,
+    /// Unix milliseconds UTC, `None` while the session is open.
+    pub ended_at: Option<i64>,
+    /// JSON metadata pointer (Herdr ids, omp session id, cwd). Never transcripts.
+    pub meta: Option<String>,
+}
+
+/// Filters for [`MachineStore::sessions`].
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
+pub struct SessionQuery {
+    /// Maximum rows, newest first.
+    pub limit: usize,
+    /// Only sessions by this actor.
+    pub actor: Option<String>,
+    /// Only sessions with `ended_at IS NULL`.
+    pub open_only: bool,
 }
 
 /// An open machine store.
@@ -150,6 +176,101 @@ impl MachineStore {
         Ok(self
             .conn
             .query_row("SELECT count(*) FROM run_index", [], |row| row.get(0))?)
+    }
+
+    // ----- Sessions (Goal 1) --------------------------------------------
+
+    /// Starts a new session, returning the row. The id is a fresh ULID.
+    pub fn start_session(
+        &self,
+        actor: &str,
+        meta: Option<&str>,
+        now: i64,
+    ) -> Result<SessionRow, LatticeError> {
+        let id = crate::ulid();
+        self.conn.execute(
+            "INSERT INTO sessions (id, actor, started_at, ended_at, meta) \
+             VALUES (?1, ?2, ?3, NULL, ?4)",
+            params![id, actor, now, meta],
+        )?;
+        Ok(SessionRow {
+            id,
+            actor: actor.to_owned(),
+            started_at: now,
+            ended_at: None,
+            meta: meta.map(str::to_owned),
+        })
+    }
+
+    /// Mint-if-missing: inserts a session with the given id only when no row
+    /// exists yet. Returns `true` when a row was created, `false` when one
+    /// already existed (in which case nothing is written). Used by
+    /// `facet-record` when `FACET_SESSION` is set on a run.
+    pub fn ensure_session(
+        &self,
+        id: &str,
+        actor: &str,
+        now: i64,
+    ) -> Result<bool, LatticeError> {
+        let inserted = self.conn.execute(
+            "INSERT OR IGNORE INTO sessions (id, actor, started_at, ended_at, meta) \
+             VALUES (?1, ?2, ?3, NULL, NULL)",
+            params![id, actor, now],
+        )?;
+        Ok(inserted > 0)
+    }
+
+    /// Ends a session. Idempotent: calling this on an already-ended session
+    /// leaves `ended_at` unchanged and returns the row. Returns `None` when
+    /// no session with `id` exists.
+    pub fn end_session(&self, id: &str, now: i64) -> Result<Option<SessionRow>, LatticeError> {
+        self.conn.execute(
+            "UPDATE sessions SET ended_at = ?2 WHERE id = ?1 AND ended_at IS NULL",
+            params![id, now],
+        )?;
+        self.session(id)
+    }
+
+    /// Fetches one session by id, or `None` when absent.
+    pub fn session(&self, id: &str) -> Result<Option<SessionRow>, LatticeError> {
+        let row = match self.conn.query_row(
+            "SELECT id, actor, started_at, ended_at, meta FROM sessions WHERE id = ?1",
+            params![id],
+            row_to_session,
+        ) {
+            Ok(row) => Some(row),
+            Err(rusqlite::Error::QueryReturnedNoRows) => None,
+            Err(other) => return Err(other.into()),
+        };
+        Ok(row)
+    }
+
+    /// Lists sessions newest first, optionally filtered by actor and open state.
+    pub fn sessions(&self, query: &SessionQuery) -> Result<Vec<SessionRow>, LatticeError> {
+        let mut sql = String::from("SELECT id, actor, started_at, ended_at, meta FROM sessions");
+        let mut clauses = Vec::new();
+        let mut values: Vec<Value> = Vec::new();
+        if let Some(actor) = &query.actor {
+            clauses.push("actor = ?");
+            values.push(Value::Text(actor.clone()));
+        }
+        if query.open_only {
+            clauses.push("ended_at IS NULL");
+        }
+        if !clauses.is_empty() {
+            sql.push_str(" WHERE ");
+            sql.push_str(&clauses.join(" AND "));
+        }
+        sql.push_str(" ORDER BY started_at DESC, id DESC LIMIT ?");
+        values.push(Value::Integer(i64::try_from(query.limit as u64).unwrap_or(i64::MAX)));
+
+        let mut statement = self.conn.prepare(&sql)?;
+        let mut rows = statement.query(rusqlite::params_from_iter(values))?;
+        let mut out = Vec::new();
+        while let Some(row) = rows.next()? {
+            out.push(row_to_session(row)?);
+        }
+        Ok(out)
     }
 
     // ----- Environments (Surface 3) --------------------------------------
@@ -350,4 +471,14 @@ pub struct EnvironmentRow {
     pub secret: bool,
     /// Unix milliseconds UTC of the last update.
     pub updated_at: i64,
+}
+
+fn row_to_session(row: &rusqlite::Row<'_>) -> rusqlite::Result<SessionRow> {
+    Ok(SessionRow {
+        id: row.get(0)?,
+        actor: row.get(1)?,
+        started_at: row.get(2)?,
+        ended_at: row.get(3)?,
+        meta: row.get(4)?,
+    })
 }

--- a/crates/lattice/src/machine.rs
+++ b/crates/lattice/src/machine.rs
@@ -206,12 +206,7 @@ impl MachineStore {
     /// exists yet. Returns `true` when a row was created, `false` when one
     /// already existed (in which case nothing is written). Used by
     /// `facet-record` when `FACET_SESSION` is set on a run.
-    pub fn ensure_session(
-        &self,
-        id: &str,
-        actor: &str,
-        now: i64,
-    ) -> Result<bool, LatticeError> {
+    pub fn ensure_session(&self, id: &str, actor: &str, now: i64) -> Result<bool, LatticeError> {
         let inserted = self.conn.execute(
             "INSERT OR IGNORE INTO sessions (id, actor, started_at, ended_at, meta) \
              VALUES (?1, ?2, ?3, NULL, NULL)",
@@ -262,7 +257,9 @@ impl MachineStore {
             sql.push_str(&clauses.join(" AND "));
         }
         sql.push_str(" ORDER BY started_at DESC, id DESC LIMIT ?");
-        values.push(Value::Integer(i64::try_from(query.limit as u64).unwrap_or(i64::MAX)));
+        values.push(Value::Integer(
+            i64::try_from(query.limit as u64).unwrap_or(i64::MAX),
+        ));
 
         let mut statement = self.conn.prepare(&sql)?;
         let mut rows = statement.query(rusqlite::params_from_iter(values))?;
@@ -376,7 +373,12 @@ impl MachineStore {
             "SELECT value, secret_ref FROM environments \
              WHERE workspace_id = ?1 AND name = ?2 AND key = ?3",
             params![workspace_id, name, key],
-            |row| Ok((row.get::<_, Option<String>>(0)?, row.get::<_, Option<String>>(1)?)),
+            |row| {
+                Ok((
+                    row.get::<_, Option<String>>(0)?,
+                    row.get::<_, Option<String>>(1)?,
+                ))
+            },
         ) {
             Ok(pair) => Some(pair),
             Err(rusqlite::Error::QueryReturnedNoRows) => None,
@@ -386,9 +388,7 @@ impl MachineStore {
             return Ok(None);
         };
         match secret_ref {
-            Some(reference) if !reference.is_empty() => {
-                Ok(get_secret_with(&reference, config)?)
-            }
+            Some(reference) if !reference.is_empty() => Ok(get_secret_with(&reference, config)?),
             _ => Ok(value),
         }
     }

--- a/crates/lattice/src/secrets.rs
+++ b/crates/lattice/src/secrets.rs
@@ -343,8 +343,8 @@ fn hex_encode(bytes: &[u8]) -> String {
 #[cfg(test)]
 mod tests {
     use super::{
-        ENCRYPTED_REF_PREFIX, SecretBackend, SecretConfig, SecretError, backend_of, delete_secret_with,
-        get_secret_with, put_secret_with,
+        ENCRYPTED_REF_PREFIX, SecretBackend, SecretConfig, SecretError, backend_of,
+        delete_secret_with, get_secret_with, put_secret_with,
     };
 
     #[test]
@@ -354,7 +354,9 @@ mod tests {
         assert_eq!(stored.backend, SecretBackend::Encrypted);
         assert!(stored.reference.starts_with(ENCRYPTED_REF_PREFIX));
         assert_eq!(
-            get_secret_with(&stored.reference, &config).unwrap().as_deref(),
+            get_secret_with(&stored.reference, &config)
+                .unwrap()
+                .as_deref(),
             Some("hunter2")
         );
         assert_eq!(
@@ -365,7 +367,9 @@ mod tests {
         let again = put_secret_with("hunter2", &config).unwrap();
         assert_ne!(stored.reference, again.reference);
         assert_eq!(
-            get_secret_with(&again.reference, &config).unwrap().as_deref(),
+            get_secret_with(&again.reference, &config)
+                .unwrap()
+                .as_deref(),
             Some("hunter2")
         );
         delete_secret_with(&stored.reference, &config).unwrap();

--- a/crates/lattice/src/store.rs
+++ b/crates/lattice/src/store.rs
@@ -192,6 +192,17 @@ pub struct HistoryQuery {
     pub actor: Option<String>,
     /// Only runs started at or after this time.
     pub since: Option<i64>,
+    /// Only runs recorded under this session id.
+    pub session_id: Option<String>,
+    /// Only runs recorded under this environment name.
+    pub environment: Option<String>,
+    /// Only runs carrying every one of these tags (AND). Matched via
+    /// `json_each(tags)`; a run with no tags never matches.
+    pub tags: Vec<String>,
+    /// Only runs whose `request_hash`, `req_body_hash`, or `res_body_hash`
+    /// equals this value. Which column matched is reported by the CLI
+    /// (`matchedHash`), not by the store.
+    pub hash: Option<String>,
 }
 
 /// A blob registry row plus its bytes.
@@ -417,6 +428,29 @@ impl WorkspaceStore {
         if let Some(since) = query.since {
             clauses.push("started_at >= ?");
             values.push(Value::Integer(since));
+        }
+        if let Some(session_id) = &query.session_id {
+            clauses.push("session_id = ?");
+            values.push(Value::Text(session_id.clone()));
+        }
+        if let Some(environment) = &query.environment {
+            clauses.push("environment = ?");
+            values.push(Value::Text(environment.clone()));
+        }
+        for tag in &query.tags {
+            // AND: every tag must appear in the run's tags array. A NULL or
+            // empty tags column yields no rows from json_each, so it never
+            // matches, which is the correct absence semantics.
+            clauses.push("EXISTS (SELECT 1 FROM json_each(tags) WHERE value = ?)");
+            values.push(Value::Text(tag.clone()));
+        }
+        if let Some(hash) = &query.hash {
+            // One column-agnostic flag across the three hash columns.
+            clauses.push("(request_hash = ? OR req_body_hash = ? OR res_body_hash = ?)");
+            let hash_value = Value::Text(hash.clone());
+            values.push(hash_value.clone());
+            values.push(hash_value.clone());
+            values.push(hash_value);
         }
         if !clauses.is_empty() {
             sql.push_str(" WHERE ");

--- a/crates/lattice/src/store.rs
+++ b/crates/lattice/src/store.rs
@@ -737,10 +737,7 @@ pub(crate) fn open_connection(
 /// blob files and set `req_body_hash`, so no body is lost. No-op on fresh
 /// stores (no `runs` table or no inline rows) and on stores already at v2
 /// (the column is gone). Idempotent: identical content shares one file.
-fn hydrate_inline_request_bodies(
-    conn: &Connection,
-    blobs_dir: &Path,
-) -> Result<(), LatticeError> {
+fn hydrate_inline_request_bodies(conn: &Connection, blobs_dir: &Path) -> Result<(), LatticeError> {
     // Only meaningful when the v1 `runs` table still has `req_body`.
     let has_req_body: i64 = conn
         .query_row(
@@ -752,8 +749,9 @@ fn hydrate_inline_request_bodies(
     if has_req_body == 0 {
         return Ok(());
     }
-    let mut statement =
-        conn.prepare("SELECT id, req_body FROM runs WHERE req_body IS NOT NULL AND req_body_hash IS NULL")?;
+    let mut statement = conn.prepare(
+        "SELECT id, req_body FROM runs WHERE req_body IS NOT NULL AND req_body_hash IS NULL",
+    )?;
     let rows: Vec<(String, Vec<u8>)> = statement
         .query_map([], |row| Ok((row.get(0)?, row.get(1)?)))?
         .filter_map(Result::ok)

--- a/crates/lattice/tests/store.rs
+++ b/crates/lattice/tests/store.rs
@@ -591,17 +591,24 @@ fn environments_round_trip_plain_and_secret() {
 #[test]
 fn session_start_end_list_show_round_trip() {
     let dir = tempfile::tempdir().unwrap();
-    let machine = MachineStore::open_at(&dir.path().join("machine.db"), &LatticeConfig::default())
-        .unwrap();
+    let machine =
+        MachineStore::open_at(&dir.path().join("machine.db"), &LatticeConfig::default()).unwrap();
 
     let started = machine
-        .start_session("claude.halo-fullstack", Some(r#"{"herdr":{"tab":"w1:tH"}}"#), 1_000)
+        .start_session(
+            "claude.halo-fullstack",
+            Some(r#"{"herdr":{"tab":"w1:tH"}}"#),
+            1_000,
+        )
         .unwrap();
     assert!(lattice::is_ulid(&started.id));
     assert_eq!(started.actor, "claude.halo-fullstack");
     assert_eq!(started.started_at, 1_000);
     assert!(started.ended_at.is_none());
-    assert_eq!(started.meta.as_deref(), Some(r#"{"herdr":{"tab":"w1:tH"}}"#));
+    assert_eq!(
+        started.meta.as_deref(),
+        Some(r#"{"herdr":{"tab":"w1:tH"}}"#)
+    );
 
     // show
     let fetched = machine.session(&started.id).unwrap().unwrap();
@@ -615,13 +622,17 @@ fn session_start_end_list_show_round_trip() {
             ..SessionQuery::default()
         })
         .unwrap();
-    assert_eq!(open, [started.clone()]);
+    assert_eq!(open, std::slice::from_ref(&started));
 
     // end is idempotent: ended_at set once, second call leaves it unchanged.
     let ended = machine.end_session(&started.id, 2_000).unwrap().unwrap();
     assert_eq!(ended.ended_at, Some(2_000));
     let again = machine.end_session(&started.id, 9_999).unwrap().unwrap();
-    assert_eq!(again.ended_at, Some(2_000), "second end must not move ended_at");
+    assert_eq!(
+        again.ended_at,
+        Some(2_000),
+        "second end must not move ended_at"
+    );
 
     // open_only now excludes it; full list still has it.
     let open_after = machine
@@ -641,15 +652,25 @@ fn session_start_end_list_show_round_trip() {
     assert_eq!(all, [ended]);
 
     // missing id -> None (CLI surfaces session_not_found).
-    assert!(machine.session("01K4NOPE00000000000000000").unwrap().is_none());
-    assert!(machine.end_session("01K4NOPE00000000000000000", 3_000).unwrap().is_none());
+    assert!(
+        machine
+            .session("01K4NOPE00000000000000000")
+            .unwrap()
+            .is_none()
+    );
+    assert!(
+        machine
+            .end_session("01K4NOPE00000000000000000", 3_000)
+            .unwrap()
+            .is_none()
+    );
 }
 
 #[test]
 fn session_list_filters_by_actor_and_orders_newest_first() {
     let dir = tempfile::tempdir().unwrap();
-    let machine = MachineStore::open_at(&dir.path().join("machine.db"), &LatticeConfig::default())
-        .unwrap();
+    let machine =
+        MachineStore::open_at(&dir.path().join("machine.db"), &LatticeConfig::default()).unwrap();
     let a = machine.start_session("agent-a", None, 1_000).unwrap();
     let b = machine.start_session("agent-b", None, 2_000).unwrap();
     let c = machine.start_session("agent-a", None, 3_000).unwrap();
@@ -672,7 +693,10 @@ fn session_list_filters_by_actor_and_orders_newest_first() {
             ..SessionQuery::default()
         })
         .unwrap();
-    assert_eq!(agent_a.iter().map(|row| row.started_at).collect::<Vec<_>>(), [3_000, 1_000]);
+    assert_eq!(
+        agent_a.iter().map(|row| row.started_at).collect::<Vec<_>>(),
+        [3_000, 1_000]
+    );
 
     let limited = machine
         .sessions(&SessionQuery {
@@ -686,15 +710,18 @@ fn session_list_filters_by_actor_and_orders_newest_first() {
 #[test]
 fn ensure_session_is_idempotent_mint_if_missing() {
     let dir = tempfile::tempdir().unwrap();
-    let machine = MachineStore::open_at(&dir.path().join("machine.db"), &LatticeConfig::default())
-        .unwrap();
+    let machine =
+        MachineStore::open_at(&dir.path().join("machine.db"), &LatticeConfig::default()).unwrap();
 
     // First call mints the row.
     let created = machine
         .ensure_session("01K4ENSURE0000000000000001", "agent-x", 1_000)
         .unwrap();
     assert!(created);
-    let row = machine.session("01K4ENSURE0000000000000001").unwrap().unwrap();
+    let row = machine
+        .session("01K4ENSURE0000000000000001")
+        .unwrap()
+        .unwrap();
     assert_eq!(row.actor, "agent-x");
     assert_eq!(row.started_at, 1_000);
     assert!(row.ended_at.is_none());
@@ -706,7 +733,10 @@ fn ensure_session_is_idempotent_mint_if_missing() {
         .ensure_session("01K4ENSURE0000000000000001", "someone-else", 9_999)
         .unwrap();
     assert!(!created_again);
-    let row_after = machine.session("01K4ENSURE0000000000000001").unwrap().unwrap();
+    let row_after = machine
+        .session("01K4ENSURE0000000000000001")
+        .unwrap()
+        .unwrap();
     assert_eq!(row_after.actor, "agent-x");
     assert_eq!(row_after.started_at, 1_000);
 
@@ -745,7 +775,10 @@ fn history_filters_by_session_environment_tag_and_hash() {
             ..NewRun::default()
         })
         .unwrap();
-    assert_eq!(in_session.req_body.hash.as_deref(), Some(req_body_hash.as_str()));
+    assert_eq!(
+        in_session.req_body.hash.as_deref(),
+        Some(req_body_hash.as_str())
+    );
     assert_eq!(in_session.res_body.hash.as_deref(), Some(res_hash.as_str()));
 
     let other_session = store
@@ -786,7 +819,10 @@ fn history_filters_by_session_environment_tag_and_hash() {
             ..HistoryQuery::default()
         })
         .unwrap();
-    assert_eq!(session_a.iter().map(|r| r.id.clone()).collect::<Vec<_>>(), [in_session.id.clone()]);
+    assert_eq!(
+        session_a.iter().map(|r| r.id.clone()).collect::<Vec<_>>(),
+        std::slice::from_ref(&in_session.id)
+    );
 
     // environment filter
     let local = store
@@ -797,7 +833,11 @@ fn history_filters_by_session_environment_tag_and_hash() {
         })
         .unwrap();
     assert_eq!(local.len(), 2);
-    assert!(local.iter().all(|r| r.environment.as_deref() == Some("local")));
+    assert!(
+        local
+            .iter()
+            .all(|r| r.environment.as_deref() == Some("local"))
+    );
 
     // tag AND: a run with both smoke and regression
     let tagged = store
@@ -807,7 +847,10 @@ fn history_filters_by_session_environment_tag_and_hash() {
             ..HistoryQuery::default()
         })
         .unwrap();
-    assert_eq!(tagged.iter().map(|r| r.id.clone()).collect::<Vec<_>>(), [in_session.id.clone()]);
+    assert_eq!(
+        tagged.iter().map(|r| r.id.clone()).collect::<Vec<_>>(),
+        std::slice::from_ref(&in_session.id)
+    );
 
     // tag that only one run has, but the other lacks
     let regression = store
@@ -817,7 +860,10 @@ fn history_filters_by_session_environment_tag_and_hash() {
             ..HistoryQuery::default()
         })
         .unwrap();
-    assert_eq!(regression.iter().map(|r| r.id.clone()).collect::<Vec<_>>(), [in_session.id.clone()]);
+    assert_eq!(
+        regression.iter().map(|r| r.id.clone()).collect::<Vec<_>>(),
+        std::slice::from_ref(&in_session.id)
+    );
 
     // a run with no tags never matches any tag filter
     let no_tags_match = store
@@ -837,7 +883,10 @@ fn history_filters_by_session_environment_tag_and_hash() {
             ..HistoryQuery::default()
         })
         .unwrap();
-    assert_eq!(by_res_hash.iter().map(|r| r.id.clone()).collect::<Vec<_>>(), [in_session.id.clone()]);
+    assert_eq!(
+        by_res_hash.iter().map(|r| r.id.clone()).collect::<Vec<_>>(),
+        std::slice::from_ref(&in_session.id)
+    );
 
     // request body hash
     let by_req_body_hash = store
@@ -847,7 +896,13 @@ fn history_filters_by_session_environment_tag_and_hash() {
             ..HistoryQuery::default()
         })
         .unwrap();
-    assert_eq!(by_req_body_hash.iter().map(|r| r.id.clone()).collect::<Vec<_>>(), [in_session.id.clone()]);
+    assert_eq!(
+        by_req_body_hash
+            .iter()
+            .map(|r| r.id.clone())
+            .collect::<Vec<_>>(),
+        std::slice::from_ref(&in_session.id)
+    );
 
     // request hash
     let by_req_hash = store
@@ -857,7 +912,10 @@ fn history_filters_by_session_environment_tag_and_hash() {
             ..HistoryQuery::default()
         })
         .unwrap();
-    assert_eq!(by_req_hash.iter().map(|r| r.id.clone()).collect::<Vec<_>>(), [in_session.id.clone()]);
+    assert_eq!(
+        by_req_hash.iter().map(|r| r.id.clone()).collect::<Vec<_>>(),
+        std::slice::from_ref(&in_session.id)
+    );
 
     // a hash that no run carries
     let by_missing_hash = store
@@ -878,7 +936,13 @@ fn history_filters_by_session_environment_tag_and_hash() {
             ..HistoryQuery::default()
         })
         .unwrap();
-    assert_eq!(session_a_smoke.iter().map(|r| r.id.clone()).collect::<Vec<_>>(), [in_session.id.clone()]);
+    assert_eq!(
+        session_a_smoke
+            .iter()
+            .map(|r| r.id.clone())
+            .collect::<Vec<_>>(),
+        std::slice::from_ref(&in_session.id)
+    );
 
     let _ = other_session;
 }

--- a/crates/lattice/tests/store.rs
+++ b/crates/lattice/tests/store.rs
@@ -5,7 +5,8 @@ use std::fs;
 
 use lattice::{
     BodyInput, HistoryQuery, LatticeConfig, LatticeError, MachineStore, NewRun, Retention,
-    SecretConfig, SqlValue, WORKSPACE_SCHEMA_VERSION, WorkspaceStore, now_ms, sha256_hex,
+    SecretConfig, SessionQuery, SqlValue, WORKSPACE_SCHEMA_VERSION, WorkspaceStore, now_ms,
+    sha256_hex,
 };
 
 fn config(threshold: u64) -> LatticeConfig {
@@ -585,4 +586,299 @@ fn environments_round_trip_plain_and_secret() {
             .delete_environment_with(wsid, "local", "API_TOKEN", &key_cfg)
             .unwrap()
     );
+}
+
+#[test]
+fn session_start_end_list_show_round_trip() {
+    let dir = tempfile::tempdir().unwrap();
+    let machine = MachineStore::open_at(&dir.path().join("machine.db"), &LatticeConfig::default())
+        .unwrap();
+
+    let started = machine
+        .start_session("claude.halo-fullstack", Some(r#"{"herdr":{"tab":"w1:tH"}}"#), 1_000)
+        .unwrap();
+    assert!(lattice::is_ulid(&started.id));
+    assert_eq!(started.actor, "claude.halo-fullstack");
+    assert_eq!(started.started_at, 1_000);
+    assert!(started.ended_at.is_none());
+    assert_eq!(started.meta.as_deref(), Some(r#"{"herdr":{"tab":"w1:tH"}}"#));
+
+    // show
+    let fetched = machine.session(&started.id).unwrap().unwrap();
+    assert_eq!(fetched, started);
+
+    // list: one open session
+    let open = machine
+        .sessions(&SessionQuery {
+            limit: 10,
+            open_only: true,
+            ..SessionQuery::default()
+        })
+        .unwrap();
+    assert_eq!(open, [started.clone()]);
+
+    // end is idempotent: ended_at set once, second call leaves it unchanged.
+    let ended = machine.end_session(&started.id, 2_000).unwrap().unwrap();
+    assert_eq!(ended.ended_at, Some(2_000));
+    let again = machine.end_session(&started.id, 9_999).unwrap().unwrap();
+    assert_eq!(again.ended_at, Some(2_000), "second end must not move ended_at");
+
+    // open_only now excludes it; full list still has it.
+    let open_after = machine
+        .sessions(&SessionQuery {
+            limit: 10,
+            open_only: true,
+            ..SessionQuery::default()
+        })
+        .unwrap();
+    assert!(open_after.is_empty());
+    let all = machine
+        .sessions(&SessionQuery {
+            limit: 10,
+            ..SessionQuery::default()
+        })
+        .unwrap();
+    assert_eq!(all, [ended]);
+
+    // missing id -> None (CLI surfaces session_not_found).
+    assert!(machine.session("01K4NOPE00000000000000000").unwrap().is_none());
+    assert!(machine.end_session("01K4NOPE00000000000000000", 3_000).unwrap().is_none());
+}
+
+#[test]
+fn session_list_filters_by_actor_and_orders_newest_first() {
+    let dir = tempfile::tempdir().unwrap();
+    let machine = MachineStore::open_at(&dir.path().join("machine.db"), &LatticeConfig::default())
+        .unwrap();
+    let a = machine.start_session("agent-a", None, 1_000).unwrap();
+    let b = machine.start_session("agent-b", None, 2_000).unwrap();
+    let c = machine.start_session("agent-a", None, 3_000).unwrap();
+
+    let all = machine
+        .sessions(&SessionQuery {
+            limit: 10,
+            ..SessionQuery::default()
+        })
+        .unwrap();
+    assert_eq!(
+        all.iter().map(|row| row.id.clone()).collect::<Vec<_>>(),
+        [c.id.clone(), b.id.clone(), a.id.clone()]
+    );
+
+    let agent_a = machine
+        .sessions(&SessionQuery {
+            limit: 10,
+            actor: Some("agent-a".into()),
+            ..SessionQuery::default()
+        })
+        .unwrap();
+    assert_eq!(agent_a.iter().map(|row| row.started_at).collect::<Vec<_>>(), [3_000, 1_000]);
+
+    let limited = machine
+        .sessions(&SessionQuery {
+            limit: 1,
+            ..SessionQuery::default()
+        })
+        .unwrap();
+    assert_eq!(limited, [c]);
+}
+
+#[test]
+fn ensure_session_is_idempotent_mint_if_missing() {
+    let dir = tempfile::tempdir().unwrap();
+    let machine = MachineStore::open_at(&dir.path().join("machine.db"), &LatticeConfig::default())
+        .unwrap();
+
+    // First call mints the row.
+    let created = machine
+        .ensure_session("01K4ENSURE0000000000000001", "agent-x", 1_000)
+        .unwrap();
+    assert!(created);
+    let row = machine.session("01K4ENSURE0000000000000001").unwrap().unwrap();
+    assert_eq!(row.actor, "agent-x");
+    assert_eq!(row.started_at, 1_000);
+    assert!(row.ended_at.is_none());
+    assert!(row.meta.is_none());
+
+    // Second call with the same id is a no-op: created is false, actor and
+    // started_at are unchanged even when different arguments are passed.
+    let created_again = machine
+        .ensure_session("01K4ENSURE0000000000000001", "someone-else", 9_999)
+        .unwrap();
+    assert!(!created_again);
+    let row_after = machine.session("01K4ENSURE0000000000000001").unwrap().unwrap();
+    assert_eq!(row_after.actor, "agent-x");
+    assert_eq!(row_after.started_at, 1_000);
+
+    // A different id mints a new row.
+    let created_other = machine
+        .ensure_session("01K4ENSURE0000000000000002", "agent-x", 2_000)
+        .unwrap();
+    assert!(created_other);
+}
+
+#[test]
+fn history_filters_by_session_environment_tag_and_hash() {
+    let dir = tempfile::tempdir().unwrap();
+    // Tiny threshold so the 5-byte response body lands as a blob and gets a
+    // res_body_hash; request bodies are hash-only regardless of size.
+    let store = WorkspaceStore::open(dir.path(), config(2)).unwrap();
+
+    let req_hash = sha256_hex(b"req-a");
+    let res_hash = sha256_hex(b"res-a");
+    let req_body_hash = sha256_hex(b"reqbody-a");
+
+    let in_session = store
+        .record_run(&NewRun {
+            started_at: 1_000,
+            request_path: "Pets/List",
+            request_hash: &req_hash,
+            environment: Some("local"),
+            method: "GET",
+            url: "http://x/pets",
+            status: Some(200),
+            req_body: BodyInput::Bytes(b"reqbody-a"),
+            res_body: BodyInput::Bytes(b"res-a"),
+            session_id: Some("01K4SESS0000000000000000A"),
+            actor: "agent-x",
+            tags: Some(r#"["smoke","regression"]"#),
+            ..NewRun::default()
+        })
+        .unwrap();
+    assert_eq!(in_session.req_body.hash.as_deref(), Some(req_body_hash.as_str()));
+    assert_eq!(in_session.res_body.hash.as_deref(), Some(res_hash.as_str()));
+
+    let other_session = store
+        .record_run(&NewRun {
+            started_at: 2_000,
+            request_path: "Pets/List",
+            request_hash: "deadbeef",
+            environment: Some("ci"),
+            method: "GET",
+            url: "http://x/pets",
+            status: Some(500),
+            session_id: Some("01K4SESS0000000000000000B"),
+            actor: "agent-x",
+            tags: Some(r#"["smoke"]"#),
+            ..NewRun::default()
+        })
+        .unwrap();
+
+    let no_session = store
+        .record_run(&NewRun {
+            started_at: 3_000,
+            request_path: "Pets/List",
+            request_hash: "deadbeef",
+            environment: Some("local"),
+            method: "GET",
+            url: "http://x/pets",
+            status: Some(200),
+            actor: "human",
+            ..NewRun::default()
+        })
+        .unwrap();
+
+    // session_id filter
+    let session_a = store
+        .history(&HistoryQuery {
+            limit: 10,
+            session_id: Some("01K4SESS0000000000000000A".into()),
+            ..HistoryQuery::default()
+        })
+        .unwrap();
+    assert_eq!(session_a.iter().map(|r| r.id.clone()).collect::<Vec<_>>(), [in_session.id.clone()]);
+
+    // environment filter
+    let local = store
+        .history(&HistoryQuery {
+            limit: 10,
+            environment: Some("local".into()),
+            ..HistoryQuery::default()
+        })
+        .unwrap();
+    assert_eq!(local.len(), 2);
+    assert!(local.iter().all(|r| r.environment.as_deref() == Some("local")));
+
+    // tag AND: a run with both smoke and regression
+    let tagged = store
+        .history(&HistoryQuery {
+            limit: 10,
+            tags: vec!["smoke".into(), "regression".into()],
+            ..HistoryQuery::default()
+        })
+        .unwrap();
+    assert_eq!(tagged.iter().map(|r| r.id.clone()).collect::<Vec<_>>(), [in_session.id.clone()]);
+
+    // tag that only one run has, but the other lacks
+    let regression = store
+        .history(&HistoryQuery {
+            limit: 10,
+            tags: vec!["regression".into()],
+            ..HistoryQuery::default()
+        })
+        .unwrap();
+    assert_eq!(regression.iter().map(|r| r.id.clone()).collect::<Vec<_>>(), [in_session.id.clone()]);
+
+    // a run with no tags never matches any tag filter
+    let no_tags_match = store
+        .history(&HistoryQuery {
+            limit: 10,
+            tags: vec!["smoke".into()],
+            ..HistoryQuery::default()
+        })
+        .unwrap();
+    assert!(!no_tags_match.iter().any(|r| r.id == no_session.id));
+
+    // hash matches any of the three columns: response body hash
+    let by_res_hash = store
+        .history(&HistoryQuery {
+            limit: 10,
+            hash: Some(res_hash.clone()),
+            ..HistoryQuery::default()
+        })
+        .unwrap();
+    assert_eq!(by_res_hash.iter().map(|r| r.id.clone()).collect::<Vec<_>>(), [in_session.id.clone()]);
+
+    // request body hash
+    let by_req_body_hash = store
+        .history(&HistoryQuery {
+            limit: 10,
+            hash: Some(req_body_hash.clone()),
+            ..HistoryQuery::default()
+        })
+        .unwrap();
+    assert_eq!(by_req_body_hash.iter().map(|r| r.id.clone()).collect::<Vec<_>>(), [in_session.id.clone()]);
+
+    // request hash
+    let by_req_hash = store
+        .history(&HistoryQuery {
+            limit: 10,
+            hash: Some(req_hash.clone()),
+            ..HistoryQuery::default()
+        })
+        .unwrap();
+    assert_eq!(by_req_hash.iter().map(|r| r.id.clone()).collect::<Vec<_>>(), [in_session.id.clone()]);
+
+    // a hash that no run carries
+    let by_missing_hash = store
+        .history(&HistoryQuery {
+            limit: 10,
+            hash: Some(sha256_hex(b"nowhere")),
+            ..HistoryQuery::default()
+        })
+        .unwrap();
+    assert!(by_missing_hash.is_empty());
+
+    // filters compose: session + tag
+    let session_a_smoke = store
+        .history(&HistoryQuery {
+            limit: 10,
+            session_id: Some("01K4SESS0000000000000000A".into()),
+            tags: vec!["smoke".into()],
+            ..HistoryQuery::default()
+        })
+        .unwrap();
+    assert_eq!(session_a_smoke.iter().map(|r| r.id.clone()).collect::<Vec<_>>(), [in_session.id.clone()]);
+
+    let _ = other_session;
 }

--- a/docs/FACET.md
+++ b/docs/FACET.md
@@ -205,8 +205,13 @@ in the Lapis vault for the full runbook.
 
 ```text
 facet request run <path> <selector> [<probe request run flags>] [--no-record] [--tag <tag>]... [--inline-body-max <size>] [--json]
-facet history [<path>] [--limit <n>] [--request <selector>] [--status <code>] [--actor <name>] [--since <unix-ms>] [--bodies] [--json]
+facet history [<path>] [--limit <n>] [--request <selector>] [--status <code>] [--actor <name>] [--since <unix-ms>] [--session <id>|current] [--environment <name>] [--tag <tag>]... [--hash <sha256>] [--bodies] [--json]
+facet history [<path>] --id <ulid> [--bodies] [--json]
 facet history [<path>] --sql "<query>" [--json]
+facet session start [--actor <name>] [--meta <json>] [--json]
+facet session end [<id>|current] [--json]
+facet session list [--limit <n>] [--actor <name>] [--open] [--json]
+facet session show <id>|current [--json]
 facet blob <hash> [<path>] [--output <file>] [--json]
 facet gc [<path>] [--history-retention <r>] [--yes] [--json]
 facet tui [<path>] [--appearance graphite|porcelain]
@@ -272,6 +277,29 @@ blob bodies are always omitted with `omissionReason: "blob"` (pull them with
 `blob <hash>`). The envelope carries `workspace: { id, path }`, or `null` with
 `runs: []` when no store exists.
 
+Filters are query-side and AND together. `--session <id>` matches
+`sessionId`; `--session current` resolves `FACET_SESSION` and fails with
+`session_not_set` (exit 5) when it is unset. `--environment <name>` matches
+the environment the request was resolved with. `--tag <tag>` may repeat;
+every tag must be present (a run with no tags never matches). `--hash <sha256>`
+is column-agnostic: it matches `requestHash`, the request body hash, or the
+response body hash (case-insensitive), and each returned row gains
+`"matchedHash": "request" | "requestBody" | "responseBody"` saying which
+column hit. `matchedHash` is absent when `--hash` is not given.
+
+### `history --id`
+
+One run by id, as one object rather than a one-element list:
+
+```json
+{ "schemaVersion": 1, "workspace": { "id": "…", "path": "…" }, "run": { …same run shape as history… } }
+```
+
+`--bodies` behaves exactly as on the list. `--id` cannot be combined with
+any filter or with `--sql` (`invalid_arguments`, exit 2). An unknown id, or
+no store at all, is `run_not_found` (exit 4). This is the seam replay and
+diff stand on: an agent keeps run ids, not bodies.
+
 ### `history --sql`
 
 Runs one read-only statement against the workspace store on a read-only
@@ -285,6 +313,41 @@ connection with `query_only` set:
 BLOB columns render as `{ "type": "blob", "sizeBytes": n }`. Writes fail with
 `sql_read_only`; parse failures with `invalid_sql` (both exit 2). A missing
 store is `lattice_not_found` (exit 9).
+
+### `session`
+
+Sessions are the unit a harness turns on and off around a run of work. They
+live in the machine store (cross-workspace); `request run` stamps
+`FACET_SESSION` on every recorded run.
+
+`session start` prints the new ULID alone in human mode, so
+`export FACET_SESSION=$(facet session start)` needs no `jq`. The actor is
+`--actor`, else `FACET_ACTOR`, else `human`. `meta` is pointers only:
+`herdr: { workspace, tab, pane }` from `HERDR_WORKSPACE_ID` / `HERDR_TAB_ID` /
+`HERDR_PANE_ID` when set, `cwd`, then the `--meta` object merged on top (it
+wins). Never transcripts, never secrets.
+
+```json
+{ "schemaVersion": 1,
+  "session": { "id": "01K…", "actor": "claude.halo-fullstack", "startedAt": 1757250000123, "endedAt": null,
+               "meta": { "herdr": { "workspace": "w1", "tab": "w1:tR", "pane": "w1:pR" }, "cwd": "/…/repos/facet" },
+               "runs": 0 } }
+```
+
+`runs` counts the session's runs in the workspace store discovered from the
+current directory; it is omitted when no store is found there. `show` and
+`end` return the same `session` object; `end` adds `"alreadyEnded": true|false`
+and is idempotent (`endedAt` never moves). `list` returns
+`{ "sessions": [ …session… ] }`, newest first, default limit 50; `--open`
+keeps only sessions with `endedAt: null`. `<id>` may be `current`
+(`FACET_SESSION`); `session end` with no id uses `FACET_SESSION` too. An
+unknown id is `session_not_found` (exit 4); no `FACET_SESSION` when one is
+needed is `session_not_set` (exit 5).
+
+Mint-if-missing: when `FACET_SESSION` names a session no `session start`
+created (a harness invented the id), the first recorded run inserts the row
+with that run's actor and no `meta`. Later runs never rewrite it. This is
+best effort like machine-store indexing and never fails the run.
 
 ### `blob`
 
@@ -320,15 +383,18 @@ Facet extends the upstream table; it never renumbers it.
 | 0–8 | As in [CLI](CLI.md#exit-codes) |
 | 9 | Lattice store failure (`lattice_error`, `lattice_not_found`) |
 
-Additional stable categories: `blob_not_found` (exit 4), `invalid_sql` and
-`sql_read_only` (exit 2). Every JSON document carries `schemaVersion: 1`;
+Additional stable categories: `blob_not_found`, `run_not_found`, and
+`session_not_found` (exit 4, "not found"); `session_not_set` (exit 5,
+configuration); `invalid_sql` and `sql_read_only` (exit 2). Every JSON document carries `schemaVersion: 1`;
 fields are added compatibly and never removed or retyped within a version.
 
 ## Tests
 
 - `crates/facet/tests/facet_commands.rs`: one golden file per command under
   `crates/facet/tests/golden/` (`UPDATE_GOLDEN=1` rewrites them), plus
-  recording, reader-rule, read-only SQL, and gc behavior through the binary.
+  recording, reader-rule, read-only SQL, gc, session lifecycle,
+  mint-if-missing, `history --id`, and the session / environment / tag /
+  hash filters through the binary.
 - `crates/lattice/tests/store.rs`: schema, threshold placement, reader rule
   across threshold changes, gc, machine index, environments (plain + secret).
 - `crates/lattice/tests/contention.rs`: Surface 4 fixture.


### PR DESCRIPTION
## Summary

Goal 1, commit 1 of deep dive §1: CLI + Lattice only. No TUI, no replay, nothing in `probe-*`.

- `facet session start|end|list|show` over the machine store. `session start` prints a bare ULID in human mode so `export FACET_SESSION=$(facet session start)` needs no `jq`. `--meta` merges over Herdr ids (`HERDR_WORKSPACE_ID`/`TAB_ID`/`PANE_ID`) and `cwd`; pointers only. `end` is idempotent and reports `alreadyEnded`. `<id>` accepts `current`.
- `history --id <ulid>`: one run object (`{ workspace, run }`), `run_not_found` exit 4, exclusive with every filter and `--sql`. `--bodies` behaves as on the list.
- `history` filters: `--session <id>|current`, `--environment`, `--tag` (repeatable, AND via `json_each`), `--hash` (request hash or either body hash, case-insensitive; each row gains `matchedHash: request|requestBody|responseBody`).
- Mint-if-missing: a recorded run whose `FACET_SESSION` names no session inserts the row with that run's actor, best effort, never failing the run. Later runs never rewrite it.
- New categories: `run_not_found`, `session_not_found` (4), `session_not_set` (5). No new exit numbers. `request run --json` envelope unchanged (`session_created` lives on `Recording::Recorded` only).
- `session.runs` counts from the workspace store discovered from cwd and is omitted when there is none (§1.2 pick; no 0003).
- Goldens: `session_{start,end,list,show}`, `history_{id,session,tag_hash}`, `error_{run_not_found,session_not_found,session_not_set}`. Existing goldens byte-identical. `docs/FACET.md` updated (commands, envelopes, exit table).

Pair: glm.halo-backend on `crates/lattice` (b981c7d) and `crates/facet-record` (f7952aa).

## Test plan

On apiary (`~/src/facet`, cargo 1.95):

- [x] `cargo test -p lattice -p facet-record -p facet-cli`: 67 passed, 0 failed (facet-cli 20/20 through the binary; lattice store 18/18; contention green).
- [x] `cargo build --release -p facet-cli`.
- [x] Shell smoke with the built binary: `export FACET_SESSION=$(facet session start --meta …)` → two `request run` → `history --session current` (2 rows) → `--tag smoke` → `--id` → `session show current` (RUNS 2, meta merged) → `session end` twice (`alreadyEnded: true`) → exit 5 on `--session current` unset, exit 4 on unknown `--id`.
- [x] `cargo fmt --check`: clean on every file this branch touches. `crates/lattice/tests/{duckdb,turso}.rs` were already unformatted on `main` and are left alone.
- [x] `cargo clippy --all-targets`: no new warnings from this branch (the remaining ones are pre-existing in `facet-tui`, `Recording` size, and two old test lines).

Not in this PR (by design): TUI grid (Goal 2), replay/diff (Goal 4), `--expect` (Goal 6, exit 1 when it lands).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01E3MvVHmyGKQdu6CRignmME
