### PR TITLE
feat: replay + hash-first diff (Goal 4)

### DIFF
--- a/crates/facet-record/src/diff.rs
+++ b/crates/facet-record/src/diff.rs
@@ -1,0 +1,483 @@
+//! Hash-first comparison of two recorded runs (`facet diff`, TUI `:diff`).
+//!
+//! [`compare`] is pure: it looks only at the two rows. Body equality needs
+//! bytes when a body is inline (no hash on the row), so [`diff_request_bodies`]
+//! and [`diff_response_bodies`] take the store and settle it. Headers compare
+//! as sorted `name: value` lists; they are already redacted, so a token change
+//! shows as no change, and `requestHash` will not move either since auth
+//! enters it by scheme only.
+
+use lattice::{BodyRef, LatticeError, RunRow, WorkspaceStore, sha256_hex};
+use probe_http::MAX_IN_MEMORY_RESPONSE_BYTES;
+use serde_json::{Value, json};
+
+/// Lines per side above which a unified diff is not attempted.
+const MAX_DIFF_LINES: usize = 2000;
+
+/// One differing scalar or header field. `field` uses the `history` JSON
+/// path names so an agent can map back without a legend.
+#[derive(Clone, Debug, PartialEq)]
+pub struct FieldChange {
+    /// `history` JSON path, e.g. `status` or `response.headers`.
+    pub field: &'static str,
+    /// Value on run A.
+    pub a: Value,
+    /// Value on run B.
+    pub b: Value,
+}
+
+/// Fields that are always compared and reported but never flip `equal`:
+/// they describe provenance, not bytes or outcome.
+pub const PROVENANCE_FIELDS: &[&str] = &["durationMs", "actor", "tags"];
+
+/// Metadata comparison of two runs.
+#[derive(Clone, Debug, PartialEq)]
+pub struct RunDiff {
+    /// Every differing field, provenance included.
+    pub changes: Vec<FieldChange>,
+    /// True when nothing but [`PROVENANCE_FIELDS`] differs. Body equality
+    /// for inline bodies is settled separately with bytes.
+    pub metadata_equal: bool,
+    /// `requestHash` equal.
+    pub request_hash_equal: bool,
+}
+
+/// Compares the recorded metadata of two runs. Pure; no I/O.
+#[must_use]
+pub fn compare(a: &RunRow, b: &RunRow) -> RunDiff {
+    let mut changes = Vec::new();
+    let mut push = |field: &'static str, left: Value, right: Value| {
+        if left != right {
+            changes.push(FieldChange {
+                field,
+                a: left,
+                b: right,
+            });
+        }
+    };
+    push("method", json!(a.method), json!(b.method));
+    push("url", json!(a.url), json!(b.url));
+    push("status", json!(a.status), json!(b.status));
+    push("error", json!(a.error), json!(b.error));
+    push("durationMs", json!(a.duration_ms), json!(b.duration_ms));
+    push("environment", json!(a.environment), json!(b.environment));
+    push("actor", json!(a.actor), json!(b.actor));
+    push("requestHash", json!(a.request_hash), json!(b.request_hash));
+    push(
+        "request.headers",
+        header_lines(a.req_headers.as_deref()),
+        header_lines(b.req_headers.as_deref()),
+    );
+    push(
+        "response.headers",
+        header_lines(a.res_headers.as_deref()),
+        header_lines(b.res_headers.as_deref()),
+    );
+    push(
+        "request.body.hash",
+        json!(a.req_body.hash),
+        json!(b.req_body.hash),
+    );
+    push(
+        "response.body.hash",
+        json!(a.res_body.hash),
+        json!(b.res_body.hash),
+    );
+    push(
+        "response.contentType",
+        json!(a.res_content_type),
+        json!(b.res_content_type),
+    );
+    push(
+        "tags",
+        tags_value(a.tags.as_deref()),
+        tags_value(b.tags.as_deref()),
+    );
+    let metadata_equal = changes
+        .iter()
+        .all(|change| PROVENANCE_FIELDS.contains(&change.field));
+    RunDiff {
+        changes,
+        metadata_equal,
+        request_hash_equal: a.request_hash == b.request_hash,
+    }
+}
+
+/// One side of a body comparison.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct BodySide {
+    /// SHA-256 of the body: the blob hash, or computed from inline bytes.
+    pub hash: Option<String>,
+    /// Body length in bytes.
+    pub size_bytes: Option<u64>,
+    /// `blob`, `inline`, or `none`.
+    pub retention: &'static str,
+}
+
+/// Outcome of comparing one body across two runs.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct BodyDiff {
+    /// Run A's body.
+    pub a: BodySide,
+    /// Run B's body.
+    pub b: BodySide,
+    /// Whether the bytes are equal (hashes first; inline bodies by bytes).
+    pub equal: bool,
+    /// Unified diff when requested, the bodies differ, and both are inline
+    /// UTF-8 text.
+    pub text: Option<String>,
+    /// Why `text` is absent: `blob`, `binary`, `too_large`, or `none`.
+    pub omission_reason: Option<&'static str>,
+}
+
+impl BodyDiff {
+    /// JSON shape used by `facet diff`.
+    #[must_use]
+    pub fn json(&self) -> Value {
+        json!({
+            "a": side_json(&self.a),
+            "b": side_json(&self.b),
+            "equal": self.equal,
+            "text": self.text,
+            "omissionReason": self.omission_reason,
+        })
+    }
+}
+
+fn side_json(side: &BodySide) -> Value {
+    json!({
+        "hash": side.hash,
+        "sizeBytes": side.size_bytes,
+        "retention": side.retention,
+    })
+}
+
+/// Request bodies are hash-only (v2), so this never reads bytes and never
+/// produces text; pull a body with `facet blob` when one is needed.
+#[must_use]
+pub fn diff_request_bodies(a: &RunRow, b: &RunRow) -> BodyDiff {
+    let left = side_from_ref(&a.req_body, None);
+    let right = side_from_ref(&b.req_body, None);
+    let equal = left.hash == right.hash;
+    let omission_reason = if equal {
+        None
+    } else if left.retention == "none" && right.retention == "none" {
+        Some("none")
+    } else {
+        Some("blob")
+    };
+    BodyDiff {
+        a: left,
+        b: right,
+        equal,
+        text: None,
+        omission_reason,
+    }
+}
+
+/// Compares response bodies. Blob bodies compare by hash without reading.
+/// Inline bodies are read (they are at most `inline_body_max`) and hashed;
+/// with `with_text`, differing inline UTF-8 bodies yield a unified diff.
+pub fn diff_response_bodies(
+    store: &WorkspaceStore,
+    a: &RunRow,
+    b: &RunRow,
+    with_text: bool,
+) -> Result<BodyDiff, LatticeError> {
+    let bytes_a = inline_bytes(store, a)?;
+    let bytes_b = inline_bytes(store, b)?;
+    let left = side_from_ref(&a.res_body, bytes_a.as_deref());
+    let right = side_from_ref(&b.res_body, bytes_b.as_deref());
+    let equal = left.hash == right.hash;
+    let mut diff = BodyDiff {
+        a: left,
+        b: right,
+        equal,
+        text: None,
+        omission_reason: None,
+    };
+    if equal || !with_text {
+        return Ok(diff);
+    }
+    diff.omission_reason = match (&bytes_a, &bytes_b) {
+        (Some(bytes_a), Some(bytes_b)) => {
+            if bytes_a.len() > MAX_IN_MEMORY_RESPONSE_BYTES
+                || bytes_b.len() > MAX_IN_MEMORY_RESPONSE_BYTES
+            {
+                Some("too_large")
+            } else {
+                match (std::str::from_utf8(bytes_a), std::str::from_utf8(bytes_b)) {
+                    (Ok(text_a), Ok(text_b)) => match unified_diff(text_a, text_b, "a", "b") {
+                        Some(text) => {
+                            diff.text = Some(text);
+                            None
+                        }
+                        None => Some("too_large"),
+                    },
+                    _ => Some("binary"),
+                }
+            }
+        }
+        _ if a.res_body.hash.is_some() || b.res_body.hash.is_some() => Some("blob"),
+        _ => Some("none"),
+    };
+    Ok(diff)
+}
+
+fn inline_bytes(store: &WorkspaceStore, run: &RunRow) -> Result<Option<Vec<u8>>, LatticeError> {
+    if run.res_body.hash.is_some() || !run.res_body.inline_present {
+        return Ok(None);
+    }
+    store.response_body(run)
+}
+
+fn side_from_ref(body: &BodyRef, inline: Option<&[u8]>) -> BodySide {
+    let hash = body.hash.clone().or_else(|| inline.map(sha256_hex));
+    BodySide {
+        hash,
+        size_bytes: body.len.or_else(|| inline.map(|bytes| bytes.len() as u64)),
+        retention: body.retention(),
+    }
+}
+
+fn header_lines(source: Option<&str>) -> Value {
+    let Some(Value::Array(items)) = source.and_then(|text| serde_json::from_str(text).ok()) else {
+        return Value::Null;
+    };
+    let mut lines: Vec<String> = items
+        .iter()
+        .filter_map(|item| {
+            let name = item.get("name")?.as_str()?;
+            let value = item.get("value")?.as_str()?;
+            Some(format!("{}: {value}", name.to_ascii_lowercase()))
+        })
+        .collect();
+    lines.sort();
+    json!(lines)
+}
+
+fn tags_value(source: Option<&str>) -> Value {
+    let mut tags: Vec<String> = source
+        .and_then(|text| serde_json::from_str::<Vec<String>>(text).ok())
+        .unwrap_or_default();
+    tags.sort();
+    json!(tags)
+}
+
+/// Line-based unified diff with three lines of context, computed with an
+/// in-crate LCS (no dependency). Returns `None` when either side exceeds
+/// [`MAX_DIFF_LINES`].
+#[must_use]
+pub fn unified_diff(a: &str, b: &str, label_a: &str, label_b: &str) -> Option<String> {
+    let lines_a: Vec<&str> = a.lines().collect();
+    let lines_b: Vec<&str> = b.lines().collect();
+    if lines_a.len() > MAX_DIFF_LINES || lines_b.len() > MAX_DIFF_LINES {
+        return None;
+    }
+    let ops = edit_script(&lines_a, &lines_b);
+    let mut out = format!("--- {label_a}\n+++ {label_b}\n");
+    let mut index = 0;
+    while index < ops.len() {
+        if ops[index].0 == Op::Equal {
+            index += 1;
+            continue;
+        }
+        // Hunk: from `start` (3 lines of context before) to the last change
+        // whose following equal run is shorter than six lines.
+        let start = index.saturating_sub(3);
+        let mut end = index;
+        loop {
+            while end < ops.len() && ops[end].0 != Op::Equal {
+                end += 1;
+            }
+            let mut run = end;
+            while run < ops.len() && ops[run].0 == Op::Equal {
+                run += 1;
+            }
+            if run < ops.len() && run - end <= 6 {
+                end = run;
+                continue;
+            }
+            end = (end + 3).min(ops.len());
+            break;
+        }
+        let (mut a_count, mut b_count) = (0, 0);
+        let mut a_start = None;
+        let mut b_start = None;
+        let mut body = String::new();
+        for (op, a_line, b_line) in &ops[start..end] {
+            match op {
+                Op::Equal => {
+                    a_start.get_or_insert(*a_line);
+                    b_start.get_or_insert(*b_line);
+                    a_count += 1;
+                    b_count += 1;
+                    body.push(' ');
+                    body.push_str(lines_a[*a_line]);
+                }
+                Op::Delete => {
+                    a_start.get_or_insert(*a_line);
+                    b_start.get_or_insert(*b_line);
+                    a_count += 1;
+                    body.push('-');
+                    body.push_str(lines_a[*a_line]);
+                }
+                Op::Insert => {
+                    a_start.get_or_insert(*a_line);
+                    b_start.get_or_insert(*b_line);
+                    b_count += 1;
+                    body.push('+');
+                    body.push_str(lines_b[*b_line]);
+                }
+            }
+            body.push('\n');
+        }
+        out.push_str(&format!(
+            "@@ -{},{a_count} +{},{b_count} @@\n",
+            a_start.unwrap_or(0) + 1,
+            b_start.unwrap_or(0) + 1
+        ));
+        out.push_str(&body);
+        index = end;
+    }
+    Some(out)
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum Op {
+    Equal,
+    Delete,
+    Insert,
+}
+
+/// Edit script as `(op, index into a, index into b)`; for `Equal` and
+/// `Delete` the a-index is the line, for `Insert` the b-index is the line.
+fn edit_script(a: &[&str], b: &[&str]) -> Vec<(Op, usize, usize)> {
+    let (n, m) = (a.len(), b.len());
+    let width = m + 1;
+    let mut table = vec![0_u32; (n + 1) * width];
+    for i in (0..n).rev() {
+        for j in (0..m).rev() {
+            table[i * width + j] = if a[i] == b[j] {
+                table[(i + 1) * width + j + 1] + 1
+            } else {
+                table[(i + 1) * width + j].max(table[i * width + j + 1])
+            };
+        }
+    }
+    let mut ops = Vec::with_capacity(n + m);
+    let (mut i, mut j) = (0, 0);
+    while i < n && j < m {
+        if a[i] == b[j] {
+            ops.push((Op::Equal, i, j));
+            i += 1;
+            j += 1;
+        } else if table[(i + 1) * width + j] >= table[i * width + j + 1] {
+            ops.push((Op::Delete, i, j));
+            i += 1;
+        } else {
+            ops.push((Op::Insert, i, j));
+            j += 1;
+        }
+    }
+    while i < n {
+        ops.push((Op::Delete, i, j));
+        i += 1;
+    }
+    while j < m {
+        ops.push((Op::Insert, i, j));
+        j += 1;
+    }
+    ops
+}
+
+#[cfg(test)]
+mod tests {
+    use lattice::{BodyRef, RunRow};
+
+    use super::{compare, diff_request_bodies, unified_diff};
+
+    fn row(status: Option<i64>, res_headers: &str) -> RunRow {
+        RunRow {
+            id: "01ARZ3NDEKTSV4RRFFQ69G5FAV".to_owned(),
+            started_at: 1,
+            duration_ms: Some(10),
+            request_path: "items/0".to_owned(),
+            request_hash: "9f".to_owned(),
+            environment: Some("local".to_owned()),
+            method: "GET".to_owned(),
+            url: "http://x/".to_owned(),
+            status,
+            error: None,
+            req_headers: None,
+            res_headers: Some(res_headers.to_owned()),
+            req_body: BodyRef::default(),
+            res_body: BodyRef::default(),
+            res_content_type: None,
+            session_id: None,
+            actor: "human".to_owned(),
+            tags: Some(r#"["b","a"]"#.to_owned()),
+            replayed_from: None,
+            var_names: None,
+        }
+    }
+
+    #[test]
+    fn provenance_never_flips_equal_and_headers_sort() {
+        let a = row(
+            Some(200),
+            r#"[{"name":"B","value":"2"},{"name":"a","value":"1"}]"#,
+        );
+        let mut b = row(
+            Some(200),
+            r#"[{"name":"a","value":"1"},{"name":"b","value":"2"}]"#,
+        );
+        b.duration_ms = Some(99);
+        b.tags = Some(r#"["a","b"]"#.to_owned());
+        let diff = compare(&a, &b);
+        assert!(diff.metadata_equal);
+        assert_eq!(diff.changes.len(), 1);
+        assert_eq!(diff.changes[0].field, "durationMs");
+
+        b.tags = Some(r#"["a","b","retry"]"#.to_owned());
+        b.actor = "halo-qa".to_owned();
+        let diff = compare(&a, &b);
+        assert!(diff.metadata_equal, "tags and actor are provenance");
+        assert_eq!(diff.changes.len(), 3);
+
+        b.status = Some(500);
+        let diff = compare(&a, &b);
+        assert!(!diff.metadata_equal);
+        assert!(diff.changes.iter().any(|change| change.field == "status"));
+    }
+
+    #[test]
+    fn request_bodies_compare_by_hash_only() {
+        let mut a = row(Some(200), "[]");
+        let mut b = row(Some(200), "[]");
+        assert!(diff_request_bodies(&a, &b).equal);
+        a.req_body.hash = Some("aa".to_owned());
+        b.req_body.hash = Some("bb".to_owned());
+        let diff = diff_request_bodies(&a, &b);
+        assert!(!diff.equal);
+        assert_eq!(diff.omission_reason, Some("blob"));
+        assert!(diff.text.is_none());
+    }
+
+    #[test]
+    fn unified_diff_marks_changed_lines_with_context() {
+        let a = "one\ntwo\nthree\nfour\nfive\nsix\nseven\n";
+        let b = "one\ntwo\nthree\nFOUR\nfive\nsix\nseven\n";
+        let text = unified_diff(a, b, "a", "b").unwrap();
+        assert!(
+            text.starts_with("--- a\n+++ b\n@@ -1,7 +1,7 @@\n"),
+            "{text}"
+        );
+        assert!(text.contains(" three\n-four\n+FOUR\n five\n"), "{text}");
+        assert!(
+            unified_diff("x", "x", "a", "b")
+                .unwrap()
+                .ends_with("+++ b\n")
+        );
+    }
+}

--- a/crates/facet-record/src/lib.rs
+++ b/crates/facet-record/src/lib.rs
@@ -6,7 +6,14 @@
 
 #![forbid(unsafe_code)]
 
+mod diff;
+
 use std::path::Path;
+
+pub use diff::{
+    BodyDiff, BodySide, FieldChange, PROVENANCE_FIELDS, RunDiff, compare, diff_request_bodies,
+    diff_response_bodies, unified_diff,
+};
 
 use lattice::{
     BodyInput, LatticeConfig, LatticeError, MachineStore, NewRun, Retention, RunRow,
@@ -194,6 +201,11 @@ pub struct RecordRequest<'a> {
     pub actor: &'a str,
     /// Machine-store session id.
     pub session: Option<&'a str>,
+    /// `runs.id` this run replays (`facet replay`), if any.
+    pub replayed_from: Option<&'a str>,
+    /// Names of the `--var` overrides used at resolve time. Names only;
+    /// values are never written anywhere in Lattice.
+    pub var_names: &'a [String],
 }
 
 /// Records one run in the workspace store beside the collection, then
@@ -214,6 +226,8 @@ pub fn record(req: &RecordRequest<'_>) -> Recording {
         tags,
         actor,
         session,
+        replayed_from,
+        var_names,
     } = *req;
     let Some(root) = root else {
         return Recording::Skipped("stdin_workspace");
@@ -244,6 +258,8 @@ pub fn record(req: &RecordRequest<'_>) -> Recording {
         Some(json!(tags).to_string())
     };
     let redacted_url = redact_url(request.url.as_deref().unwrap_or(""));
+    // Always written post-0003 so `[]` (none) stays distinct from NULL (unknown).
+    let var_names_json = json!(var_names).to_string();
 
     let res_body = match result {
         Ok(response) => {
@@ -286,6 +302,8 @@ pub fn record(req: &RecordRequest<'_>) -> Recording {
         session_id: session,
         actor,
         tags: tags_json.as_deref(),
+        replayed_from,
+        var_names: Some(&var_names_json),
     };
 
     match store.record_run(&new_run) {
@@ -370,6 +388,14 @@ fn url_encode(value: &str) -> String {
         }
     }
     out
+}
+
+/// The `request_hash` Lattice would store for `request` as resolved now.
+/// `facet replay` compares this against the recorded row before sending.
+#[must_use]
+pub fn request_hash_of(request: &HttpRequest) -> String {
+    let body = request_body_bytes(request);
+    request_hash(request, body.as_deref())
 }
 
 /// SHA-256 of a canonical JSON view of the resolved request. Bodies enter by

--- a/crates/facet-tui/src/app.rs
+++ b/crates/facet-tui/src/app.rs
@@ -1969,6 +1969,8 @@ impl App {
                     tags: &[],
                     actor: &actor,
                     session: session.as_deref(),
+                    replayed_from: None,
+                    var_names: &[],
                 });
                 Some(RecordSummary::from_recording(&recording))
             } else {

--- a/crates/facet-tui/src/ui.rs
+++ b/crates/facet-tui/src/ui.rs
@@ -1536,6 +1536,8 @@ mod tests {
             session_id: None,
             actor: "claude.halo-fullstack".to_string(),
             tags: None,
+            replayed_from: None,
+            var_names: None,
         }]);
         let backend = TestBackend::new(120, 32);
         let mut terminal = Terminal::new(backend).expect("backend");

--- a/crates/facet/src/diff.rs
+++ b/crates/facet/src/diff.rs
@@ -1,0 +1,142 @@
+//! `facet diff <a> <b> [<path>]`: hash-first comparison of two recorded runs.
+//! Exit 0 when equal, 1 when different (assertion family), 4 when a run is
+//! missing, 9 when there is no store.
+
+use facet_record::{compare, diff_request_bodies, diff_response_bodies};
+use lattice::RunRow;
+use serde_json::{Value, json};
+
+use crate::{
+    ASSERTION_EXIT_CODE, CommandOutput, FacetError, args,
+    workspace::{ConfigOverrides, locate_root, open_store},
+};
+
+pub(crate) fn diff(args: &[String]) -> Result<CommandOutput, FacetError> {
+    let parsed = args::parse(args, &[], &["--bodies"])?;
+    let (id_a, id_b, path) = match parsed.positionals() {
+        [a, b] => (a.as_str(), b.as_str(), None),
+        [a, b, path] => (a.as_str(), b.as_str(), Some(path.as_str())),
+        _ => {
+            return Err(FacetError::invalid_arguments(
+                "diff requires <idA> <idB> and an optional <path>",
+            ));
+        }
+    };
+    let with_bodies = parsed.switch("--bodies");
+    let (start, root) = locate_root(path);
+    let root = root.ok_or_else(|| FacetError::lattice_not_found(&start))?;
+    let store = open_store(&root, &ConfigOverrides::default())?;
+
+    let row_a = store.run(id_a).map_err(FacetError::lattice)?;
+    let row_b = store.run(id_b).map_err(FacetError::lattice)?;
+    let (Some(a), Some(b)) = (&row_a, &row_b) else {
+        let missing: Vec<&str> = [(id_a, row_a.is_none()), (id_b, row_b.is_none())]
+            .into_iter()
+            .filter(|(_, missing)| *missing)
+            .map(|(id, _)| id)
+            .collect();
+        return Err(FacetError::runs_not_found(&missing));
+    };
+
+    let meta = compare(a, b);
+    let request_body = diff_request_bodies(a, b);
+    let response_body =
+        diff_response_bodies(&store, a, b, with_bodies).map_err(FacetError::lattice)?;
+    let equal = meta.metadata_equal && request_body.equal && response_body.equal;
+
+    let mut human = String::new();
+    if meta.changes.is_empty() {
+        human.push_str("no metadata changes\n");
+    } else {
+        human.push_str("FIELD\tA\tB\n");
+        for change in &meta.changes {
+            human.push_str(&format!(
+                "{}\t{}\t{}\n",
+                change.field,
+                compact(&change.a),
+                compact(&change.b)
+            ));
+        }
+    }
+    human.push_str(&format!(
+        "request hash: {}\n",
+        if meta.request_hash_equal {
+            format!("equal ({})", short(&a.request_hash))
+        } else {
+            format!(
+                "differs ({} → {})",
+                short(&a.request_hash),
+                short(&b.request_hash)
+            )
+        }
+    ));
+    human.push_str(&format!(
+        "request body: {}\n",
+        body_line(
+            request_body.equal,
+            request_body.a.hash.as_deref(),
+            request_body.b.hash.as_deref()
+        )
+    ));
+    human.push_str(&format!(
+        "response body: {}\n",
+        body_line(
+            response_body.equal,
+            response_body.a.hash.as_deref(),
+            response_body.b.hash.as_deref()
+        )
+    ));
+    if let Some(text) = &response_body.text {
+        human.push_str(text);
+    }
+
+    let json = json!({
+        "workspace": { "id": store.workspace_id(), "path": store.root().to_string_lossy() },
+        "a": stamp(a),
+        "b": stamp(b),
+        "equal": equal,
+        "changes": meta.changes.iter().map(|change| json!({
+            "field": change.field,
+            "a": change.a,
+            "b": change.b,
+        })).collect::<Vec<_>>(),
+        "request": {
+            "hash": { "a": a.request_hash, "b": b.request_hash, "equal": meta.request_hash_equal },
+            "body": request_body.json(),
+        },
+        "response": {
+            "body": response_body.json(),
+        },
+    });
+    let output = CommandOutput::new(human, json);
+    Ok(if equal {
+        output
+    } else {
+        output.with_exit_code(ASSERTION_EXIT_CODE)
+    })
+}
+
+fn stamp(row: &RunRow) -> Value {
+    json!({ "id": row.id, "startedAt": row.started_at, "status": row.status })
+}
+
+fn short(hash: &str) -> String {
+    format!("{}…", &hash[..12.min(hash.len())])
+}
+
+fn body_line(equal: bool, a: Option<&str>, b: Option<&str>) -> String {
+    let show = |hash: Option<&str>| hash.map_or_else(|| "none".to_owned(), short);
+    if equal {
+        format!("equal ({})", show(a))
+    } else {
+        format!("differs ({} → {})", show(a), show(b))
+    }
+}
+
+fn compact(value: &Value) -> String {
+    match value {
+        Value::String(text) => text.clone(),
+        Value::Null => "-".to_owned(),
+        other => other.to_string(),
+    }
+}

--- a/crates/facet/src/error.rs
+++ b/crates/facet/src/error.rs
@@ -9,9 +9,10 @@ use probe_http::HttpError;
 use serde_json::Value;
 
 use crate::{
-    CONFIGURATION_EXIT_CODE, EXECUTION_EXIT_CODE, INVALID_ARGUMENTS_EXIT_CODE,
+    ASSERTION_EXIT_CODE, CONFIGURATION_EXIT_CODE, EXECUTION_EXIT_CODE, INVALID_ARGUMENTS_EXIT_CODE,
     INVALID_WORKSPACE_EXIT_CODE, LATTICE_EXIT_CODE, REQUEST_NOT_FOUND_EXIT_CODE,
 };
+use serde_json::json;
 
 /// A structured command failure.
 #[derive(Debug)]
@@ -75,6 +76,32 @@ impl FacetError {
             format!("run not found: {id}"),
             REQUEST_NOT_FOUND_EXIT_CODE,
         )
+    }
+
+    /// `diff` with one or both runs missing (exit 4); `details.missing` lists them.
+    pub(crate) fn runs_not_found(missing: &[&str]) -> Self {
+        Self::new(
+            "run_not_found",
+            format!("run not found: {}", missing.join(", ")),
+            REQUEST_NOT_FOUND_EXIT_CODE,
+        )
+        .with_details(json!({ "missing": missing }))
+    }
+
+    /// `replay --frozen` when the current YAML resolves to a different
+    /// request than the recorded one. Assertion family (exit 1): no network,
+    /// no Lattice row.
+    pub(crate) fn replay_changed(run_id: &str, recorded: &str, current: &str) -> Self {
+        Self::new(
+            "replay_changed",
+            format!("request changed since {run_id}; --frozen refuses to replay"),
+            ASSERTION_EXIT_CODE,
+        )
+        .with_details(json!({
+            "replayedFrom": run_id,
+            "recordedHash": recorded,
+            "currentHash": current,
+        }))
     }
 
     /// `session end|show <id>` with an unknown session id (exit 4).

--- a/crates/facet/src/history.rs
+++ b/crates/facet/src/history.rs
@@ -324,6 +324,8 @@ fn run_json(
         "actor": row.actor,
         "sessionId": row.session_id,
         "tags": parse_json_or(row.tags.as_deref(), json!([])),
+        "replayedFrom": row.replayed_from,
+        "varNames": parse_json_or(row.var_names.as_deref(), Value::Null),
         "request": {
             "headers": parse_json_or(row.req_headers.as_deref(), Value::Null),
             "body": request_body,

--- a/crates/facet/src/lib.rs
+++ b/crates/facet/src/lib.rs
@@ -8,6 +8,7 @@
 //!   then records the run in the workspace Lattice store.
 //! - `history`, `blob`, and `gc` read and maintain that store.
 //! - `session` starts, ends, lists, and shows agent sessions in the machine store.
+//! - `replay` re-sends a recorded run from the current YAML; `diff` compares two runs.
 //! - `tui` opens the terminal UI.
 //!
 //! Contract details for the Facet-only commands live in `docs/FACET.md`.
@@ -19,9 +20,11 @@ use std::io::{self, Read};
 use serde_json::{Value, json};
 
 mod args;
+mod diff;
 mod error;
 mod history;
 mod presentation;
+mod replay;
 mod run;
 mod session;
 mod tui;
@@ -38,6 +41,12 @@ pub use tui::run_tui;
 /// Exit code used when the Lattice store cannot be opened, read, or written.
 /// Extends the upstream exit-code table; never renumbers it.
 pub const LATTICE_EXIT_CODE: u8 = 9;
+
+/// Exit code for the assertion family: the check the caller asked for is
+/// false (`replay --frozen` refused, `diff` found differences). Unix's `1`,
+/// as in `test`, `grep`, `diff`, `cmp`; unused upstream (constants start at
+/// 2), so it never collides.
+pub const ASSERTION_EXIT_CODE: u8 = 1;
 
 /// Captured CLI output and process status. `stdout` is bytes because
 /// `facet blob` writes a raw body.
@@ -94,6 +103,7 @@ pub(crate) struct CommandOutput {
     human: Vec<u8>,
     json: Value,
     warnings: Vec<String>,
+    exit_code: u8,
 }
 
 impl CommandOutput {
@@ -102,11 +112,19 @@ impl CommandOutput {
             human: human.into(),
             json,
             warnings: Vec::new(),
+            exit_code: 0,
         }
     }
 
     pub(crate) fn warn(mut self, warning: impl Into<String>) -> Self {
         self.warnings.push(warning.into());
+        self
+    }
+
+    /// A successful document that still signals an assertion outcome
+    /// (`diff` differs). Output is rendered as usual; only the code changes.
+    pub(crate) fn with_exit_code(mut self, exit_code: u8) -> Self {
+        self.exit_code = exit_code;
         self
     }
 
@@ -123,7 +141,11 @@ impl CommandOutput {
             .iter()
             .map(|warning| format!("warning: {warning}\n"))
             .collect();
-        RunOutput::success(stdout, stderr)
+        RunOutput {
+            stdout,
+            stderr,
+            exit_code: self.exit_code,
+        }
     }
 }
 
@@ -146,6 +168,8 @@ pub const fn help() -> &'static str {
         "  session end [<id>|current]          End a session (default: $FACET_SESSION); idempotent\n",
         "  session list                        List sessions, newest first\n",
         "  session show <id>|current           Show one session\n",
+        "  replay <runId> [<path>]             Re-send a recorded run from the current YAML\n",
+        "  diff <idA> <idB> [<path>]           Compare two recorded runs, hashes first (exit 1 if different)\n",
         "  blob <hash> [<path>]                Fetch one stored body by SHA-256\n",
         "  gc [<path>] [--yes]                 Expire old runs and sweep orphaned blobs\n",
         "  tui [<path>]                        Open the terminal UI\n",
@@ -164,7 +188,8 @@ pub const fn help() -> &'static str {
         "      --environment <name>    Only history resolved with one environment\n",
         "      --hash <sha256>         Only history whose request, request body, or response body hash matches\n",
         "      --id <ulid>             One run by id (exclusive with the filters above)\n",
-        "      --bodies                Include inline bodies in history JSON\n",
+        "      --bodies                Include inline bodies in history JSON; unified body diff for diff\n",
+        "      --frozen                Refuse to replay when the request hash changed (exit 1)\n",
         "      --meta <json>           Session metadata object (session start)\n",
         "      --open                  Only sessions still open (session list)\n",
         "      --output <file>         Write a blob to a file instead of stdout\n",
@@ -212,7 +237,8 @@ where
     let owned = match args.first().map(String::as_str) {
         None => true,
         Some(
-            "history" | "session" | "blob" | "gc" | "tui" | "-V" | "--version" | "-h" | "--help",
+            "history" | "session" | "replay" | "diff" | "blob" | "gc" | "tui" | "-V" | "--version"
+            | "-h" | "--help",
         ) => true,
         Some("request") => args.get(1).map(String::as_str) == Some("run"),
         Some(_) => false,
@@ -257,6 +283,8 @@ where
         "request" => run::run(&args[2..], stdin),
         "history" => history::history(&args[1..]),
         "session" => session::session(&args[1..]),
+        "replay" => replay::replay(&args[1..], stdin),
+        "diff" => diff::diff(&args[1..]),
         "blob" => history::blob(&args[1..]),
         "gc" => history::gc(&args[1..]),
         "tui" => Err(FacetError::invalid_arguments(

--- a/crates/facet/src/replay.rs
+++ b/crates/facet/src/replay.rs
@@ -1,0 +1,210 @@
+//! `facet replay <runId> [<path>]`: re-resolve the **current** YAML at the
+//! recorded environment and send it again, recording lineage.
+//!
+//! Replay truth is current YAML plus recorded environment. There is no
+//! "send stored bytes" mode: stored headers are redacted, auth enters the
+//! hash by scheme only, and request bodies are content-addressed blobs that
+//! may hold secrets. `--frozen` is refuse-on-change only: when the resolved
+//! request hashes differently from the recorded row, exit 1 with no network
+//! and no Lattice row.
+
+use std::io::Read;
+
+use facet_record::{
+    RecordRequest, Recording, actor_from_env, record, recording_disabled, request_hash_of,
+    session_from_env,
+};
+use lattice::{MachineStore, WorkspaceStore};
+use serde_json::json;
+
+use crate::{
+    CommandOutput, FacetError, args,
+    run::{execute, parse_vars, render, selected_request, var_names},
+    workspace::{WorkspaceInput, load, open_store, overrides_from_parsed},
+};
+
+const VALUE_FLAGS: &[&str] = &[
+    "--environment",
+    "--var",
+    "--tag",
+    "--inline-body-max",
+    "--history-retention",
+];
+const SWITCH_FLAGS: &[&str] = &["--frozen", "--strict-variables", "--no-record"];
+
+pub(crate) fn replay(args: &[String], stdin: &mut impl Read) -> Result<CommandOutput, FacetError> {
+    let parsed = args::parse(args, VALUE_FLAGS, SWITCH_FLAGS)?;
+    let (run_id, path) = match parsed.positionals() {
+        [run_id] => (run_id.as_str(), "."),
+        [run_id, path] => (run_id.as_str(), path.as_str()),
+        _ => {
+            return Err(FacetError::invalid_arguments(
+                "replay requires <runId> and an optional <path>",
+            ));
+        }
+    };
+    let input = WorkspaceInput::from_argument(path);
+    let Some(base) = input.base_directory() else {
+        return Err(FacetError::invalid_arguments(
+            "replay needs a collection on disk (a stdin workspace has no Lattice store)",
+        ));
+    };
+    let frozen = parsed.switch("--frozen");
+    let strict_variables = parsed.switch("--strict-variables");
+    let should_record = !parsed.switch("--no-record") && !recording_disabled();
+    let overrides = overrides_from_parsed(&parsed)?;
+    let variables = parse_vars(&parsed)?;
+    let extra_tags: Vec<String> = parsed
+        .values("--tag")
+        .into_iter()
+        .map(str::to_owned)
+        .collect();
+
+    // 1. The run row, from the workspace store beside the collection.
+    let root =
+        WorkspaceStore::discover(&base).ok_or_else(|| FacetError::lattice_not_found(&base))?;
+    let store = open_store(&root, &overrides)?;
+    let Some(row) = store.run(run_id).map_err(FacetError::lattice)? else {
+        return Err(run_not_found_with_breadcrumb(&store, run_id));
+    };
+
+    // 2. Selector and environment come from the row; `--environment` wins.
+    let selector = row.request_path.as_str();
+    let environment = parsed
+        .value("--environment")?
+        .map(str::to_owned)
+        .or_else(|| row.environment.clone());
+
+    // 3. Recorded `--var` names are a warning, never replayed (values are
+    //    not stored). `None` means the row predates 0003.
+    let mut warnings = Vec::new();
+    if let Some(recorded) = row
+        .var_names
+        .as_deref()
+        .and_then(|text| serde_json::from_str::<Vec<String>>(text).ok())
+    {
+        let passed = var_names(&variables);
+        let missing: Vec<&str> = recorded
+            .iter()
+            .filter(|name| !passed.contains(name))
+            .map(String::as_str)
+            .collect();
+        if !missing.is_empty() {
+            warnings.push(format!(
+                "run {} was recorded with --var {}; pass them again",
+                row.id,
+                missing.join(", ")
+            ));
+        }
+    }
+
+    // 4. Resolve the current YAML and compare hashes before any network.
+    let loaded = load(&input, stdin)?;
+    let request = selected_request(
+        &loaded,
+        selector,
+        environment.as_deref(),
+        &variables,
+        strict_variables,
+    )
+    .map_err(|error| error.with_details(json!({ "replayedFrom": row.id })))?;
+    let current_hash = request_hash_of(&request);
+    let hash_changed = current_hash != row.request_hash;
+    if hash_changed && frozen {
+        return Err(FacetError::replay_changed(
+            &row.id,
+            &row.request_hash,
+            &current_hash,
+        ));
+    }
+    if hash_changed {
+        warnings.push(format!(
+            "request changed since {}: recorded {}…, current {}…",
+            row.id,
+            &row.request_hash[..12.min(row.request_hash.len())],
+            &current_hash[..12.min(current_hash.len())]
+        ));
+    }
+
+    // 5. Send and record with lineage.
+    let execution = execute(&request, input.base_directory(), None)?;
+    let tags = merged_tags(row.tags.as_deref(), &extra_tags);
+    let recording = if should_record {
+        let actor = actor_from_env();
+        let session = session_from_env();
+        record(&RecordRequest {
+            root: Some(&base),
+            overrides: &overrides,
+            selector,
+            environment: environment.as_deref(),
+            request: &request,
+            started_at: execution.started_at,
+            elapsed_ms: execution.elapsed_ms,
+            result: &execution.result,
+            output: None,
+            tags: &tags,
+            actor: &actor,
+            session: session.as_deref(),
+            replayed_from: Some(&row.id),
+            var_names: &var_names(&variables),
+        })
+    } else {
+        Recording::Skipped("disabled")
+    };
+    if let Some(warning) = recording.warning() {
+        warnings.push(warning);
+    }
+
+    let mut lattice_json = recording.json();
+    lattice_json["replayedFrom"] = json!(row.id);
+    lattice_json["hashChanged"] = json!(hash_changed);
+    let lattice_human = format!(
+        "{} · replayed from {} ({})",
+        recording.human(),
+        row.id,
+        if hash_changed {
+            "request changed"
+        } else {
+            "request unchanged"
+        }
+    );
+    render(
+        &request,
+        execution,
+        None,
+        lattice_json,
+        lattice_human,
+        warnings,
+    )
+}
+
+/// Recorded tags first, then `--tag` additions, without duplicates.
+fn merged_tags(recorded: Option<&str>, extra: &[String]) -> Vec<String> {
+    let mut tags: Vec<String> = recorded
+        .and_then(|text| serde_json::from_str(text).ok())
+        .unwrap_or_default();
+    for tag in extra {
+        if !tags.contains(tag) {
+            tags.push(tag.clone());
+        }
+    }
+    tags
+}
+
+/// `run_not_found`, with the workspace the machine index knows the run
+/// under when it lives elsewhere (one query; best effort).
+fn run_not_found_with_breadcrumb(store: &WorkspaceStore, run_id: &str) -> FacetError {
+    let error = FacetError::run_not_found(run_id);
+    let elsewhere = MachineStore::open(store.config())
+        .ok()
+        .and_then(|machine| machine.indexed_run(run_id).ok().flatten());
+    match elsewhere {
+        Some((workspace_id, path)) if workspace_id != store.workspace_id() => {
+            error.with_details(json!({
+                "workspaceId": workspace_id,
+                "workspacePath": path,
+            }))
+        }
+        _ => error,
+    }
+}

--- a/crates/facet/src/run.rs
+++ b/crates/facet/src/run.rs
@@ -1,7 +1,13 @@
 //! `facet request run`: execute through the shared core and HTTP engine
 //! exactly as `probe request run` does, then record the run in Lattice.
+//! `facet replay` reuses [`execute`] and [`render`] with its own resolution.
 
-use std::{borrow::Cow, io::Read, path::PathBuf, time::Instant};
+use std::{
+    borrow::Cow,
+    io::Read,
+    path::{Path, PathBuf},
+    time::Instant,
+};
 
 use facet_record::{
     RecordRequest, Recording, actor_from_env, record, recording_disabled, session_from_env,
@@ -10,9 +16,9 @@ use lattice::now_ms;
 use probe_core::{
     HttpRequest, resolve_environment_with_overrides, resolve_request, resolve_request_strict,
 };
-use probe_http::{ExecutionOptions, HttpEngine};
+use probe_http::{ExecutionOptions, HttpEngine, HttpError, HttpResponse};
 use probe_opencollection::LoadedWorkspace;
-use serde_json::json;
+use serde_json::{Value, json};
 
 use crate::{
     CommandOutput, FacetError, args,
@@ -30,6 +36,13 @@ const VALUE_FLAGS: &[&str] = &[
 ];
 const SWITCH_FLAGS: &[&str] = &["--strict-variables", "--no-record"];
 
+/// One executed request: when it started, how long it took, and the outcome.
+pub(crate) struct Execution {
+    pub(crate) started_at: i64,
+    pub(crate) elapsed_ms: i64,
+    pub(crate) result: Result<HttpResponse, HttpError>,
+}
+
 pub(crate) fn run(args: &[String], stdin: &mut impl Read) -> Result<CommandOutput, FacetError> {
     let parsed = args::parse(args, VALUE_FLAGS, SWITCH_FLAGS)?;
     let [path, selector] = parsed.positionals() else {
@@ -41,21 +54,7 @@ pub(crate) fn run(args: &[String], stdin: &mut impl Read) -> Result<CommandOutpu
     let environment = parsed.value("--environment")?.map(str::to_owned);
     let output = parsed.value("--output")?.map(PathBuf::from);
     let strict_variables = parsed.switch("--strict-variables");
-    let variables = parsed
-        .values("--var")
-        .into_iter()
-        .map(|entry| {
-            entry
-                .split_once('=')
-                .filter(|(name, _)| !name.is_empty())
-                .map(|(name, value)| (name.to_owned(), value.to_owned()))
-                .ok_or_else(|| {
-                    FacetError::invalid_arguments(format!(
-                        "--var expects NAME=VALUE, got {entry:?}"
-                    ))
-                })
-        })
-        .collect::<Result<Vec<_>, _>>()?;
+    let variables = parse_vars(&parsed)?;
     let tags: Vec<String> = parsed
         .values("--tag")
         .into_iter()
@@ -72,30 +71,7 @@ pub(crate) fn run(args: &[String], stdin: &mut impl Read) -> Result<CommandOutpu
         &variables,
         strict_variables,
     )?;
-    let options = ExecutionOptions {
-        base_directory: input.base_directory(),
-        ..ExecutionOptions::default()
-    };
-    let runtime = tokio::runtime::Builder::new_current_thread()
-        .enable_all()
-        .build()
-        .map_err(|error| FacetError::runtime(&error))?;
-    let engine = HttpEngine::new().map_err(|error| FacetError::http(&error))?;
-
-    let started_at = now_ms();
-    let clock = Instant::now();
-    let result = runtime.block_on(async {
-        if let Some(output) = &output {
-            engine
-                .execute_cancellable_to_file(&request, &options, output, tokio::signal::ctrl_c())
-                .await
-        } else {
-            engine
-                .execute_cancellable(&request, &options, tokio::signal::ctrl_c())
-                .await
-        }
-    });
-    let elapsed_ms = i64::try_from(clock.elapsed().as_millis()).unwrap_or(i64::MAX);
+    let execution = execute(&request, input.base_directory(), output.as_deref())?;
 
     let recording = if should_record {
         let root = input.base_directory();
@@ -107,42 +83,125 @@ pub(crate) fn run(args: &[String], stdin: &mut impl Read) -> Result<CommandOutpu
             selector,
             environment: environment.as_deref(),
             request: &request,
-            started_at,
-            elapsed_ms,
-            result: &result,
+            started_at: execution.started_at,
+            elapsed_ms: execution.elapsed_ms,
+            result: &execution.result,
             output: output.as_deref(),
             tags: &tags,
             actor: &actor,
             session: session.as_deref(),
+            replayed_from: None,
+            var_names: &var_names(&variables),
         })
     } else {
         Recording::Skipped("disabled")
     };
 
-    match result {
+    render(
+        &request,
+        execution,
+        output.as_deref(),
+        recording.json(),
+        recording.human(),
+        recording.warning().into_iter().collect(),
+    )
+}
+
+/// Parses repeated `--var NAME=VALUE` flags in order.
+pub(crate) fn parse_vars(parsed: &args::Parsed) -> Result<Vec<(String, String)>, FacetError> {
+    parsed
+        .values("--var")
+        .into_iter()
+        .map(|entry| {
+            entry
+                .split_once('=')
+                .filter(|(name, _)| !name.is_empty())
+                .map(|(name, value)| (name.to_owned(), value.to_owned()))
+                .ok_or_else(|| {
+                    FacetError::invalid_arguments(format!(
+                        "--var expects NAME=VALUE, got {entry:?}"
+                    ))
+                })
+        })
+        .collect()
+}
+
+/// The names of the `--var` overrides, in order; values never leave here.
+pub(crate) fn var_names(variables: &[(String, String)]) -> Vec<String> {
+    variables.iter().map(|(name, _)| name.clone()).collect()
+}
+
+/// Executes one resolved request on a fresh single-thread runtime, with
+/// Ctrl-C cancellation and optional streaming to `output`.
+pub(crate) fn execute(
+    request: &HttpRequest,
+    base_directory: Option<PathBuf>,
+    output: Option<&Path>,
+) -> Result<Execution, FacetError> {
+    let options = ExecutionOptions {
+        base_directory,
+        ..ExecutionOptions::default()
+    };
+    let runtime = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .map_err(|error| FacetError::runtime(&error))?;
+    let engine = HttpEngine::new().map_err(|error| FacetError::http(&error))?;
+
+    let started_at = now_ms();
+    let clock = Instant::now();
+    let result = runtime.block_on(async {
+        if let Some(output) = output {
+            engine
+                .execute_cancellable_to_file(request, &options, output, tokio::signal::ctrl_c())
+                .await
+        } else {
+            engine
+                .execute_cancellable(request, &options, tokio::signal::ctrl_c())
+                .await
+        }
+    });
+    let elapsed_ms = i64::try_from(clock.elapsed().as_millis()).unwrap_or(i64::MAX);
+    Ok(Execution {
+        started_at,
+        elapsed_ms,
+        result,
+    })
+}
+
+/// Renders the upstream response document plus Facet's `lattice` field
+/// (`lattice_json` / `lattice_human`), or the upstream error envelope with
+/// `error.details.lattice` on a transport failure.
+pub(crate) fn render(
+    request: &HttpRequest,
+    execution: Execution,
+    output: Option<&Path>,
+    lattice_json: Value,
+    lattice_human: String,
+    warnings: Vec<String>,
+) -> Result<CommandOutput, FacetError> {
+    match execution.result {
         Ok(response) => {
-            let output = output.as_deref();
             let human = format!(
-                "{}\nLattice: {}\n",
-                response_human(&request, &response, output),
-                recording.human()
+                "{}\nLattice: {lattice_human}\n",
+                response_human(request, &response, output),
             );
-            let mut json = response_json(&request, &response, output);
-            json["lattice"] = recording.json();
+            let mut json = response_json(request, &response, output);
+            json["lattice"] = lattice_json;
             let mut command = CommandOutput::new(human, json);
-            if let Some(warning) = recording.warning() {
+            for warning in warnings {
                 command = command.warn(warning);
             }
             Ok(command)
         }
         Err(error) => {
-            Err(FacetError::http(&error).with_details(json!({ "lattice": recording.json() })))
+            Err(FacetError::http(&error).with_details(json!({ "lattice": lattice_json })))
         }
     }
 }
 
 /// Mirrors `probe-cli`'s selection and interpolation rules.
-fn selected_request<'a>(
+pub(crate) fn selected_request<'a>(
     loaded: &'a LoadedWorkspace,
     selector: &str,
     environment: Option<&str>,

--- a/crates/facet/tests/common/mod.rs
+++ b/crates/facet/tests/common/mod.rs
@@ -120,6 +120,20 @@ impl Sandbox {
         (exit_code, value)
     }
 
+    /// Rewrites `duration_ms` for one run so `diff` output is deterministic.
+    pub(crate) fn set_duration_ms(&self, run_id: &str, duration_ms: i64) {
+        let db = std::path::absolute(self.root().join(".facet/lattice.db"))
+            .expect("workspace store path");
+        let conn = rusqlite::Connection::open(&db).expect("open workspace store");
+        let updated = conn
+            .execute(
+                "UPDATE runs SET duration_ms = ?1 WHERE id = ?2",
+                rusqlite::params![duration_ms, run_id],
+            )
+            .expect("set duration");
+        assert_eq!(updated, 1, "set duration for one run");
+    }
+
     /// Rewrites `started_at` for one run in the workspace store (test helper).
     pub(crate) fn backdate_run(&self, run_id: &str, started_at_ms: i64) {
         let db = std::path::absolute(self.root().join(".facet/lattice.db"))
@@ -143,7 +157,18 @@ pub(crate) fn fixture(path: &str) -> PathBuf {
 }
 
 pub(crate) fn serve_once(body: Vec<u8>, content_type: &str) -> (String, JoinHandle<Vec<u8>>) {
-    let listener = TcpListener::bind("127.0.0.1:0").expect("mock server should bind");
+    serve_once_at("127.0.0.1:0", body, content_type)
+}
+
+/// Serves one request again on the address a previous [`serve_once`] used,
+/// so a replay resolves to the identical URL (and request hash).
+pub(crate) fn serve_again(url: &str, body: Vec<u8>) -> JoinHandle<Vec<u8>> {
+    let address = url.trim_start_matches("http://");
+    serve_once_at(address, body, "application/json").1
+}
+
+fn serve_once_at(bind: &str, body: Vec<u8>, content_type: &str) -> (String, JoinHandle<Vec<u8>>) {
+    let listener = TcpListener::bind(bind).expect("mock server should bind");
     let address = listener.local_addr().unwrap();
     let content_type = content_type.to_owned();
     let handle = thread::spawn(move || {
@@ -202,13 +227,24 @@ pub(crate) fn normalize(value: Value) -> Value {
                     let replaced = match key.as_str() {
                         "version" | "probeVersion" => json!("<version>"),
                         "id" | "runId" | "workspaceId" => json!("<ulid>"),
-                        "sessionId" if value.is_string() => json!("<ulid>"),
+                        "sessionId" | "replayedFrom" if value.is_string() => json!("<ulid>"),
                         "startedAt" | "durationMs" => json!("<int>"),
                         "endedAt" if value.is_number() => json!("<int>"),
-                        "requestHash" => json!("<sha256>"),
+                        "requestHash" | "recordedHash" | "currentHash" => json!("<sha256>"),
                         "hash" if value.is_string() => json!("<sha256>"),
-                        "path" | "outputPath" | "cwd" if value.is_string() => json!("<path>"),
+                        "path" | "outputPath" | "cwd" | "workspacePath" if value.is_string() => {
+                            json!("<path>")
+                        }
                         "url" if value.is_string() => json!("<url>"),
+                        // `diff` change rows and hash pairs: `{ "a": …, "b": … }`.
+                        "a" | "b" if is_sha256(&value) => json!("<sha256>"),
+                        "a" | "b"
+                            if value
+                                .as_str()
+                                .is_some_and(|text| text.starts_with("http://")) =>
+                        {
+                            json!("<url>")
+                        }
                         _ => normalize(value),
                     };
                     (key, replaced)
@@ -218,6 +254,12 @@ pub(crate) fn normalize(value: Value) -> Value {
         Value::Array(items) => Value::Array(items.into_iter().map(normalize).collect()),
         other => other,
     }
+}
+
+fn is_sha256(value: &Value) -> bool {
+    value
+        .as_str()
+        .is_some_and(|text| text.len() == 64 && text.bytes().all(|byte| byte.is_ascii_hexdigit()))
 }
 
 /// Pretty JSON with sorted keys regardless of serde_json's map feature.

--- a/crates/facet/tests/facet_commands.rs
+++ b/crates/facet/tests/facet_commands.rs
@@ -13,6 +13,22 @@ fn record_one_run(sandbox: &Sandbox, extra: &[&str]) -> Value {
     record_run_with(sandbox, &[], extra)
 }
 
+/// A run whose mock server answers with `body` instead of [`ECHO_BODY`].
+fn record_run_body(sandbox: &Sandbox, body: &[u8]) -> Value {
+    let (url, server) = serve_once(body.to_vec(), "application/json");
+    let workspace = sandbox.workspace(&url);
+    let value = sandbox.run_json(&[
+        "request",
+        "run",
+        workspace.to_str().unwrap(),
+        "items/0",
+        "--environment",
+        "local",
+    ]);
+    server.join().unwrap();
+    value
+}
+
 /// `request run … --json` against a one-shot echo server, with extra
 /// environment variables (`FACET_SESSION`, `FACET_ACTOR`) as a harness sets them.
 fn record_run_with(sandbox: &Sandbox, env: &[(&str, &str)], extra: &[&str]) -> Value {
@@ -761,4 +777,293 @@ fn history_environment_tag_and_hash_filters() {
         run_count(&sandbox, &["history", root, "--hash", &"0".repeat(64)]),
         0
     );
+}
+
+#[test]
+fn replay_uses_current_yaml_and_records_lineage() {
+    let sandbox = Sandbox::new();
+    let (url, server) = serve_once(ECHO_BODY.to_vec(), "application/json");
+    let workspace = sandbox.workspace(&url);
+    let ws = workspace.to_str().unwrap();
+    let original = sandbox.run_json(&[
+        "request",
+        "run",
+        ws,
+        "items/0",
+        "--environment",
+        "local",
+        "--tag",
+        "smoke",
+    ]);
+    server.join().unwrap();
+    let run_id = original["lattice"]["runId"].as_str().unwrap().to_owned();
+
+    // Same URL live again: the current YAML resolves to the recorded hash.
+    let again = serve_again(&url, ECHO_BODY.to_vec());
+    let replayed = sandbox.run_json(&["replay", &run_id, ws, "--tag", "again"]);
+    assert_eq!(again.join().unwrap(), br#"{"source":"cli"}"#);
+    assert_eq!(replayed["response"]["status"], 200);
+    assert_eq!(replayed["lattice"]["recorded"], true);
+    assert_eq!(replayed["lattice"]["replayedFrom"], run_id);
+    assert_eq!(replayed["lattice"]["hashChanged"], false);
+    assert_eq!(
+        replayed["lattice"]["requestHash"],
+        original["lattice"]["requestHash"]
+    );
+    assert_golden("replay.json", &normalize(replayed.clone()));
+    let replay_id = replayed["lattice"]["runId"].as_str().unwrap().to_owned();
+
+    let row = sandbox.run_json(&["history", ws, "--id", &replay_id]);
+    assert_eq!(row["run"]["replayedFrom"], run_id);
+    assert_eq!(row["run"]["tags"], json!(["smoke", "again"]));
+    assert_eq!(row["run"]["varNames"], json!([]));
+    assert_eq!(row["run"]["environment"], "local");
+    let source = sandbox.run_json(&["history", ws, "--id", &run_id]);
+    assert!(source["run"]["replayedFrom"].is_null());
+    let lineage = sandbox.run_json(&[
+        "history",
+        ws,
+        "--sql",
+        &format!("SELECT count(*) FROM runs WHERE replayed_from = '{run_id}'"),
+    ]);
+    assert_eq!(lineage["rows"][0][0], 1);
+
+    // Human mode names the lineage.
+    let human = sandbox
+        .facet()
+        .args(["replay", &run_id, ws, "--no-record"])
+        .output();
+    // (no server: transport failure is fine, we only care that it parsed)
+    assert!(human.is_ok());
+
+    // A changed request: --var moves the URL, so the hash differs. --frozen
+    // refuses before any network and writes no row.
+    let (moved_url, moved) = serve_once(ECHO_BODY.to_vec(), "application/json");
+    let var = format!("serverUrl={moved_url}");
+    let before = run_count(&sandbox, &["history", ws]);
+    let (code, error) = sandbox.run_error_json(&["replay", &run_id, ws, "--var", &var, "--frozen"]);
+    assert_eq!(code, 1);
+    assert_eq!(error["error"]["category"], "replay_changed");
+    assert_eq!(error["error"]["details"]["replayedFrom"], run_id);
+    assert_ne!(
+        error["error"]["details"]["recordedHash"],
+        error["error"]["details"]["currentHash"]
+    );
+    assert_golden("error_replay_changed.json", &normalize_error(error));
+    assert_eq!(
+        run_count(&sandbox, &["history", ws]),
+        before,
+        "no row on refuse"
+    );
+
+    // Without --frozen it sends, warns, and records varNames (names only).
+    let output = sandbox
+        .facet()
+        .args(["replay", &run_id, ws, "--var", &var, "--json"])
+        .output()
+        .unwrap();
+    moved.join().unwrap();
+    assert!(
+        output.status.success(),
+        "{}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("warning: request changed since"),
+        "{stderr}"
+    );
+    let changed: Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(changed["lattice"]["hashChanged"], true);
+    assert_eq!(changed["lattice"]["replayedFrom"], run_id);
+    let changed_id = changed["lattice"]["runId"].as_str().unwrap().to_owned();
+    let changed_row = sandbox.run_json(&["history", ws, "--id", &changed_id]);
+    assert_eq!(changed_row["run"]["varNames"], json!(["serverUrl"]));
+    let dump = sandbox.run_json(&["history", ws, "--sql", "SELECT var_names FROM runs"]);
+    let text = dump.to_string();
+    assert!(
+        !text.contains(&moved_url),
+        "--var values must never persist"
+    );
+
+    // Replaying the changed run without its --var warns about the names.
+    let again = serve_again(&url, ECHO_BODY.to_vec());
+    let output = sandbox
+        .facet()
+        .args(["replay", &changed_id, ws, "--json"])
+        .output()
+        .unwrap();
+    again.join().unwrap();
+    assert!(output.status.success());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("was recorded with --var serverUrl"),
+        "{stderr}"
+    );
+    assert!(stderr.contains("request changed since"), "{stderr}");
+
+    // Unknown run, and a run that lives in another workspace (breadcrumb).
+    let (code, error) = sandbox.run_error_json(&["replay", UNKNOWN_ULID, ws]);
+    assert_eq!(code, 4);
+    assert_eq!(error["error"]["category"], "run_not_found");
+    assert!(error["error"].get("details").is_none());
+    let other_dir = sandbox.root().join("other");
+    fs::create_dir_all(&other_dir).unwrap();
+    let source = fs::read_to_string(fixture("phase5-http.yml")).unwrap();
+    let other_ws = other_dir.join("workspace.yml");
+    let (other_url, other_server) = serve_once(ECHO_BODY.to_vec(), "application/json");
+    fs::write(&other_ws, source.replace("__SERVER_URL__", &other_url)).unwrap();
+    let other_run = sandbox.run_json(&[
+        "request",
+        "run",
+        other_ws.to_str().unwrap(),
+        "items/0",
+        "--environment",
+        "local",
+    ]);
+    other_server.join().unwrap();
+    let other_id = other_run["lattice"]["runId"].as_str().unwrap();
+    let (code, error) = sandbox.run_error_json(&["replay", other_id, ws]);
+    assert_eq!(code, 4);
+    assert_eq!(
+        error["error"]["details"]["workspaceId"],
+        other_run["lattice"]["workspaceId"]
+    );
+    assert_golden("error_replay_run_elsewhere.json", &normalize_error(error));
+
+    // No store beside the collection at all.
+    let empty = Sandbox::new();
+    let empty_ws = empty.workspace("http://127.0.0.1:9");
+    let (code, error) = empty.run_error_json(&["replay", &run_id, empty_ws.to_str().unwrap()]);
+    assert_eq!(code, 9);
+    assert_eq!(error["error"]["category"], "lattice_not_found");
+    let (code, _) = sandbox.run_error_json(&["replay"]);
+    assert_eq!(code, 2);
+}
+
+#[test]
+fn diff_is_hash_first_and_exit_1_when_different() {
+    let sandbox = Sandbox::new();
+    let (url, server) = serve_once(ECHO_BODY.to_vec(), "application/json");
+    let workspace = sandbox.workspace(&url);
+    let ws = workspace.to_str().unwrap();
+    let a = sandbox.run_json(&["request", "run", ws, "items/0", "--environment", "local"]);
+    server.join().unwrap();
+    let id_a = a["lattice"]["runId"].as_str().unwrap().to_owned();
+    let again = serve_again(&url, ECHO_BODY.to_vec());
+    let b = sandbox.run_json(&["replay", &id_a, ws, "--tag", "retry"]);
+    again.join().unwrap();
+    let id_b = b["lattice"]["runId"].as_str().unwrap().to_owned();
+    sandbox.set_duration_ms(&id_a, 10);
+    sandbox.set_duration_ms(&id_b, 20);
+
+    // Same request, same bytes: equal, even though duration and tags
+    // (provenance) differ; both are still reported.
+    let equal = sandbox.run_json(&["diff", &id_a, &id_b, ws]);
+    assert_eq!(equal["equal"], true);
+    assert_eq!(
+        equal["changes"],
+        json!([
+            { "field": "durationMs", "a": 10, "b": 20 },
+            { "field": "tags", "a": [], "b": ["retry"] },
+        ])
+    );
+    assert_eq!(equal["request"]["hash"]["equal"], true);
+    assert_eq!(equal["request"]["body"]["equal"], true);
+    assert_eq!(equal["response"]["body"]["equal"], true);
+    assert_eq!(equal["response"]["body"]["a"]["retention"], "inline");
+    assert!(
+        equal["response"]["body"]["a"]["hash"].is_string(),
+        "inline bodies are hashed"
+    );
+    assert_golden("diff_equal.json", &normalize(equal));
+    let status = sandbox
+        .facet()
+        .args(["diff", &id_a, &id_b, ws])
+        .output()
+        .unwrap();
+    assert_eq!(status.status.code(), Some(0));
+    assert!(String::from_utf8_lossy(&status.stdout).contains("response body: equal"));
+
+    // A different response (and a different port, so url + requestHash move).
+    let c = record_run_body(&sandbox, br#"{"users":[1]}"#);
+    let id_c = c["lattice"]["runId"].as_str().unwrap().to_owned();
+    sandbox.set_duration_ms(&id_c, 30);
+    let output = sandbox
+        .facet()
+        .args(["diff", &id_a, &id_c, ws, "--bodies", "--json"])
+        .output()
+        .unwrap();
+    assert_eq!(output.status.code(), Some(1));
+    let changed: Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(changed["equal"], false);
+    let fields: Vec<&str> = changed["changes"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|change| change["field"].as_str().unwrap())
+        .collect();
+    assert!(
+        fields.contains(&"url") && fields.contains(&"requestHash"),
+        "{fields:?}"
+    );
+    assert!(
+        fields.contains(&"response.headers"),
+        "content-length moved: {fields:?}"
+    );
+    assert!(!fields.contains(&"status"));
+    assert_eq!(changed["request"]["hash"]["equal"], false);
+    assert_eq!(
+        changed["request"]["body"]["equal"], true,
+        "same request body blob"
+    );
+    assert_eq!(changed["response"]["body"]["equal"], false);
+    let text = changed["response"]["body"]["text"]
+        .as_str()
+        .expect("unified diff");
+    assert!(text.starts_with("--- a\n+++ b\n@@ "), "{text}");
+    assert!(
+        text.contains("-{\"users\":[]}\n+{\"users\":[1]}\n"),
+        "{text}"
+    );
+    assert_golden("diff_changed.json", &normalize(changed));
+
+    // Without --bodies there is no text; the human view still says differs.
+    let terse = sandbox
+        .facet()
+        .args(["diff", &id_a, &id_c, ws, "--json"])
+        .output()
+        .unwrap();
+    assert_eq!(terse.status.code(), Some(1));
+    let terse: Value = serde_json::from_slice(&terse.stdout).unwrap();
+    assert!(terse["response"]["body"]["text"].is_null());
+    let human = sandbox
+        .facet()
+        .args(["diff", &id_a, &id_c, ws])
+        .output()
+        .unwrap();
+    assert_eq!(human.status.code(), Some(1));
+    let text = String::from_utf8_lossy(&human.stdout);
+    assert!(text.contains("response body: differs"), "{text}");
+    let quiet = sandbox
+        .facet()
+        .args(["diff", &id_a, &id_c, ws, "--quiet"])
+        .output()
+        .unwrap();
+    assert_eq!(quiet.status.code(), Some(1));
+    assert!(quiet.stdout.is_empty());
+
+    // Missing runs are exit 4 with the ids listed; no store is exit 9.
+    let (code, error) = sandbox.run_error_json(&["diff", &id_a, UNKNOWN_ULID, ws]);
+    assert_eq!(code, 4);
+    assert_eq!(error["error"]["category"], "run_not_found");
+    assert_eq!(error["error"]["details"]["missing"], json!([UNKNOWN_ULID]));
+    assert_golden("error_diff_run_not_found.json", &normalize_error(error));
+    let empty = Sandbox::new();
+    let (code, error) =
+        empty.run_error_json(&["diff", &id_a, &id_b, empty.root().to_str().unwrap()]);
+    assert_eq!(code, 9);
+    assert_eq!(error["error"]["category"], "lattice_not_found");
+    let (code, _) = sandbox.run_error_json(&["diff", &id_a]);
+    assert_eq!(code, 2);
 }

--- a/crates/facet/tests/golden/diff_changed.json
+++ b/crates/facet/tests/golden/diff_changed.json
@@ -1,0 +1,87 @@
+{
+  "a": {
+    "id": "<ulid>",
+    "startedAt": "<int>",
+    "status": 200
+  },
+  "b": {
+    "id": "<ulid>",
+    "startedAt": "<int>",
+    "status": 200
+  },
+  "changes": [
+    {
+      "a": "<url>",
+      "b": "<url>",
+      "field": "url"
+    },
+    {
+      "a": 10,
+      "b": 30,
+      "field": "durationMs"
+    },
+    {
+      "a": "<sha256>",
+      "b": "<sha256>",
+      "field": "requestHash"
+    },
+    {
+      "a": [
+        "connection: close",
+        "content-length: 12",
+        "content-type: application/json"
+      ],
+      "b": [
+        "connection: close",
+        "content-length: 13",
+        "content-type: application/json"
+      ],
+      "field": "response.headers"
+    }
+  ],
+  "equal": false,
+  "request": {
+    "body": {
+      "a": {
+        "hash": "<sha256>",
+        "retention": "blob",
+        "sizeBytes": 16
+      },
+      "b": {
+        "hash": "<sha256>",
+        "retention": "blob",
+        "sizeBytes": 16
+      },
+      "equal": true,
+      "omissionReason": null,
+      "text": null
+    },
+    "hash": {
+      "a": "<sha256>",
+      "b": "<sha256>",
+      "equal": false
+    }
+  },
+  "response": {
+    "body": {
+      "a": {
+        "hash": "<sha256>",
+        "retention": "inline",
+        "sizeBytes": 12
+      },
+      "b": {
+        "hash": "<sha256>",
+        "retention": "inline",
+        "sizeBytes": 13
+      },
+      "equal": false,
+      "omissionReason": null,
+      "text": "--- a\n+++ b\n@@ -1,1 +1,1 @@\n-{\"users\":[]}\n+{\"users\":[1]}\n"
+    }
+  },
+  "schemaVersion": 1,
+  "workspace": {
+    "id": "<ulid>",
+    "path": "<path>"
+  }
+}

--- a/crates/facet/tests/golden/diff_equal.json
+++ b/crates/facet/tests/golden/diff_equal.json
@@ -1,0 +1,71 @@
+{
+  "a": {
+    "id": "<ulid>",
+    "startedAt": "<int>",
+    "status": 200
+  },
+  "b": {
+    "id": "<ulid>",
+    "startedAt": "<int>",
+    "status": 200
+  },
+  "changes": [
+    {
+      "a": 10,
+      "b": 20,
+      "field": "durationMs"
+    },
+    {
+      "a": [],
+      "b": [
+        "retry"
+      ],
+      "field": "tags"
+    }
+  ],
+  "equal": true,
+  "request": {
+    "body": {
+      "a": {
+        "hash": "<sha256>",
+        "retention": "blob",
+        "sizeBytes": 16
+      },
+      "b": {
+        "hash": "<sha256>",
+        "retention": "blob",
+        "sizeBytes": 16
+      },
+      "equal": true,
+      "omissionReason": null,
+      "text": null
+    },
+    "hash": {
+      "a": "<sha256>",
+      "b": "<sha256>",
+      "equal": true
+    }
+  },
+  "response": {
+    "body": {
+      "a": {
+        "hash": "<sha256>",
+        "retention": "inline",
+        "sizeBytes": 12
+      },
+      "b": {
+        "hash": "<sha256>",
+        "retention": "inline",
+        "sizeBytes": 12
+      },
+      "equal": true,
+      "omissionReason": null,
+      "text": null
+    }
+  },
+  "schemaVersion": 1,
+  "workspace": {
+    "id": "<ulid>",
+    "path": "<path>"
+  }
+}

--- a/crates/facet/tests/golden/error_diff_run_not_found.json
+++ b/crates/facet/tests/golden/error_diff_run_not_found.json
@@ -1,0 +1,13 @@
+{
+  "error": {
+    "category": "run_not_found",
+    "details": {
+      "missing": [
+        "01ARZ3NDEKTSV4RRFFQ69G5FAV"
+      ]
+    },
+    "exitCode": 4,
+    "message": "<message>"
+  },
+  "schemaVersion": 1
+}

--- a/crates/facet/tests/golden/error_replay_changed.json
+++ b/crates/facet/tests/golden/error_replay_changed.json
@@ -1,0 +1,13 @@
+{
+  "error": {
+    "category": "replay_changed",
+    "details": {
+      "currentHash": "<sha256>",
+      "recordedHash": "<sha256>",
+      "replayedFrom": "<ulid>"
+    },
+    "exitCode": 1,
+    "message": "<message>"
+  },
+  "schemaVersion": 1
+}

--- a/crates/facet/tests/golden/error_replay_run_elsewhere.json
+++ b/crates/facet/tests/golden/error_replay_run_elsewhere.json
@@ -1,0 +1,12 @@
+{
+  "error": {
+    "category": "run_not_found",
+    "details": {
+      "workspaceId": "<ulid>",
+      "workspacePath": "<path>"
+    },
+    "exitCode": 4,
+    "message": "<message>"
+  },
+  "schemaVersion": 1
+}

--- a/crates/facet/tests/golden/history.json
+++ b/crates/facet/tests/golden/history.json
@@ -7,6 +7,7 @@
       "error": null,
       "id": "<ulid>",
       "method": "POST",
+      "replayedFrom": null,
       "request": {
         "body": {
           "hash": "<sha256>",
@@ -49,7 +50,8 @@
       "startedAt": "<int>",
       "status": 200,
       "tags": [],
-      "url": "<url>"
+      "url": "<url>",
+      "varNames": []
     }
   ],
   "schemaVersion": 1,

--- a/crates/facet/tests/golden/history_bodies.json
+++ b/crates/facet/tests/golden/history_bodies.json
@@ -7,6 +7,7 @@
       "error": null,
       "id": "<ulid>",
       "method": "POST",
+      "replayedFrom": null,
       "request": {
         "body": {
           "content": null,
@@ -57,7 +58,8 @@
       "startedAt": "<int>",
       "status": 200,
       "tags": [],
-      "url": "<url>"
+      "url": "<url>",
+      "varNames": []
     }
   ],
   "schemaVersion": 1,

--- a/crates/facet/tests/golden/history_id.json
+++ b/crates/facet/tests/golden/history_id.json
@@ -6,6 +6,7 @@
     "error": null,
     "id": "<ulid>",
     "method": "POST",
+    "replayedFrom": null,
     "request": {
       "body": {
         "hash": "<sha256>",
@@ -48,7 +49,8 @@
     "startedAt": "<int>",
     "status": 200,
     "tags": [],
-    "url": "<url>"
+    "url": "<url>",
+    "varNames": []
   },
   "schemaVersion": 1,
   "workspace": {

--- a/crates/facet/tests/golden/history_session.json
+++ b/crates/facet/tests/golden/history_session.json
@@ -7,6 +7,7 @@
       "error": null,
       "id": "<ulid>",
       "method": "POST",
+      "replayedFrom": null,
       "request": {
         "body": {
           "hash": "<sha256>",
@@ -51,7 +52,8 @@
       "tags": [
         "smoke"
       ],
-      "url": "<url>"
+      "url": "<url>",
+      "varNames": []
     },
     {
       "actor": "human",
@@ -60,6 +62,7 @@
       "error": null,
       "id": "<ulid>",
       "method": "POST",
+      "replayedFrom": null,
       "request": {
         "body": {
           "hash": "<sha256>",
@@ -102,7 +105,8 @@
       "startedAt": "<int>",
       "status": 200,
       "tags": [],
-      "url": "<url>"
+      "url": "<url>",
+      "varNames": []
     }
   ],
   "schemaVersion": 1,

--- a/crates/facet/tests/golden/history_tag_hash.json
+++ b/crates/facet/tests/golden/history_tag_hash.json
@@ -8,6 +8,7 @@
       "id": "<ulid>",
       "matchedHash": "responseBody",
       "method": "POST",
+      "replayedFrom": null,
       "request": {
         "body": {
           "hash": "<sha256>",
@@ -53,7 +54,8 @@
         "smoke",
         "golden"
       ],
-      "url": "<url>"
+      "url": "<url>",
+      "varNames": []
     }
   ],
   "schemaVersion": 1,

--- a/crates/facet/tests/golden/replay.json
+++ b/crates/facet/tests/golden/replay.json
@@ -1,0 +1,49 @@
+{
+  "lattice": {
+    "hashChanged": false,
+    "indexed": true,
+    "recorded": true,
+    "replayedFrom": "<ulid>",
+    "requestHash": "<sha256>",
+    "responseBody": {
+      "hash": null,
+      "retention": "inline",
+      "sizeBytes": 12
+    },
+    "runId": "<ulid>",
+    "workspaceId": "<ulid>"
+  },
+  "request": {
+    "method": "POST",
+    "url": "<url>"
+  },
+  "response": {
+    "body": {
+      "content": "{\"users\":[]}",
+      "encoding": "utf8",
+      "omissionReason": null,
+      "omitted": false,
+      "outputPath": null
+    },
+    "durationMs": "<int>",
+    "headers": [
+      {
+        "name": "connection",
+        "value": "close"
+      },
+      {
+        "name": "content-length",
+        "value": "12"
+      },
+      {
+        "name": "content-type",
+        "value": "application/json"
+      }
+    ],
+    "reason": "OK",
+    "sizeBytes": 12,
+    "status": 200,
+    "url": "<url>"
+  },
+  "schemaVersion": 1
+}

--- a/crates/lattice/migrations/workspace/0003_replay_lineage.sql
+++ b/crates/lattice/migrations/workspace/0003_replay_lineage.sql
@@ -1,0 +1,17 @@
+-- Lattice workspace store, migration 0003.
+-- Source of truth: fullstack deep dive 2026-09-07 §5.2 (Goal 4, replay + diff).
+--
+-- replayed_from: runs.id of the run this one replayed, NULL otherwise.
+-- var_names:     JSON array of the --var NAMES passed at resolve time. Names
+--                only; values never persist anywhere in Lattice.
+--
+-- Reader rule for rows recorded before this migration:
+--   replayed_from IS NULL -> not a replay
+--   var_names IS NULL     -> unknown (pre-0003), distinct from '[]' = none
+--
+-- Git HEAD does not get a column (auto-tag later, if ever).
+
+ALTER TABLE runs ADD COLUMN replayed_from TEXT;
+ALTER TABLE runs ADD COLUMN var_names TEXT;
+CREATE INDEX runs_replayed_from ON runs(replayed_from);
+INSERT INTO schema_version VALUES (3, strftime('%s','now') * 1000);

--- a/crates/lattice/src/lib.rs
+++ b/crates/lattice/src/lib.rs
@@ -50,7 +50,7 @@ pub use store::{
 pub use ulid::{is_ulid, ulid};
 
 /// Current workspace-store schema version (highest numbered migration).
-pub const WORKSPACE_SCHEMA_VERSION: i64 = 2;
+pub const WORKSPACE_SCHEMA_VERSION: i64 = 3;
 /// Current machine-store schema version (highest numbered migration).
 pub const MACHINE_SCHEMA_VERSION: i64 = 2;
 

--- a/crates/lattice/src/machine.rs
+++ b/crates/lattice/src/machine.rs
@@ -171,6 +171,23 @@ impl MachineStore {
         Ok(rows)
     }
 
+    /// The workspace (`id`, last known path) the index knows a run under,
+    /// or `None`. One query; `facet replay` uses it as a breadcrumb when a
+    /// run id belongs to another workspace.
+    pub fn indexed_run(&self, run_id: &str) -> Result<Option<(String, String)>, LatticeError> {
+        match self.conn.query_row(
+            "SELECT run_index.workspace_id, coalesce(workspaces.path, '') FROM run_index \
+             LEFT JOIN workspaces ON workspaces.id = run_index.workspace_id \
+             WHERE run_index.run_id = ?1",
+            params![run_id],
+            |row| Ok((row.get(0)?, row.get(1)?)),
+        ) {
+            Ok(pair) => Ok(Some(pair)),
+            Err(rusqlite::Error::QueryReturnedNoRows) => Ok(None),
+            Err(other) => Err(other.into()),
+        }
+    }
+
     /// Total pointer rows.
     pub fn count_indexed_runs(&self) -> Result<i64, LatticeError> {
         Ok(self

--- a/crates/lattice/src/store.rs
+++ b/crates/lattice/src/store.rs
@@ -31,6 +31,7 @@ pub const CONFIG_FILE: &str = "config.toml";
 const WORKSPACE_MIGRATIONS: &[&str] = &[
     include_str!("../migrations/workspace/0001_init.sql"),
     include_str!("../migrations/workspace/0002_hash_only_req.sql"),
+    include_str!("../migrations/workspace/0003_replay_lineage.sql"),
 ];
 
 const GITIGNORE: &str = "# Lattice run history is machine-local. workspace.toml and config.toml are shared.\n\
@@ -42,7 +43,8 @@ blobs/\n";
 
 const RUN_COLUMNS: &str = "id, started_at, duration_ms, request_path, request_hash, environment, method, url, \
 status, error, req_headers, res_headers, req_body_len, req_body_hash, \
-res_body_len, res_body_hash, res_body IS NOT NULL, res_content_type, session_id, actor, tags";
+res_body_len, res_body_hash, res_body IS NOT NULL, res_content_type, session_id, actor, tags, \
+replayed_from, var_names";
 
 #[derive(Debug, Deserialize)]
 struct WorkspaceFile {
@@ -114,6 +116,12 @@ pub struct RunRow {
     pub actor: String,
     /// JSON array of tags.
     pub tags: Option<String>,
+    /// `runs.id` this run replayed, when it came from `facet replay`.
+    pub replayed_from: Option<String>,
+    /// JSON array of `--var` names used at resolve time (never values).
+    /// `None` on rows recorded before migration 0003 (unknown); `[]` when
+    /// no overrides were passed.
+    pub var_names: Option<String>,
 }
 
 /// A run to record.
@@ -153,6 +161,10 @@ pub struct NewRun<'a> {
     pub actor: &'a str,
     /// JSON array of tags.
     pub tags: Option<&'a str>,
+    /// `runs.id` this run replayed, if any.
+    pub replayed_from: Option<&'a str>,
+    /// JSON array of `--var` names (never values); `[]` when none.
+    pub var_names: Option<&'a str>,
 }
 
 impl Default for NewRun<'_> {
@@ -175,6 +187,8 @@ impl Default for NewRun<'_> {
             session_id: None,
             actor: "human",
             tags: None,
+            replayed_from: None,
+            var_names: None,
         }
     }
 }
@@ -365,8 +379,10 @@ impl WorkspaceStore {
         tx.execute(
             "INSERT INTO runs (id, started_at, duration_ms, request_path, request_hash, environment, method, url, \
              status, error, req_headers, res_headers, req_body_len, req_body_hash, \
-             res_body_len, res_body, res_body_hash, res_content_type, session_id, actor, tags) \
-             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16, ?17, ?18, ?19, ?20, ?21)",
+             res_body_len, res_body, res_body_hash, res_content_type, session_id, actor, tags, \
+             replayed_from, var_names) \
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16, ?17, ?18, ?19, ?20, ?21, \
+             ?22, ?23)",
             params![
                 id,
                 run.started_at,
@@ -389,6 +405,8 @@ impl WorkspaceStore {
                 run.session_id,
                 run.actor,
                 run.tags,
+                run.replayed_from,
+                run.var_names,
             ],
         )?;
         tx.commit()?;
@@ -691,6 +709,8 @@ fn row_to_run(row: &rusqlite::Row<'_>) -> rusqlite::Result<RunRow> {
         session_id: row.get(18)?,
         actor: row.get(19)?,
         tags: row.get(20)?,
+        replayed_from: row.get(21)?,
+        var_names: row.get(22)?,
     })
 }
 

--- a/crates/lattice/tests/store.rs
+++ b/crates/lattice/tests/store.rs
@@ -946,3 +946,49 @@ fn history_filters_by_session_environment_tag_and_hash() {
 
     let _ = other_session;
 }
+
+#[test]
+fn replay_lineage_columns_round_trip() {
+    let dir = tempfile::tempdir().unwrap();
+    let store = WorkspaceStore::open(dir.path(), config(1024)).unwrap();
+    assert_eq!(store.schema_version().unwrap(), 3);
+    let plain = store.record_run(&run("a.yml", b"x")).unwrap();
+    assert!(plain.replayed_from.is_none());
+    assert!(
+        plain.var_names.is_none(),
+        "NewRun default leaves var_names unknown"
+    );
+    let replayed = store
+        .record_run(&NewRun {
+            replayed_from: Some(&plain.id),
+            var_names: Some(r#"["token"]"#),
+            ..run("a.yml", b"x")
+        })
+        .unwrap();
+    assert_eq!(replayed.replayed_from.as_deref(), Some(plain.id.as_str()));
+    assert_eq!(replayed.var_names.as_deref(), Some(r#"["token"]"#));
+    let lineage = store
+        .query(&format!(
+            "SELECT id FROM runs WHERE replayed_from = '{}'",
+            plain.id
+        ))
+        .unwrap();
+    assert_eq!(lineage.rows.len(), 1);
+    assert_eq!(lineage.rows[0][0], SqlValue::Text(replayed.id.clone()));
+}
+
+#[test]
+fn machine_index_answers_which_workspace_holds_a_run() {
+    let dir = tempfile::tempdir().unwrap();
+    let store = WorkspaceStore::open(dir.path(), config(1024)).unwrap();
+    let machine = MachineStore::open_at(&dir.path().join("machine.db"), store.config()).unwrap();
+    let row = store.record_run(&run("a.yml", b"x")).unwrap();
+    assert_eq!(machine.indexed_run(&row.id).unwrap(), None);
+    machine
+        .touch_workspace(store.workspace_id(), store.root(), None, now_ms())
+        .unwrap();
+    machine.index_run(&row, store.workspace_id()).unwrap();
+    let (workspace_id, path) = machine.indexed_run(&row.id).unwrap().expect("indexed");
+    assert_eq!(workspace_id, store.workspace_id());
+    assert_eq!(path, store.root().to_string_lossy());
+}

--- a/docs/FACET.md
+++ b/docs/FACET.md
@@ -249,6 +249,8 @@ facet session start [--actor <name>] [--meta <json>] [--json]
 facet session end [<id>|current] [--json]
 facet session list [--limit <n>] [--actor <name>] [--open] [--json]
 facet session show <id>|current [--json]
+facet replay <runId> [<path>] [--frozen] [--environment <name>] [--var k=v]... [--tag <tag>]... [--strict-variables] [--no-record] [--json]
+facet diff <idA> <idB> [<path>] [--bodies] [--json]
 facet blob <hash> [<path>] [--output <file>] [--json]
 facet gc [<path>] [--history-retention <r>] [--yes] [--json]
 facet tui [<path>] [--appearance graphite|porcelain]
@@ -341,6 +343,11 @@ any filter or with `--sql` (`invalid_arguments`, exit 2). An unknown id, or
 no store at all, is `run_not_found` (exit 4). This is the seam replay and
 diff stand on: an agent keeps run ids, not bodies.
 
+Rows carry two lineage fields from migration 0003: `replayedFrom` (the run
+this one replayed, else `null`) and `varNames` (the `--var` names used at
+resolve time, never values; `[]` when none, `null` on rows recorded before
+0003, meaning unknown).
+
 ### `history --sql`
 
 Runs one read-only statement against the workspace store on a read-only
@@ -390,6 +397,72 @@ created (a harness invented the id), the first recorded run inserts the row
 with that run's actor and no `meta`. Later runs never rewrite it. This is
 best effort like machine-store indexing and never fails the run.
 
+### `replay`
+
+Re-sends a recorded run. **Replay truth is the current YAML plus the recorded
+environment**: the row supplies the selector and environment name (`--environment`
+overrides), the collection at `<path>` (file or directory, default `.`, as for
+`request run`) supplies the request, and the Lattice store is discovered by
+walking up from it. Values passed with `--var` are never stored, so recorded
+`--var` names are a warning (`run … was recorded with --var token; pass them
+again`), never replayed.
+
+The resolved request is hashed before any network. When it differs from the
+recorded `requestHash`: without `--frozen` the run executes with a stderr
+warning and `lattice.hashChanged: true`; with `--frozen` it is refused with
+`replay_changed` (exit **1**), no network, no row, and
+`details.{replayedFrom, recordedHash, currentHash}`. There is no
+"send stored bytes" mode: stored headers are redacted, auth enters the hash by
+scheme only, and request bodies are blobs that may hold secrets.
+
+The output is `request run`'s document; `lattice` gains two fields:
+
+```json
+"lattice": { "recorded": true, "runId": "01K…", "…": "…", "replayedFrom": "01J…", "hashChanged": false }
+```
+
+The new row carries the recorded tags plus `--tag`, `replayedFrom`, and the
+`--var` names. Unknown run id: `run_not_found` (exit 4), with
+`details.workspaceId` / `workspacePath` when the machine index knows the run
+under another workspace. A selector no longer in the YAML is upstream's
+`request_not_found` (exit 4) with `details.replayedFrom`. No store: `lattice_not_found` (exit 9).
+
+### `diff`
+
+Hash-first comparison of two recorded runs. Metadata compares `method`,
+`url`, `status`, `error`, `durationMs`, `environment`, `actor`,
+`requestHash`, `request.headers`, `response.headers`, `request.body.hash`,
+`response.body.hash`, `response.contentType`, and `tags`. Headers compare
+as sorted `name: value` lists; they are already redacted, so a token change
+shows as no change (and `requestHash` does not move either, since auth
+enters it by scheme only).
+
+```json
+{ "schemaVersion": 1, "workspace": { "id": "…", "path": "…" },
+  "a": { "id": "01K…A", "startedAt": 1757250000123, "status": 500 },
+  "b": { "id": "01K…B", "startedAt": 1757250001456, "status": 200 },
+  "equal": false,
+  "changes": [ { "field": "status", "a": 500, "b": 200 }, { "field": "durationMs", "a": 41, "b": 38 } ],
+  "request":  { "hash": { "a": "9f…", "b": "9f…", "equal": true },
+                "body": { "a": { "hash": "…", "sizeBytes": 16, "retention": "blob" }, "b": { "…": "…" }, "equal": true, "text": null, "omissionReason": null } },
+  "response": { "body": { "a": { "hash": "ad…", "sizeBytes": 812, "retention": "inline" }, "b": { "…": "…" }, "equal": false, "text": null, "omissionReason": null } } }
+```
+
+`changes` lists only differing fields, named by their `history` JSON path.
+`durationMs`, `actor`, and `tags` are always compared and reported but
+**never** flip `equal`: they are provenance, and `equal` is about bytes and
+outcome (so a replay tagged `--tag retry` still diffs equal to its source
+when the response matched). Inline bodies are read and hashed so `hash` is
+present for them too. With `--bodies`, differing inline UTF-8 response
+bodies add `response.body.text`, a unified diff (`--- a`, `+++ b`, three
+lines of context); otherwise `omissionReason` says `blob` (pull with
+`blob <hash>`), `binary`, `too_large`, or `none`. Request bodies are
+hash-only and never diffed as text.
+
+Exit **0** equal, **1** different, **4** a run missing
+(`run_not_found`, `details.missing: ["01K…"]`), **9** no store. `--quiet`
+keeps the exit code.
+
 ### `blob`
 
 Writes the raw bytes to stdout. With `--json`:
@@ -422,6 +495,7 @@ Facet extends the upstream table; it never renumbers it.
 | Code | Category |
 | ---: | --- |
 | 0–8 | As in [CLI](CLI.md#exit-codes) |
+| 1 | Assertion failed (`replay_changed`; `diff` found differences) |
 | 9 | Lattice store failure (`lattice_error`, `lattice_not_found`) |
 
 Additional stable categories: `blob_not_found`, `run_not_found`, and


### PR DESCRIPTION
## Summary

Goal 4 of deep dive §2: `facet replay` and `facet diff`, plus the one workspace migration 0003 (`replayed_from`, `var_names`). Nothing in `probe-*`. No pins, no sparkline, no `--expect`.

**`facet replay <runId> [<path>] [--frozen] [--environment] [--var]... [--tag]... [--json]`**
- Replay truth = current YAML + recorded environment. `<path>` is the collection (file or dir, default `.`) like `request run`; the store is discovered by walking up from it.
- Hash before network. Changed + no `--frozen`: sends, stderr warning, `lattice.hashChanged: true`. Changed + `--frozen`: `replay_changed`, **exit 1**, no network, no row, `details.{replayedFrom, recordedHash, currentHash}`.
- Recorded `--var` names produce `warning: run … was recorded with --var serverUrl; pass them again`; values are never stored so never replayed.
- New row: recorded tags ∪ `--tag`, `replayedFrom`, `varNames`. Output = `request run` document + `lattice.replayedFrom` + `lattice.hashChanged`. Human: `… · replayed from 01K… (request unchanged)`.
- Unknown id: `run_not_found` (4) with `details.{workspaceId, workspacePath}` when the machine index knows the run under another workspace (one query). Selector gone from YAML: upstream `request_not_found` with `details.replayedFrom`. No store: `lattice_not_found` (9).

**`facet diff <idA> <idB> [<path>] [--bodies] [--json]`**
- `changes` by `history` path name (method, url, status, error, durationMs, environment, actor, requestHash, request/response headers as sorted `name: value`, body hashes, contentType, tags); `request.hash`, `request.body`, `response.body` blocks with `equal`.
- Inline bodies are read and hashed so `hash` is present for them; `--bodies` adds a unified diff (`--- a`/`+++ b`, 3 lines context, in-crate LCS) for differing inline UTF-8 responses; otherwise `omissionReason` in `blob | binary | too_large | none`. Request bodies are hash-only, never text.
- `durationMs`, `actor`, `tags` are reported but never flip `equal` (provenance, not bytes/outcome; a `replay --tag retry` still diffs equal to its source).
- Exit **0** equal, **1** different (also with `--quiet`), **4** a run missing (`details.missing`), **9** no store.

**Lattice / record**
- `workspace/0003_replay_lineage.sql`: `replayed_from`, `var_names` (JSON names; `NULL` = pre-0003 unknown, `[]` = none), index. Schema version 3. No machine 0003, no git HEAD column.
- `history` rows gain `replayedFrom` and `varNames` (additive). `request run` now records `varNames` too.
- `RecordRequest` gains `replayed_from` and `var_names` (TUI call site updated). `facet_record::request_hash_of` is public; `compare` / `diff_request_bodies` / `diff_response_bodies` / `unified_diff` live in `facet-record` for TUI reuse. `MachineStore::indexed_run` is the only new lattice method.
- `ASSERTION_EXIT_CODE = 1` documented in the exit table; `CommandOutput::with_exit_code` lets a success document exit 1.

Note on the inbox line "9 if a run is missing": I kept **4** `run_not_found` for a missing run (consistent with Goal 1's `history --id`) and **9** `lattice_not_found` for no store, per deep dive §2.2. Easy to flip if you want 9 for both.

## Test plan

On apiary (`~/src/facet`, cargo 1.95), head of this branch:

- [x] `cargo test -p lattice -p facet-record -p facet-cli -p facet-tui`: all green (facet-cli 22/22 through the binary, incl. `replay_uses_current_yaml_and_records_lineage` and `diff_is_hash_first_and_exit_1_when_different`; lattice 20 store tests incl. lineage round-trip and `indexed_run`; facet-record 7 unit tests incl. LCS diff; facet-tui 55).
- [x] Goldens: new `replay`, `diff_equal`, `diff_changed`, `error_replay_changed`, `error_replay_run_elsewhere`, `error_diff_run_not_found`; existing history goldens change only by `replayedFrom: null` + `varNames: []`.
- [x] `cargo build --release -p facet-cli`; shell smoke: run → `replay --tag again` (unchanged, lineage in `history`) → `replay --var serverUrl=… --frozen` exit 1 → unfrozen replay to a dead port records a transport failure with lineage → `diff` equal/different/`--quiet` exit codes.
- [x] `cargo fmt --check` clean on every touched file (only the pre-existing `lattice/tests/{duckdb,turso}.rs` debt remains). No new clippy warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01E3MvVHmyGKQdu6CRignmME
