### PR TITLE
feat(facet-tui): :history grid with hydrate + yank (Goal 2)

### DIFF
--- a/crates/facet-tui/Cargo.toml
+++ b/crates/facet-tui/Cargo.toml
@@ -14,6 +14,7 @@ probe-opencollection = { path = "../opencollection" }
 ratatui = { version = "0.30", default-features = false, features = ["crossterm"] }
 crossterm = "0.29"
 serde_json = "1"
+base64 = "0.23.1"
 tokio = { version = "1.53.1", features = ["rt", "rt-multi-thread", "macros", "time"] }
 unicode-width = "0.2"
 

--- a/crates/facet-tui/src/app.rs
+++ b/crates/facet-tui/src/app.rs
@@ -8,7 +8,7 @@ use std::{
 use facet_record::{ConfigOverrides, RecordRequest, Recording, record};
 
 use crossterm::event::{KeyCode, KeyModifiers};
-use lattice::{HistoryQuery, LatticeConfig, SqlValue, WorkspaceStore};
+use lattice::{HistoryQuery, LatticeConfig, RunRow, SqlValue, WorkspaceStore};
 use probe_core::{
     FolderKey, Header, HttpRequest, QueryParameter, RequestKey, RequestUpdate, resolve_environment,
     resolve_request,
@@ -439,8 +439,13 @@ pub struct App {
     command: String,
     /// `?` help overlay.
     help_open: bool,
-    /// `:history` / `:sql` overlay (title + body lines).
+    /// `:sql` overlay (title + body lines). `:history` is the grid below.
     data_overlay: Option<(String, Vec<String>)>,
+    /// `:history` grid overlay (Goal 2).
+    history_grid: Option<HistoryGrid>,
+    /// Set when the response pane shows a hydrated Lattice run instead of
+    /// a live send; rendered as the pane title (`run 01K… · replayed view`).
+    response_origin: Option<String>,
     /// Awaiting the second key of a `Ctrl-W` focus chord.
     ctrl_w_pending: bool,
     /// Awaiting a second `g` for `gg`.
@@ -508,6 +513,88 @@ impl RecordSummary {
     }
 }
 
+/// Bodies over this size are not pulled into the response pane on hydrate;
+/// the grid shows `blob <hash> · omitted` instead (same cap as the CLI).
+const HYDRATE_BODY_CAP: u64 = 16 * 1024 * 1024;
+
+/// `:history` grid state (Goal 2). A navigable table of Lattice runs —
+/// not a text dump. Keys live in Normal mode inside the overlay:
+/// `j`/`k`/arrows move, `gg`/`G` jump, Enter hydrates the response pane
+/// from the store, `y` yanks the run id (OSC 52), `Y` yanks the response
+/// body hash, `/` filters by selector substring, `s` toggles
+/// "this session only", Esc/`q` closes.
+pub struct HistoryGrid {
+    /// Workspace root the store was opened from; reopened per hydrate so
+    /// the grid never holds a SQLite handle across the UI loop.
+    pub(crate) root: PathBuf,
+    /// Newest-first runs as last queried.
+    pub(crate) rows: Vec<RunRow>,
+    /// Selection index into the *filtered* view, not `rows`.
+    pub(crate) selected: usize,
+    /// `/` selector substring filter.
+    pub(crate) filter: String,
+    /// True while the `/` input is capturing keys.
+    pub(crate) filtering: bool,
+    /// `s` — restrict to runs recorded under `$FACET_SESSION`.
+    pub(crate) session_only: bool,
+    /// Awaiting the second `g` of `gg`.
+    pub(crate) g_pending: bool,
+    /// Footer notice (`yanked 01K…`, hydrate errors). Cleared on move.
+    pub(crate) notice: Option<String>,
+}
+
+impl HistoryGrid {
+    fn new(root: PathBuf, rows: Vec<RunRow>) -> Self {
+        Self {
+            root,
+            rows,
+            selected: 0,
+            filter: String::new(),
+            filtering: false,
+            session_only: false,
+            g_pending: false,
+            notice: None,
+        }
+    }
+
+    /// Indices into `rows` that pass the `/` filter, in display order.
+    pub(crate) fn visible_indices(&self) -> Vec<usize> {
+        let needle = self.filter.to_lowercase();
+        self.rows
+            .iter()
+            .enumerate()
+            .filter(|(_, row)| {
+                needle.is_empty() || row.request_path.to_lowercase().contains(&needle)
+            })
+            .map(|(index, _)| index)
+            .collect()
+    }
+
+    /// The focused row, if any survive the filter.
+    pub(crate) fn selected_row(&self) -> Option<&RunRow> {
+        let visible = self.visible_indices();
+        visible.get(self.selected).map(|&index| &self.rows[index])
+    }
+
+    fn clamp_selection(&mut self) {
+        let len = self.visible_indices().len();
+        self.selected = if len == 0 {
+            0
+        } else {
+            self.selected.min(len - 1)
+        };
+    }
+
+    fn move_selection(&mut self, delta: isize) {
+        let len = self.visible_indices().len() as isize;
+        if len == 0 {
+            return;
+        }
+        self.selected = (self.selected as isize + delta).clamp(0, len - 1) as usize;
+        self.notice = None;
+    }
+}
+
 impl App {
     /// Loads a workspace from disk (or starts empty when no path is given).
     pub async fn load(path: Option<&Path>) -> Self {
@@ -528,6 +615,8 @@ impl App {
             command: String::new(),
             help_open: false,
             data_overlay: None,
+            history_grid: None,
+            response_origin: None,
             ctrl_w_pending: false,
             g_pending: false,
             editor: Editor::default(),
@@ -610,6 +699,7 @@ impl App {
             self.editor_snapshot = EditorSnapshot::default();
             self.editor_dirty = false;
             self.response = None;
+            self.response_origin = None;
             self.status = RunStatus::Idle;
             self.kv_index = 0;
             return;
@@ -619,6 +709,7 @@ impl App {
         self.editor_snapshot = snapshot;
         self.editor_dirty = false;
         self.response = None;
+        self.response_origin = None;
         self.status = RunStatus::Idle;
         self.response_scroll = 0;
         self.kv_index = 0;
@@ -765,6 +856,9 @@ impl App {
         }
         if self.help_open {
             return self.handle_help_key(code);
+        }
+        if self.history_grid.is_some() {
+            return self.handle_history_key(code);
         }
         if self.data_overlay.is_some() {
             return self.handle_data_overlay_key(code);
@@ -1221,39 +1315,288 @@ impl App {
             Err(error) => {
                 self.status = RunStatus::Failed(format!("history: {error}"));
             }
-            Ok(Some(store)) => match store.history(&HistoryQuery {
-                limit: 50,
-                ..HistoryQuery::default()
-            }) {
+            Ok(Some(store)) => {
+                let root = self.workspace_root().expect("a store implies a root");
+                match Self::query_history(&store, false) {
+                    Ok(rows) => {
+                        self.help_open = false;
+                        self.data_overlay = None;
+                        self.history_grid = Some(HistoryGrid::new(root, rows));
+                    }
+                    Err(error) => {
+                        self.status = RunStatus::Failed(format!("history: {error}"));
+                    }
+                }
+            }
+        }
+    }
+
+    fn query_history(
+        store: &WorkspaceStore,
+        session_only: bool,
+    ) -> Result<Vec<RunRow>, lattice::LatticeError> {
+        store.history(&HistoryQuery {
+            limit: 50,
+            session_id: if session_only {
+                facet_record::session_from_env()
+            } else {
+                None
+            },
+            ..HistoryQuery::default()
+        })
+    }
+
+    /// Re-runs the grid query after the `s` session toggle, preserving the
+    /// `/` filter and clamping the selection.
+    fn refresh_history_grid(&mut self) {
+        let Some(grid) = self.history_grid.as_mut() else {
+            return;
+        };
+        let session_only = grid.session_only;
+        match WorkspaceStore::open_existing(&grid.root, LatticeConfig::default()) {
+            Ok(Some(store)) => match Self::query_history(&store, session_only) {
                 Ok(rows) => {
-                    let mut lines = vec![format!(
-                        "{:<6} {:<6} {:<7} {}",
-                        "STATUS", "MS", "METHOD", "REQUEST"
-                    )];
-                    if rows.is_empty() {
-                        lines.push("(no runs)".to_string());
-                    }
-                    for row in rows {
-                        let status = row
-                            .status
-                            .map(|code| code.to_string())
-                            .unwrap_or_else(|| "ERR".to_string());
-                        let ms = row
-                            .duration_ms
-                            .map(|value| value.to_string())
-                            .unwrap_or_else(|| "-".to_string());
-                        lines.push(format!(
-                            "{status:<6} {ms:<6} {:<7} {}",
-                            row.method, row.request_path
-                        ));
-                    }
-                    self.open_data_overlay(" history ", lines);
+                    let grid = self.history_grid.as_mut().expect("grid");
+                    grid.rows = rows;
+                    grid.clamp_selection();
                 }
                 Err(error) => {
                     self.status = RunStatus::Failed(format!("history: {error}"));
                 }
             },
+            Ok(None) => {
+                self.history_grid = None;
+                self.status = RunStatus::Failed("history: store went away".to_string());
+            }
+            Err(error) => {
+                self.status = RunStatus::Failed(format!("history: {error}"));
+            }
         }
+    }
+
+    /// Normal-mode keys while the `:history` grid is open. Esc closes the
+    /// grid (or exits the `/` input); it never quits the app.
+    fn handle_history_key(&mut self, code: KeyCode) -> Result<bool, TuiError> {
+        // Phase 1: the `/` filter input captures everything printable.
+        {
+            let grid = self.history_grid.as_mut().expect("grid");
+            if grid.filtering {
+                match code {
+                    KeyCode::Esc => {
+                        grid.filtering = false;
+                        grid.filter.clear();
+                        grid.clamp_selection();
+                    }
+                    KeyCode::Enter => {
+                        grid.filtering = false;
+                    }
+                    KeyCode::Backspace => {
+                        grid.filter.pop();
+                        grid.selected = 0;
+                    }
+                    KeyCode::Char(ch) if !ch.is_control() => {
+                        grid.filter.push(ch);
+                        grid.selected = 0;
+                    }
+                    _ => {}
+                }
+                return Ok(true);
+            }
+        }
+
+        // Phase 2: the `gg` chord. A non-`g` second key ends the chord and
+        // falls through to be handled on its own, mirroring the tree.
+        {
+            let grid = self.history_grid.as_mut().expect("grid");
+            if grid.g_pending {
+                grid.g_pending = false;
+                match code {
+                    KeyCode::Char('g') => {
+                        grid.selected = 0;
+                        grid.notice = None;
+                        return Ok(true);
+                    }
+                    KeyCode::Char('G') => {
+                        let len = grid.visible_indices().len();
+                        grid.selected = len.saturating_sub(1);
+                        grid.notice = None;
+                        return Ok(true);
+                    }
+                    KeyCode::Esc => return Ok(true),
+                    _ => {}
+                }
+            }
+        }
+
+        // Phase 3: decide the action against the grid, then act on `self`
+        // (hydrate and yank need the store / stdout, not the grid borrow).
+        enum Action {
+            Close,
+            Move(isize),
+            First,
+            Last,
+            Filter,
+            ToggleSession,
+            YankId(String),
+            YankBodyHash(Option<String>),
+            Hydrate(String),
+            Ignored,
+        }
+        let action = {
+            let grid = self.history_grid.as_mut().expect("grid");
+            match code {
+                KeyCode::Esc | KeyCode::Char('q') => Action::Close,
+                KeyCode::Char('j') | KeyCode::Down => Action::Move(1),
+                KeyCode::Char('k') | KeyCode::Up => Action::Move(-1),
+                KeyCode::Home => Action::First,
+                KeyCode::End => Action::Last,
+                KeyCode::Char('g') => {
+                    grid.g_pending = true;
+                    Action::Ignored
+                }
+                KeyCode::Char('G') => Action::Last,
+                KeyCode::Char('/') => Action::Filter,
+                KeyCode::Char('s') => Action::ToggleSession,
+                KeyCode::Char('y') => grid
+                    .selected_row()
+                    .map(|row| Action::YankId(row.id.clone()))
+                    .unwrap_or(Action::Ignored),
+                KeyCode::Char('Y') => grid
+                    .selected_row()
+                    .map(|row| Action::YankBodyHash(row.res_body.hash.clone()))
+                    .unwrap_or(Action::Ignored),
+                KeyCode::Enter => grid
+                    .selected_row()
+                    .map(|row| Action::Hydrate(row.id.clone()))
+                    .unwrap_or(Action::Ignored),
+                _ => Action::Ignored,
+            }
+        };
+
+        match action {
+            Action::Close => {
+                self.history_grid = None;
+            }
+            Action::Move(delta) => {
+                self.history_grid
+                    .as_mut()
+                    .expect("grid")
+                    .move_selection(delta);
+            }
+            Action::First => {
+                let grid = self.history_grid.as_mut().expect("grid");
+                grid.selected = 0;
+                grid.notice = None;
+            }
+            Action::Last => {
+                let grid = self.history_grid.as_mut().expect("grid");
+                let len = grid.visible_indices().len();
+                grid.selected = len.saturating_sub(1);
+                grid.notice = None;
+            }
+            Action::Filter => {
+                self.history_grid.as_mut().expect("grid").filtering = true;
+            }
+            Action::ToggleSession => {
+                if facet_record::session_from_env().is_some() {
+                    let grid = self.history_grid.as_mut().expect("grid");
+                    grid.session_only = !grid.session_only;
+                    grid.selected = 0;
+                    self.refresh_history_grid();
+                } else {
+                    let grid = self.history_grid.as_mut().expect("grid");
+                    grid.notice = Some("FACET_SESSION not set".to_string());
+                }
+            }
+            Action::YankId(id) => {
+                osc52_yank(&id);
+                let grid = self.history_grid.as_mut().expect("grid");
+                grid.notice = Some(format!("yanked {id}"));
+            }
+            Action::YankBodyHash(hash) => {
+                let grid = self.history_grid.as_mut().expect("grid");
+                match hash {
+                    Some(hash) => {
+                        osc52_yank(&hash);
+                        grid.notice =
+                            Some(format!("yanked body hash {}", &hash[..8.min(hash.len())]));
+                    }
+                    None => {
+                        grid.notice = Some("no response body hash on this run".to_string());
+                    }
+                }
+            }
+            Action::Hydrate(id) => self.hydrate_from_history(&id),
+            Action::Ignored => {}
+        }
+        Ok(true)
+    }
+
+    /// Enter on a grid row: load the run and its stored response body from
+    /// Lattice into the response pane, then close the grid so the replayed
+    /// view is visible. The pane title names the run.
+    fn hydrate_from_history(&mut self, run_id: &str) {
+        let Some(grid) = self.history_grid.as_ref() else {
+            return;
+        };
+        let root = grid.root.clone();
+        let store = match WorkspaceStore::open_existing(&root, LatticeConfig::default()) {
+            Ok(Some(store)) => store,
+            Ok(None) => {
+                self.history_grid = None;
+                self.status = RunStatus::Failed("history: store went away".to_string());
+                return;
+            }
+            Err(error) => {
+                self.status = RunStatus::Failed(format!("history: {error}"));
+                return;
+            }
+        };
+        let row = match store.run(run_id) {
+            Ok(Some(row)) => row,
+            Ok(None) => {
+                let grid = self.history_grid.as_mut().expect("grid");
+                grid.notice = Some(format!("run {run_id} not found"));
+                return;
+            }
+            Err(error) => {
+                self.status = RunStatus::Failed(format!("history: {error}"));
+                return;
+            }
+        };
+        let body = hydrated_body(&store, &row);
+        let status = row
+            .status
+            .and_then(|code| u16::try_from(code).ok())
+            .unwrap_or(0);
+        let reason = match row.status {
+            Some(_) => reason_phrase(status).to_string(),
+            // Transport failures have no status; the error text is the reason.
+            None => row.error.clone().unwrap_or_default(),
+        };
+        let view = ResponseView {
+            status,
+            reason,
+            url: row.url.clone(),
+            duration: Duration::from_millis(
+                row.duration_ms
+                    .and_then(|ms| u64::try_from(ms).ok())
+                    .unwrap_or(0),
+            ),
+            headers: parse_stored_headers(row.res_headers.as_deref()),
+            body_len: row
+                .res_body
+                .len
+                .and_then(|len| usize::try_from(len).ok())
+                .unwrap_or(body.len()),
+            body,
+        };
+        self.response = Some(view);
+        self.response_origin = Some(format!("run {} · replayed view", row.id));
+        self.response_scroll = 0;
+        self.response_tab = ResponseTab::Pretty;
+        self.history_grid = None;
+        self.focus = Focus::Response;
     }
 
     fn show_sql(&mut self, sql: &str) {
@@ -1579,6 +1922,7 @@ impl App {
         self.pending = Some(receiver);
         self.status = RunStatus::Running;
         self.response = None;
+        self.response_origin = None;
         self.response_scroll = 0;
         self.last_recording = None;
 
@@ -1652,6 +1996,7 @@ impl App {
                     status: view.status,
                     duration: view.duration,
                 };
+                self.response_origin = None;
                 self.response = Some(view);
             }
             RunResult::Err(message) => {
@@ -1694,9 +2039,28 @@ impl App {
         self.help_open
     }
 
-    /// `:history` / `:sql` overlay, if open.
+    /// `:sql` overlay, if open.
     pub fn data_overlay(&self) -> Option<&(String, Vec<String>)> {
         self.data_overlay.as_ref()
+    }
+
+    /// `:history` grid, if open.
+    pub fn history_grid(&self) -> Option<&HistoryGrid> {
+        self.history_grid.as_ref()
+    }
+
+    /// Pane title override when the response is a hydrated Lattice run.
+    pub fn response_origin(&self) -> Option<&str> {
+        self.response_origin.as_deref()
+    }
+
+    /// Opens a history grid over canned rows for headless harnesses.
+    /// Not part of the product API.
+    #[doc(hidden)]
+    pub fn preview_history_grid(&mut self, rows: Vec<RunRow>) {
+        self.help_open = false;
+        self.data_overlay = None;
+        self.history_grid = Some(HistoryGrid::new(PathBuf::from("."), rows));
     }
 
     /// Opens a data overlay for headless harnesses. Not part of the product API.
@@ -1857,6 +2221,111 @@ impl App {
             .collect::<Vec<_>>()
             .join(" › ")
     }
+}
+
+/// Stored response body for the replayed view: inline bytes or the blob,
+/// capped at 16 MiB; over that the pane says `blob <hash> · omitted`.
+fn hydrated_body(store: &WorkspaceStore, row: &RunRow) -> String {
+    if row.res_body.len.is_some_and(|len| len > HYDRATE_BODY_CAP) {
+        let hash = row.res_body.hash.as_deref().unwrap_or("?");
+        return format!("blob {hash} · omitted");
+    }
+    match store.response_body(row) {
+        Ok(Some(bytes)) => String::from_utf8_lossy(&bytes).into_owned(),
+        Ok(None) => match &row.res_body.hash {
+            Some(hash) => format!("blob {hash} · not in store"),
+            None => String::new(),
+        },
+        Err(error) => format!("body unreadable: {error}"),
+    }
+}
+
+/// Stored response headers are a JSON array of `{"name", "value"}`.
+fn parse_stored_headers(json: Option<&str>) -> Vec<(String, String)> {
+    let Some(json) = json else {
+        return Vec::new();
+    };
+    let Ok(items) = serde_json::from_str::<Vec<serde_json::Value>>(json) else {
+        return Vec::new();
+    };
+    items
+        .iter()
+        .filter_map(|item| {
+            Some((
+                item.get("name")?.as_str()?.to_string(),
+                item.get("value")?.as_str()?.to_string(),
+            ))
+        })
+        .collect()
+}
+
+/// Canonical reason phrase for the codes a replayed view is likely to
+/// show. Lattice stores the status, not the phrase; unknown codes render
+/// as the bare number.
+fn reason_phrase(status: u16) -> &'static str {
+    match status {
+        200 => "OK",
+        201 => "Created",
+        202 => "Accepted",
+        204 => "No Content",
+        301 => "Moved Permanently",
+        302 => "Found",
+        304 => "Not Modified",
+        307 => "Temporary Redirect",
+        308 => "Permanent Redirect",
+        400 => "Bad Request",
+        401 => "Unauthorized",
+        403 => "Forbidden",
+        404 => "Not Found",
+        405 => "Method Not Allowed",
+        409 => "Conflict",
+        422 => "Unprocessable Content",
+        429 => "Too Many Requests",
+        500 => "Internal Server Error",
+        502 => "Bad Gateway",
+        503 => "Service Unavailable",
+        504 => "Gateway Timeout",
+        _ => "",
+    }
+}
+
+/// Yanks text to the system clipboard via OSC 52 — no clipboard crate.
+/// Terminals that ignore OSC 52 just swallow the sequence.
+fn osc52_yank(text: &str) {
+    use base64::Engine as _;
+    use std::io::Write as _;
+    let encoded = base64::engine::general_purpose::STANDARD.encode(text.as_bytes());
+    let mut out = std::io::stdout();
+    let _ = out.write_all(format!("\x1b]52;c;{encoded}\x07").as_bytes());
+    let _ = out.flush();
+}
+
+/// `MM-DD HH:MM` UTC for the grid's STARTED column.
+pub(crate) fn format_started(unix_ms: i64) -> String {
+    let seconds = unix_ms.div_euclid(1000);
+    let days = seconds.div_euclid(86_400);
+    let day_seconds = seconds.rem_euclid(86_400);
+    let (_, month, day) = civil_from_days(days);
+    format!(
+        "{month:02}-{day:02} {:02}:{:02}",
+        day_seconds / 3600,
+        (day_seconds % 3600) / 60,
+    )
+}
+
+/// Howard Hinnant's days-from-civil inverse; same math the CLI's
+/// `format_utc` uses, duplicated so the TUI takes no date dependency.
+fn civil_from_days(days: i64) -> (i64, u32, u32) {
+    let z = days + 719_468;
+    let era = z.div_euclid(146_097);
+    let doe = z.rem_euclid(146_097);
+    let yoe = (doe - doe / 1460 + doe / 36_524 - doe / 146_096) / 365;
+    let year = yoe + era * 400;
+    let doy = doe - (365 * yoe + yoe / 4 - yoe / 100);
+    let mp = (5 * doy + 2) / 153;
+    let day = (doy - (153 * mp + 2) / 5 + 1) as u32;
+    let month = if mp < 10 { mp + 3 } else { mp - 9 } as u32;
+    (if month <= 2 { year + 1 } else { year }, month, day)
 }
 
 fn sql_value_human(value: &SqlValue) -> String {
@@ -2414,8 +2883,9 @@ mod tests {
         );
     }
 
-    #[tokio::test]
-    async fn history_and_sql_read_an_existing_store() {
+    /// Temp collection dir with a Lattice store holding two runs; the
+    /// first has an inline response body for the hydrate path.
+    async fn app_with_store() -> (std::path::PathBuf, App) {
         let dir = std::env::temp_dir().join(format!(
             "facet-tui-s2-{}-{}",
             std::process::id(),
@@ -2437,23 +2907,227 @@ mod tests {
                 method: "GET",
                 url: "https://example.com/pets",
                 status: Some(200),
+                res_headers: Some(r#"[{"name":"content-type","value":"application/json"}]"#),
+                res_body: lattice::BodyInput::Bytes(b"{\"pets\":[]}"),
+                res_content_type: Some("application/json"),
                 actor: "human",
                 ..Default::default()
             })
             .unwrap();
+        store
+            .record_run(&lattice::NewRun {
+                started_at: lattice::now_ms() + 1,
+                duration_ms: Some(40),
+                request_path: "Pets/Create pet",
+                request_hash: "def",
+                method: "POST",
+                url: "https://example.com/pets",
+                status: Some(500),
+                actor: "claude.halo-fullstack",
+                ..Default::default()
+            })
+            .unwrap();
         drop(store);
+        let app = App::load(Some(&yaml)).await;
+        (dir, app)
+    }
 
-        let mut app = App::load(Some(&yaml)).await;
+    #[tokio::test]
+    async fn history_opens_a_grid_with_run_ids() {
+        let (dir, mut app) = app_with_store().await;
         assert!(app.lattice_ready());
         app.command = "history".to_string();
         app.execute_command().await.unwrap();
-        let (_, lines) = app.data_overlay().expect("history overlay");
-        assert!(
-            lines.iter().any(|line| line.contains("Pets/List pets")),
-            "{lines:?}"
-        );
-        assert!(lines.iter().any(|line| line.contains("200")), "{lines:?}");
+        assert!(app.data_overlay().is_none(), "grid replaced the dump");
+        let grid = app.history_grid().expect("history grid");
+        assert_eq!(grid.rows.len(), 2);
+        // Newest first: the POST 500 is row zero.
+        let row = grid.selected_row().expect("row");
+        assert_eq!(row.request_path, "Pets/Create pet");
+        assert!(!row.id.is_empty(), "run id visible");
 
+        // j/k move, gg/G jump, Esc closes without quitting.
+        app.handle_key(KeyCode::Char('j'), KeyModifiers::NONE)
+            .await
+            .unwrap();
+        assert_eq!(
+            app.history_grid()
+                .unwrap()
+                .selected_row()
+                .unwrap()
+                .request_path,
+            "Pets/List pets"
+        );
+        app.handle_key(KeyCode::Char('k'), KeyModifiers::NONE)
+            .await
+            .unwrap();
+        app.handle_key(KeyCode::Char('G'), KeyModifiers::NONE)
+            .await
+            .unwrap();
+        assert_eq!(
+            app.history_grid()
+                .unwrap()
+                .selected_row()
+                .unwrap()
+                .request_path,
+            "Pets/List pets"
+        );
+        app.handle_key(KeyCode::Char('g'), KeyModifiers::NONE)
+            .await
+            .unwrap();
+        app.handle_key(KeyCode::Char('g'), KeyModifiers::NONE)
+            .await
+            .unwrap();
+        assert_eq!(
+            app.history_grid()
+                .unwrap()
+                .selected_row()
+                .unwrap()
+                .request_path,
+            "Pets/Create pet"
+        );
+        app.handle_key(KeyCode::Esc, KeyModifiers::NONE)
+            .await
+            .unwrap();
+        assert!(app.history_grid().is_none());
+        assert!(!app.should_quit);
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[tokio::test]
+    async fn history_enter_hydrates_the_response_pane() {
+        let (dir, mut app) = app_with_store().await;
+        app.command = "history".to_string();
+        app.execute_command().await.unwrap();
+        // Move to the 200 run with the inline body and hydrate it.
+        app.handle_key(KeyCode::Char('j'), KeyModifiers::NONE)
+            .await
+            .unwrap();
+        app.handle_key(KeyCode::Enter, KeyModifiers::NONE)
+            .await
+            .unwrap();
+
+        assert!(app.history_grid().is_none(), "hydrate closes the grid");
+        assert_eq!(app.focus(), Focus::Response);
+        let response = app.response().expect("hydrated response");
+        assert_eq!(response.status, 200);
+        assert_eq!(response.reason, "OK");
+        assert_eq!(response.url, "https://example.com/pets");
+        assert_eq!(response.body, "{\"pets\":[]}");
+        assert_eq!(
+            response.headers,
+            vec![("content-type".to_string(), "application/json".to_string())]
+        );
+        let origin = app.response_origin().expect("replayed title");
+        assert!(origin.starts_with("run 01"), "{origin}");
+        assert!(origin.ends_with("· replayed view"), "{origin}");
+
+        // A live send result supersedes the replayed view's title.
+        app.apply_run_result(RunResult::Ok(ResponseView {
+            status: 200,
+            reason: "OK".to_string(),
+            url: "https://example.com/pets".to_string(),
+            duration: Duration::from_millis(3),
+            headers: Vec::new(),
+            body: "{}".to_string(),
+            body_len: 2,
+        }));
+        assert!(app.response_origin().is_none());
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[tokio::test]
+    async fn history_y_yanks_the_run_id() {
+        let (dir, mut app) = app_with_store().await;
+        app.command = "history".to_string();
+        app.execute_command().await.unwrap();
+        let id = app
+            .history_grid()
+            .unwrap()
+            .selected_row()
+            .unwrap()
+            .id
+            .clone();
+        app.handle_key(KeyCode::Char('y'), KeyModifiers::NONE)
+            .await
+            .unwrap();
+        let grid = app.history_grid().expect("grid still open");
+        assert_eq!(
+            grid.notice.as_deref(),
+            Some(format!("yanked {id}").as_str())
+        );
+
+        // Y on a run without a blob body says so instead of yanking.
+        app.handle_key(KeyCode::Char('Y'), KeyModifiers::NONE)
+            .await
+            .unwrap();
+        let grid = app.history_grid().unwrap();
+        assert!(
+            grid.notice
+                .as_deref()
+                .is_some_and(|note| note.contains("no response body hash")),
+            "{:?}",
+            grid.notice
+        );
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[tokio::test]
+    async fn history_slash_filters_by_selector() {
+        let (dir, mut app) = app_with_store().await;
+        app.command = "history".to_string();
+        app.execute_command().await.unwrap();
+        app.handle_key(KeyCode::Char('/'), KeyModifiers::NONE)
+            .await
+            .unwrap();
+        for ch in "create".chars() {
+            app.handle_key(KeyCode::Char(ch), KeyModifiers::NONE)
+                .await
+                .unwrap();
+        }
+        app.handle_key(KeyCode::Enter, KeyModifiers::NONE)
+            .await
+            .unwrap();
+        let grid = app.history_grid().unwrap();
+        assert_eq!(grid.visible_indices().len(), 1);
+        assert_eq!(grid.selected_row().unwrap().request_path, "Pets/Create pet");
+        // Esc while not filtering closes the grid.
+        app.handle_key(KeyCode::Esc, KeyModifiers::NONE)
+            .await
+            .unwrap();
+        assert!(app.history_grid().is_none());
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[tokio::test]
+    async fn history_session_toggle_needs_facet_session() {
+        let (dir, mut app) = app_with_store().await;
+        app.command = "history".to_string();
+        app.execute_command().await.unwrap();
+        // The test harness scrubs FACET_SESSION, so `s` explains itself.
+        if facet_record::session_from_env().is_none() {
+            app.handle_key(KeyCode::Char('s'), KeyModifiers::NONE)
+                .await
+                .unwrap();
+            let grid = app.history_grid().unwrap();
+            assert_eq!(
+                grid.notice.as_deref(),
+                Some("FACET_SESSION not set"),
+                "{:?}",
+                grid.notice
+            );
+            assert!(!grid.session_only);
+        }
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[tokio::test]
+    async fn sql_reads_an_existing_store() {
+        let (dir, mut app) = app_with_store().await;
         app.command = "sql SELECT status, method, request_path FROM runs".to_string();
         app.execute_command().await.unwrap();
         let (_, lines) = app.data_overlay().expect("sql overlay");

--- a/crates/facet-tui/src/app.rs
+++ b/crates/facet-tui/src/app.rs
@@ -513,9 +513,12 @@ impl RecordSummary {
     }
 }
 
-/// Bodies over this size are not pulled into the response pane on hydrate;
-/// the grid shows `blob <hash> · omitted` instead (same cap as the CLI).
-const HYDRATE_BODY_CAP: u64 = 16 * 1024 * 1024;
+/// Bodies over the engine's in-memory cap are not pulled into the response
+/// pane on hydrate; the grid shows `blob <hash> · omitted` instead (same
+/// cap as the CLI's `--bodies` path).
+fn hydrate_body_cap() -> u64 {
+    u64::try_from(probe_http::MAX_IN_MEMORY_RESPONSE_BYTES).unwrap_or(u64::MAX)
+}
 
 /// `:history` grid state (Goal 2). A navigable table of Lattice runs —
 /// not a text dump. Keys live in Normal mode inside the overlay:
@@ -2226,7 +2229,7 @@ impl App {
 /// Stored response body for the replayed view: inline bytes or the blob,
 /// capped at 16 MiB; over that the pane says `blob <hash> · omitted`.
 fn hydrated_body(store: &WorkspaceStore, row: &RunRow) -> String {
-    if row.res_body.len.is_some_and(|len| len > HYDRATE_BODY_CAP) {
+    if row.res_body.len.is_some_and(|len| len > hydrate_body_cap()) {
         let hash = row.res_body.hash.as_deref().unwrap_or("?");
         return format!("blob {hash} · omitted");
     }

--- a/crates/facet-tui/src/ui.rs
+++ b/crates/facet-tui/src/ui.rs
@@ -50,6 +50,9 @@ pub fn draw(frame: &mut Frame, app: &App) {
     if app.help_open() {
         render_help_overlay(frame, shell[1], styles);
     }
+    if app.history_grid().is_some() {
+        render_history_grid(frame, shell[1], app, styles);
+    }
     if let Some((title, lines)) = app.data_overlay() {
         render_data_overlay(frame, shell[1], title, lines, styles);
     }
@@ -715,7 +718,9 @@ fn render_response_pane(frame: &mut Frame, area: Rect, app: &App, styles: Styles
         styles.muted
     };
     let lines: Vec<Line> = match app.response() {
-        Some(response) => response_lines(response, app, styles, header_style),
+        Some(response) => {
+            response_lines(response, app, styles, header_style, app.response_origin())
+        }
         None => match app.status() {
             RunStatus::Running => vec![Line::from(Span::styled(
                 "  Sending… / waiting for the server",
@@ -745,12 +750,16 @@ fn response_lines<'a>(
     app: &'a App,
     styles: Styles,
     header_style: ratatui::style::Style,
+    origin: Option<&'a str>,
 ) -> Vec<Line<'a>> {
     let palette = app.theme().palette();
     let status_color = palette.response_status(response.status);
     let mut lines = Vec::new();
+    // A hydrated run names itself (`run 01K… · replayed view`); a live
+    // send keeps the plain label.
+    let label = origin.unwrap_or("Response");
     lines.push(Line::from(vec![
-        Span::styled("  Response  ", header_style),
+        Span::styled(format!("  {label}  "), header_style),
         Span::styled(
             format!("{} {}", response.status, response.reason),
             styles.base.fg(status_color),
@@ -857,6 +866,8 @@ fn render_footer(frame: &mut Frame, area: Rect, app: &App, styles: Styles) {
         "insert · Esc normal · Enter save".to_string()
     } else if app.help_open() {
         "help · Esc close".to_string()
+    } else if app.history_grid().is_some() {
+        "history · Enter hydrate · y yank · / filter · Esc close".to_string()
     } else if app.data_overlay().is_some() {
         "overlay · Esc close".to_string()
     } else if app.searching() {
@@ -1005,7 +1016,7 @@ fn render_running_overlay(frame: &mut Frame, area: Rect, styles: Styles) {
 /// actions in editor text. This is option A's discoverability device —
 /// one overlay, no which-key.
 fn render_help_overlay(frame: &mut Frame, area: Rect, styles: Styles) {
-    const KEYS: [(&str, &str); 15] = [
+    const KEYS: [(&str, &str); 16] = [
         ("j/k · arrows", "move (tree, rows, response scroll)"),
         ("gg / G", "first / last row (tree, request, response)"),
         ("Enter", "folder toggle · open · send · :send"),
@@ -1019,6 +1030,10 @@ fn render_help_overlay(frame: &mut Frame, area: Rect, styles: Styles) {
         ("Ctrl-W h/j/k/l", "focus pane · Ctrl-W w cycles"),
         ("Ctrl-S", "save to disk · :w"),
         (":", "command line (:w :q :send :theme :history :sql)"),
+        (
+            ":history grid",
+            "j/k · Enter hydrate · y yank id · / filter",
+        ),
         ("?", "this help · :help"),
         ("q", "quit · Esc cancels run/overlay"),
     ];
@@ -1044,6 +1059,194 @@ fn render_help_overlay(frame: &mut Frame, area: Rect, styles: Styles) {
         styles.muted,
     )));
     frame.render_widget(Paragraph::new(lines).block(block), overlay);
+}
+
+/// Fixed-width cell: exact fits pass through, longer text truncates from
+/// the right with `…`, shorter text space-pads.
+fn cell(text: &str, width: usize) -> String {
+    let text_width = UnicodeWidthStr::width(text);
+    if text_width == width {
+        return text.to_string();
+    }
+    let mut out = String::new();
+    let mut used = 0;
+    if text_width < width {
+        out.push_str(text);
+        used = text_width;
+    } else {
+        for ch in text.chars() {
+            let ch_width = unicode_width::UnicodeWidthChar::width(ch).unwrap_or(0);
+            if used + ch_width > width.saturating_sub(1) {
+                break;
+            }
+            out.push(ch);
+            used += ch_width;
+        }
+        out.push('…');
+        used += 1;
+    }
+    while used < width {
+        out.push(' ');
+        used += 1;
+    }
+    out
+}
+
+/// `:history` grid (Goal 2): one row per Lattice run, run id visible.
+/// Column order is fixed — `STARTED STATUS MS METHOD REQUEST ACTOR ID` —
+/// with REQUEST taking the slack. The focused row's full ULID is on the
+/// overlay footer so `y` is discoverable.
+#[allow(clippy::too_many_lines)]
+fn render_history_grid(frame: &mut Frame, area: Rect, app: &App, styles: Styles) {
+    use crate::app::format_started;
+
+    let Some(grid) = app.history_grid() else {
+        return;
+    };
+    let palette = app.theme().palette();
+    let visible = grid.visible_indices();
+
+    const STARTED_W: usize = 11; // "MM-DD HH:MM"
+    const STATUS_W: usize = 6;
+    const MS_W: usize = 6;
+    const METHOD_W: usize = 7;
+    const ACTOR_W: usize = 12;
+    const ID_W: usize = 8;
+    const REQUEST_MIN: usize = 12;
+    // 1 leading pad + 6 single-space separators + 1 trailing pad.
+    const CHROME: usize = 1 + 6 + 1;
+    let fixed = STARTED_W + STATUS_W + MS_W + METHOD_W + ACTOR_W + ID_W + CHROME + REQUEST_MIN;
+    let width = ((fixed + 12) as u16).clamp(64, 110).min(area.width);
+    let height = (visible.len().max(1) as u16 + 4)
+        .min(area.height.saturating_sub(2))
+        .max(5);
+    let overlay = centered(area, width, height);
+    frame.render_widget(Clear, overlay);
+
+    let mut title = " history ".to_string();
+    if grid.session_only {
+        title = " history · this session ".to_string();
+    }
+    if !grid.filter.is_empty() {
+        title = format!("{}· /{} ", title.trim_end(), grid.filter);
+    }
+    let block = Block::default()
+        .borders(Borders::ALL)
+        .border_style(styles.border)
+        .style(styles.editor)
+        .title(Span::styled(title, styles.brand));
+    let inner = block.inner(overlay);
+    frame.render_widget(block, overlay);
+    if inner.height < 2 {
+        return;
+    }
+
+    let request_w = (inner.width as usize).saturating_sub(fixed - REQUEST_MIN);
+    let header = Line::from(Span::styled(
+        format!(
+            " {} {} {} {} {} {} {}",
+            cell("STARTED", STARTED_W),
+            cell("STATUS", STATUS_W),
+            cell("MS", MS_W),
+            cell("METHOD", METHOD_W),
+            cell("REQUEST", request_w),
+            cell("ACTOR", ACTOR_W),
+            cell("ID", ID_W),
+        ),
+        styles.muted,
+    ));
+
+    let body_height = inner.height.saturating_sub(2) as usize; // header + footer
+    let offset = if grid.selected >= body_height {
+        grid.selected + 1 - body_height
+    } else {
+        0
+    };
+    let mut lines = vec![header];
+    if visible.is_empty() {
+        let empty = if grid.filter.is_empty() {
+            " (no runs)"
+        } else {
+            " (no runs match the filter)"
+        };
+        lines.push(Line::from(Span::styled(empty, styles.placeholder)));
+    }
+    for (row_index, &run_index) in visible.iter().enumerate().skip(offset).take(body_height) {
+        let row = &grid.rows[run_index];
+        let selected = row_index == grid.selected;
+        let status_text = row
+            .status
+            .map(|code| code.to_string())
+            .unwrap_or_else(|| "ERR".to_string());
+        let ms = row
+            .duration_ms
+            .map(|value| format!("{value:>6}"))
+            .unwrap_or_else(|| "     -".to_string());
+        let id8: String = row.id.chars().take(ID_W).collect();
+        if selected {
+            lines.push(Line::from(Span::styled(
+                format!(
+                    " {} {} {} {} {} {} {}",
+                    cell(&format_started(row.started_at), STARTED_W),
+                    cell(&status_text, STATUS_W),
+                    ms,
+                    cell(&row.method, METHOD_W),
+                    cell(&row.request_path, request_w),
+                    cell(&row.actor, ACTOR_W),
+                    cell(&id8, ID_W),
+                ),
+                styles.selected_row,
+            )));
+        } else {
+            let status_style = match row.status {
+                Some(code) => styles
+                    .base
+                    .fg(palette.response_status(u16::try_from(code).unwrap_or(0))),
+                None => styles.status_error,
+            };
+            lines.push(Line::from(vec![
+                Span::styled(
+                    format!(" {}", cell(&format_started(row.started_at), STARTED_W)),
+                    styles.editor,
+                ),
+                Span::styled(format!(" {}", cell(&status_text, STATUS_W)), status_style),
+                Span::styled(format!(" {ms} "), styles.editor),
+                Span::styled(cell(&row.method, METHOD_W), styles.editor),
+                Span::styled(
+                    format!(" {}", cell(&row.request_path, request_w)),
+                    styles.editor,
+                ),
+                Span::styled(format!(" {}", cell(&row.actor, ACTOR_W)), styles.editor),
+                Span::styled(format!(" {}", cell(&id8, ID_W)), styles.muted),
+            ]));
+        }
+    }
+
+    // Footer: the `/` input while filtering, else the notice, else the
+    // focused run's full ULID so `y` is discoverable.
+    let footer = if grid.filtering {
+        format!(" /{}▌", grid.filter)
+    } else if let Some(notice) = &grid.notice {
+        format!(" {notice}")
+    } else {
+        match grid.selected_row() {
+            Some(row) => format!(" {} · Enter hydrate · y yank · Esc close", row.id),
+            None => " Esc close".to_string(),
+        }
+    };
+    lines.push(Line::from(Span::styled(
+        cell(&footer, inner.width as usize),
+        styles.muted,
+    )));
+
+    let drawn_height = (lines.len() as u16).min(inner.height);
+    frame.render_widget(
+        Paragraph::new(lines).style(styles.editor),
+        Rect {
+            height: drawn_height,
+            ..inner
+        },
+    );
 }
 
 fn render_data_overlay(
@@ -1311,25 +1514,47 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn history_overlay_renders_rows() {
+    async fn history_grid_renders_rows_with_run_ids() {
         let mut app = App::load(Some(&fixture())).await;
         app.apply_theme(Theme::new(Appearance::Dark).with_depth(Depth::Truecolor));
-        app.preview_data_overlay(
-            " history ",
-            vec![
-                "STATUS  MS     METHOD  REQUEST".to_string(),
-                "200     12     GET     Pets/List pets".to_string(),
-            ],
-        );
+        app.preview_history_grid(vec![lattice::RunRow {
+            id: "01ARZ3NDEKTSV4RRFFQ69G5FAV".to_string(),
+            started_at: 1_757_250_000_123,
+            duration_ms: Some(12),
+            request_path: "Pets/List pets".to_string(),
+            request_hash: "9f86d081".to_string(),
+            environment: None,
+            method: "GET".to_string(),
+            url: "https://example.com/pets".to_string(),
+            status: Some(200),
+            error: None,
+            req_headers: None,
+            res_headers: None,
+            req_body: lattice::BodyRef::default(),
+            res_body: lattice::BodyRef::default(),
+            res_content_type: None,
+            session_id: None,
+            actor: "claude.halo-fullstack".to_string(),
+            tags: None,
+        }]);
         let backend = TestBackend::new(120, 32);
         let mut terminal = Terminal::new(backend).expect("backend");
         app.render_to(&mut terminal).expect("render");
         let text = dump(terminal.backend().buffer());
         assert!(text.contains("history"), "title: {text}");
+        assert!(text.contains("STARTED"), "header: {text}");
+        assert!(text.contains("STATUS"), "{text}");
         assert!(text.contains("Pets/List pets"), "{text}");
+        // The grid shows the id fragment in-row and the full ULID on the
+        // overlay footer so `y` is discoverable.
+        assert!(text.contains("01ARZ3ND"), "id fragment: {text}");
         assert!(
-            text.contains("overlay · Esc close") || text.contains("Esc close"),
-            "{text}"
+            text.contains("01ARZ3NDEKTSV4RRFFQ69G5FAV · Enter hydrate"),
+            "footer id: {text}"
+        );
+        assert!(
+            text.contains("history · Enter hydrate · y yank"),
+            "footer hints: {text}"
         );
     }
 

--- a/docs/FACET.md
+++ b/docs/FACET.md
@@ -255,9 +255,13 @@ facet tui [<path>] [--appearance graphite|porcelain]
 ```
 
 Graphite Honey is the TUI default. `:theme` (bare) toggles Porcelain Honey;
-`:theme graphite|porcelain` sets one. `:history` and `:sql <query>` open
-Lattice overlays. `gg` / `G` jump to the first / last row of the focused
-pane. `?` lists the rest.
+`:theme graphite|porcelain` sets one. `:history` opens the run grid
+(`STARTED STATUS MS METHOD REQUEST ACTOR ID`): `j`/`k` or arrows move,
+`gg`/`G` jump, Enter hydrates the response pane from Lattice (titled
+`run <id> · replayed view`), `y` yanks the run id and `Y` the response
+body hash (OSC 52), `/` filters by selector, `s` toggles runs from
+`$FACET_SESSION` only, Esc closes. `:sql <query>` opens a read-only
+overlay. `?` lists the rest.
 
 Roadmap (Probe's public list, folded): HTTP live; next WebSocket, GraphQL,
 gRPC streaming, user-defined theme files, git integration. Secret storage


### PR DESCRIPTION
## Goal 2 — TUI history grid (deep-dive §1.8, commit 2)

`:history` is now a grid, not a dump. Lead: frontend. Branched off `main` at eb80c9c (PR #8).

### What ships
- **Grid**: `STARTED STATUS MS METHOD REQUEST ACTOR ID(8)`, fixed column order, REQUEST takes the slack, status cell uses the existing `response_status` color. Full ULID of the focused row on the overlay footer so `y` is discoverable.
- **Enter hydrates** the response pane from Lattice (`WorkspaceStore::run` + `response_body`): inline body or blob bytes under 16 MiB, else `blob <hash> · omitted`. Pane title: `run 01K… · replayed view`. Grid closes and focus moves to Response.
- **`y`** yanks the run id, **`Y`** the response body hash — OSC 52, no clipboard crate. Footer notice confirms (`yanked 01K…`).
- **vim-modal + flat fallback**: `j`/`k` + arrows, `gg`/`G` + Home/End, `/` filters by selector substring, `s` toggles `$FACET_SESSION`-only runs (title shows it). Esc/`q` closes; Esc never quits. No B/C.
- Store is reopened per hydrate — no SQLite handle lives across the UI loop.

### Not in this PR
- Sparkline (per dispatch).
- `:session` TUI command (§1.5) — deferred; CLI `facet session` covers it meanwhile.

### Verification (on apiary; no Facet cargo on lathe)
- `cargo test -p lattice -p facet-record -p facet-cli -p facet-tui`: **122 passed, 0 failed** (facet-tui 55, incl. new grid navigation / hydrate / yank / filter / session-guard tests and a render test asserting the id fragment + footer ULID).
- `cargo clippy -p facet-tui --all-targets`: no new warnings (only pre-existing theme/tree/facet-record ones).
- `cargo fmt --check` clean; `cargo run -p facet-tui --example smoke` renders clean.

Docs: `docs/FACET.md` TUI paragraph now describes the grid.

Made with [Cursor](https://cursor.com)