### PR TITLE
feat: secret hydration + facet env (Goal 5)

### DIFF
--- a/crates/facet-record/src/hydrate.rs
+++ b/crates/facet-record/src/hydrate.rs
@@ -1,0 +1,286 @@
+//! Secret hydration (Goal 5): overlay Lattice machine-store environment
+//! values as `--var` overrides **before** resolve.
+//!
+//! Three layers, in order. (1) OpenCollection YAML declares a variable,
+//! plain or `secret: true`; probe-core refuses to interpolate a declared
+//! secret with no value (`secret_variable_unavailable`). (2) The Lattice
+//! machine store holds values keyed `(workspace, environment, key)`, plain or
+//! through the secrets layer. (3) `--var` is the public override channel and
+//! always wins. This module produces layer 2 as overrides placed *before*
+//! the user's, so `resolve_environment_with_overrides` sees user values last.
+//!
+//! Rules: only with a selected environment; only names the request
+//! references; never substitute an empty value or the name; values never
+//! leave the resolved request (only names are reported).
+
+use std::path::Path;
+
+use lattice::{
+    LatticeConfig, LatticeError, MachineStore, SECRET_KEY_ENV, SecretConfig, WorkspaceStore,
+};
+use probe_core::{Environment, HttpRequest, discover_request_variables};
+use serde_json::{Value, json};
+
+/// What the overlay contributed to one resolve.
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct Hydration {
+    /// `(name, value)` pairs to place before the user's `--var` overrides.
+    /// Values live here only until resolve; never log or store them.
+    pub overrides: Vec<(String, String)>,
+    /// Names taken from Lattice, in request-reference order.
+    pub hydrated: Vec<String>,
+    /// How many of `hydrated` came through the secrets layer.
+    pub secrets: usize,
+    /// `keyring` or `encrypted` when a secret was read, `plain` when only
+    /// plaintext rows were used, `None` when nothing was hydrated.
+    pub source: Option<&'static str>,
+    /// Values of variables the YAML declares `secret` (hydrated or passed
+    /// with `--var`), for the recorder to scrub from stored text. Never
+    /// logged; only ever compared against.
+    pub redact: Vec<String>,
+}
+
+impl Hydration {
+    /// The `lattice.secrets` field: names only.
+    #[must_use]
+    pub fn json(&self) -> Value {
+        json!({ "hydrated": self.hydrated, "source": self.source })
+    }
+
+    /// `hydrated 1 secret from keyring`, or `None` when nothing happened.
+    #[must_use]
+    pub fn human(&self) -> Option<String> {
+        if self.hydrated.is_empty() {
+            return None;
+        }
+        let noun = match (self.secrets, self.hydrated.len()) {
+            (1, 1) => "secret".to_owned(),
+            (secrets, total) if secrets == total => "secrets".to_owned(),
+            (0, 1) => "value".to_owned(),
+            (0, _) => "values".to_owned(),
+            (secrets, _) => format!("values ({secrets} secret)"),
+        };
+        Some(format!(
+            "hydrated {} {noun} from {}",
+            self.hydrated.len(),
+            self.source.unwrap_or("lattice")
+        ))
+    }
+
+    /// Overlay first, user overrides last (they win on collisions).
+    #[must_use]
+    pub fn merged(&self, user: &[(String, String)]) -> Vec<(String, String)> {
+        let mut merged = self.overrides.clone();
+        merged.extend(user.iter().cloned());
+        merged
+    }
+}
+
+/// Why hydration could not proceed. Only raised when a referenced variable
+/// is declared `secret` in the YAML; otherwise problems are silent and the
+/// YAML value (or `secret_variable_unavailable`) applies.
+#[derive(Debug)]
+pub enum HydrateError {
+    /// The secrets backend cannot serve a declared secret (no keyring and no
+    /// `FACET_SECRET_KEY`, empty key, wrong key, keyring failure).
+    BackendUnavailable {
+        /// The variable that needed the backend.
+        name: String,
+        /// Underlying reason.
+        reason: String,
+    },
+    /// The machine store failed while a declared secret was referenced.
+    Lattice(LatticeError),
+}
+
+impl std::fmt::Display for HydrateError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::BackendUnavailable { name, reason } => write!(
+                f,
+                "secret backend unavailable for {name}: {reason}; \
+                 set {SECRET_KEY_ENV} or make the OS keyring available"
+            ),
+            Self::Lattice(error) => write!(f, "{error}"),
+        }
+    }
+}
+
+/// Builds the overlay for `request` resolved in `environment` from the
+/// workspace whose collection lives under `root`. Empty when there is no
+/// environment, no store, or nothing referenced. `user_overrides` are
+/// skipped (they win anyway, and their secrets are never read).
+pub fn overlay_secrets(
+    root: Option<&Path>,
+    environment: Option<&str>,
+    request: &HttpRequest,
+    environments: &[Environment],
+    user_overrides: &[(String, String)],
+) -> Result<Hydration, HydrateError> {
+    let (Some(root), Some(environment)) = (root, environment) else {
+        return Ok(Hydration::default());
+    };
+    // Discovery errors (unknown environment, bad inheritance) are core's to
+    // report at resolve time with the right category; do nothing here.
+    let Ok(referenced) = discover_request_variables(request, environments, Some(environment))
+    else {
+        return Ok(Hydration::default());
+    };
+    // A user `--var` for a declared secret is still a secret: remember its
+    // value for redaction even though Lattice is not consulted for it.
+    let mut redact: Vec<String> = referenced
+        .iter()
+        .filter(|info| info.secret)
+        .filter_map(|info| {
+            user_overrides
+                .iter()
+                .find(|(name, _)| *name == info.name)
+                .map(|(_, value)| value.clone())
+        })
+        .collect();
+    let referenced: Vec<_> = referenced
+        .into_iter()
+        .filter(|info| !user_overrides.iter().any(|(name, _)| *name == info.name))
+        .collect();
+    if referenced.is_empty() {
+        return Ok(Hydration {
+            redact,
+            ..Hydration::default()
+        });
+    }
+    let strict = referenced.iter().any(|info| info.secret);
+
+    // A store beside the collection is the only way to have Lattice values.
+    let Some(workspace_root) = WorkspaceStore::discover(root) else {
+        return Ok(Hydration {
+            redact,
+            ..Hydration::default()
+        });
+    };
+    let opened = LatticeConfig::load(&workspace_root)
+        .map_err(LatticeError::from)
+        .and_then(|config| WorkspaceStore::open_existing(&workspace_root, config));
+    let store = match opened {
+        Ok(Some(store)) => store,
+        Ok(None) => {
+            return Ok(Hydration {
+                redact,
+                ..Hydration::default()
+            });
+        }
+        Err(error) if strict => return Err(HydrateError::Lattice(error)),
+        Err(_) => {
+            return Ok(Hydration {
+                redact,
+                ..Hydration::default()
+            });
+        }
+    };
+    let machine = match MachineStore::open(store.config()) {
+        Ok(machine) => machine,
+        Err(error) if strict => return Err(HydrateError::Lattice(error)),
+        Err(_) => {
+            return Ok(Hydration {
+                redact,
+                ..Hydration::default()
+            });
+        }
+    };
+    let rows = match machine.environments(store.workspace_id()) {
+        Ok(rows) => rows,
+        Err(error) if strict => return Err(HydrateError::Lattice(error)),
+        Err(_) => {
+            return Ok(Hydration {
+                redact,
+                ..Hydration::default()
+            });
+        }
+    };
+
+    let secret_config = SecretConfig::from_env();
+    let backend_label = match std::env::var(SECRET_KEY_ENV) {
+        Ok(value) if !value.is_empty() => "encrypted",
+        _ => "keyring",
+    };
+    let plain_config = SecretConfig::keyring();
+
+    let mut hydration = Hydration::default();
+    for info in referenced {
+        let Some(row) = rows
+            .iter()
+            .find(|row| row.name == environment && row.key == info.name)
+        else {
+            continue;
+        };
+        let config = if row.secret {
+            match &secret_config {
+                Ok(config) => config,
+                Err(error) if info.secret => {
+                    return Err(HydrateError::BackendUnavailable {
+                        name: info.name,
+                        reason: error.to_string(),
+                    });
+                }
+                Err(_) => continue,
+            }
+        } else {
+            &plain_config
+        };
+        match machine.environment_with(store.workspace_id(), environment, &info.name, config) {
+            Ok(Some(value)) if !value.is_empty() => {
+                if row.secret || info.secret {
+                    hydration.secrets += usize::from(row.secret);
+                    redact.push(value.clone());
+                }
+                hydration.overrides.push((info.name.clone(), value));
+                hydration.hydrated.push(info.name);
+            }
+            Ok(_) => {}
+            Err(LatticeError::Secret(error)) if info.secret => {
+                return Err(HydrateError::BackendUnavailable {
+                    name: info.name,
+                    reason: error.to_string(),
+                });
+            }
+            Err(error) if strict && !matches!(error, LatticeError::Secret(_)) => {
+                return Err(HydrateError::Lattice(error));
+            }
+            Err(_) => {}
+        }
+    }
+    hydration.redact = redact;
+    hydration.source = if hydration.secrets > 0 {
+        Some(backend_label)
+    } else if hydration.hydrated.is_empty() {
+        None
+    } else {
+        Some("plain")
+    };
+    Ok(hydration)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Hydration;
+
+    #[test]
+    fn user_overrides_come_last_and_human_counts() {
+        let hydration = Hydration {
+            overrides: vec![("token".to_owned(), "abc".to_owned())],
+            hydrated: vec!["token".to_owned()],
+            secrets: 1,
+            source: Some("encrypted"),
+            redact: vec!["abc".to_owned()],
+        };
+        let merged = hydration.merged(&[("token".to_owned(), "user".to_owned())]);
+        assert_eq!(merged.len(), 2);
+        assert_eq!(merged[1].1, "user", "last one wins in core");
+        assert_eq!(
+            hydration.human().as_deref(),
+            Some("hydrated 1 secret from encrypted")
+        );
+        assert_eq!(hydration.json()["hydrated"][0], "token");
+        assert!(hydration.json().to_string().find("abc").is_none());
+        assert!(Hydration::default().human().is_none());
+    }
+}

--- a/crates/facet-record/src/lib.rs
+++ b/crates/facet-record/src/lib.rs
@@ -7,6 +7,7 @@
 #![forbid(unsafe_code)]
 
 mod diff;
+mod hydrate;
 
 use std::path::Path;
 
@@ -14,6 +15,7 @@ pub use diff::{
     BodyDiff, BodySide, FieldChange, PROVENANCE_FIELDS, RunDiff, compare, diff_request_bodies,
     diff_response_bodies, unified_diff,
 };
+pub use hydrate::{HydrateError, Hydration, overlay_secrets};
 
 use lattice::{
     BodyInput, LatticeConfig, LatticeError, MachineStore, NewRun, Retention, RunRow,
@@ -206,6 +208,9 @@ pub struct RecordRequest<'a> {
     /// Names of the `--var` overrides used at resolve time. Names only;
     /// values are never written anywhere in Lattice.
     pub var_names: &'a [String],
+    /// Secret values to scrub from stored text (URL, header values, error
+    /// text) before the row is written. See [`Hydration::redact`].
+    pub redact: &'a [String],
 }
 
 /// Records one run in the workspace store beside the collection, then
@@ -228,6 +233,7 @@ pub fn record(req: &RecordRequest<'_>) -> Recording {
         session,
         replayed_from,
         var_names,
+        redact,
     } = *req;
     let Some(root) = root else {
         return Recording::Skipped("stdin_workspace");
@@ -239,12 +245,17 @@ pub fn record(req: &RecordRequest<'_>) -> Recording {
 
     let req_body_bytes = request_body_bytes(request);
     let request_hash = request_hash(request, req_body_bytes.as_deref());
-    let req_headers = request_headers_json(&request.headers).to_string();
-    let error_text = result.as_ref().err().map(ToString::to_string);
-    let res_headers = result
+    let req_headers = scrub(&request_headers_json(&request.headers).to_string(), redact);
+    let error_text = result
         .as_ref()
-        .ok()
-        .map(|response| response_headers_json(&response.headers).to_string());
+        .err()
+        .map(|error| scrub(&error.to_string(), redact));
+    let res_headers = result.as_ref().ok().map(|response| {
+        scrub(
+            &response_headers_json(&response.headers).to_string(),
+            redact,
+        )
+    });
     let content_type = result.as_ref().ok().and_then(|response| {
         response
             .headers
@@ -257,7 +268,7 @@ pub fn record(req: &RecordRequest<'_>) -> Recording {
     } else {
         Some(json!(tags).to_string())
     };
-    let redacted_url = redact_url(request.url.as_deref().unwrap_or(""));
+    let redacted_url = scrub(&redact_url(request.url.as_deref().unwrap_or("")), redact);
     // Always written post-0003 so `[]` (none) stays distinct from NULL (unknown).
     let var_names_json = json!(var_names).to_string();
 
@@ -449,6 +460,25 @@ fn response_headers_json(headers: &[ResponseHeader]) -> Value {
     )
 }
 
+/// Shortest secret value that is scrubbed from stored text. Shorter values
+/// would mangle unrelated text (and are not secrets in any useful sense).
+pub const MIN_REDACT_LEN: usize = 4;
+
+/// Replaces every occurrence of each known secret value with `<redacted>`.
+/// Applied to stored URL, header JSON, and error text so a secret the YAML
+/// interpolates into a query string or a custom header never lands in
+/// Lattice. Bodies are content-addressed blobs and are not rewritten.
+#[must_use]
+pub fn scrub(text: &str, secrets: &[String]) -> String {
+    let mut out = text.to_owned();
+    for secret in secrets {
+        if secret.len() >= MIN_REDACT_LEN && out.contains(secret.as_str()) {
+            out = out.replace(secret.as_str(), REDACTED);
+        }
+    }
+    out
+}
+
 /// Strips `user:password@` from a URL's authority.
 fn redact_url(url: &str) -> String {
     let Some(scheme_end) = url.find("://") else {
@@ -474,7 +504,7 @@ fn redact_url(url: &str) -> String {
 mod tests {
     use probe_core::{Header, HttpRequest};
 
-    use super::{form_encode, redact_url, request_hash, request_headers_json, url_encode};
+    use super::{form_encode, redact_url, request_hash, request_headers_json, scrub, url_encode};
 
     fn request(url: &str) -> HttpRequest {
         HttpRequest {
@@ -524,6 +554,16 @@ mod tests {
         assert_eq!(first, same);
         assert_ne!(first, other);
         assert_eq!(first.len(), 64);
+    }
+
+    #[test]
+    fn scrubs_known_secret_values_but_not_tiny_ones() {
+        let secrets = vec!["hunter2".to_owned(), "ab".to_owned()];
+        assert_eq!(
+            scrub("http://x/?t=hunter2&u=ab", &secrets),
+            "http://x/?t=<redacted>&u=ab"
+        );
+        assert_eq!(scrub("clean", &secrets), "clean");
     }
 
     #[test]

--- a/crates/facet-tui/src/app.rs
+++ b/crates/facet-tui/src/app.rs
@@ -10,8 +10,7 @@ use facet_record::{ConfigOverrides, RecordRequest, Recording, record};
 use crossterm::event::{KeyCode, KeyModifiers};
 use lattice::{HistoryQuery, LatticeConfig, RunRow, SqlValue, WorkspaceStore};
 use probe_core::{
-    FolderKey, Header, HttpRequest, QueryParameter, RequestKey, RequestUpdate, resolve_environment,
-    resolve_request,
+    FolderKey, Header, HttpRequest, QueryParameter, RequestKey, RequestUpdate, resolve_request,
 };
 use probe_http::{ExecutionOptions, HttpEngine, HttpResponse};
 use probe_opencollection::{LoadedWorkspace, SaveError, load_workspace};
@@ -1872,7 +1871,9 @@ impl App {
         }
     }
 
-    fn prepared_request(&self) -> Result<HttpRequest, String> {
+    /// The request to send plus the secret values hydrated into it, which the
+    /// recorder scrubs from stored text.
+    fn prepared_request_with_redact(&self) -> Result<(HttpRequest, Vec<String>), String> {
         let Some((_, request)) = self.selected_request() else {
             return Err("no request selected".to_string());
         };
@@ -1880,24 +1881,40 @@ impl App {
         build_update(&self.method, &self.editor).apply(&mut prepared);
         if let Some(index) = self.active_environment {
             let Some(entry) = self.environments.get(index) else {
-                return Ok(prepared);
+                return Ok((prepared, Vec::new()));
             };
             let Some(loaded) = self.loaded.as_ref() else {
-                return Ok(prepared);
+                return Ok((prepared, Vec::new()));
             };
-            let resolved = resolve_environment(loaded.workspace().environments(), &entry.name)
-                .map_err(|error| error.to_string())?;
+            // Secret hydration (Goal 5): Lattice environment values overlay
+            // as overrides before resolve, same path as the CLI.
+            let base = self.base_directory();
+            let hydration = facet_record::overlay_secrets(
+                base.as_deref(),
+                Some(&entry.name),
+                &prepared,
+                loaded.workspace().environments(),
+                &[],
+            )
+            .map_err(|error| error.to_string())?;
+            let resolved = probe_core::resolve_environment_with_overrides(
+                loaded.workspace().environments(),
+                Some(&entry.name),
+                &hydration.overrides,
+            )
+            .map_err(|error| error.to_string())?;
             prepared = resolve_request(&prepared, &resolved).map_err(|error| error.to_string())?;
+            return Ok((prepared, hydration.redact));
         }
-        Ok(prepared)
+        Ok((prepared, Vec::new()))
     }
 
     async fn run_selected(&mut self) -> Result<(), TuiError> {
         if self.pending.is_some() {
             return Ok(());
         }
-        let request = match self.prepared_request() {
-            Ok(request) => request,
+        let (request, redact) = match self.prepared_request_with_redact() {
+            Ok(prepared) => prepared,
             Err(message) => {
                 self.status = RunStatus::Failed(message);
                 return Ok(());
@@ -1971,6 +1988,7 @@ impl App {
                     session: session.as_deref(),
                     replayed_from: None,
                     var_names: &[],
+                    redact: &redact,
                 });
                 Some(RecordSummary::from_recording(&recording))
             } else {

--- a/crates/facet/src/env.rs
+++ b/crates/facet/src/env.rs
@@ -1,0 +1,188 @@
+//! `facet env set|list|delete`: Facet's machine-store environment values,
+//! keyed by workspace. This is **not** Probe's `environment` command (which
+//! edits YAML and rejects secrets); the two stores are different and the
+//! names do not collide. Values are written here and read by the hydration
+//! overlay at resolve time. No command ever prints a value.
+
+use lattice::{LatticeConfig, LatticeError, MachineStore, SecretConfig};
+use serde_json::{Value, json};
+
+use crate::{
+    CommandOutput, FacetError, args,
+    presentation::format_utc,
+    workspace::{ConfigOverrides, WorkspaceInput, locate_root, open_store},
+};
+
+pub(crate) fn env(args: &[String]) -> Result<CommandOutput, FacetError> {
+    let Some((verb, rest)) = args.split_first() else {
+        return Err(FacetError::invalid_arguments(
+            "env requires a subcommand: set, list, or delete",
+        ));
+    };
+    match verb.as_str() {
+        "set" => set(rest),
+        "list" => list(rest),
+        "delete" => delete(rest),
+        other => Err(FacetError::invalid_arguments(format!(
+            "unknown env subcommand: {other} (expected set, list, or delete)"
+        ))),
+    }
+}
+
+fn set(args: &[String]) -> Result<CommandOutput, FacetError> {
+    let parsed = args::parse(args, &["--environment", "--name", "--value"], &["--secret"])?;
+    let path = single_optional_path(parsed.positionals(), "env set")?;
+    let environment = required(&parsed, "--environment")?;
+    let name = required(&parsed, "--name")?;
+    let value = required(&parsed, "--value")?;
+    let secret = parsed.switch("--secret");
+
+    // `set` may be the first Lattice write for a collection: create the
+    // workspace store beside it when none exists yet.
+    let (start, root) = locate_root(path);
+    let root = match root {
+        Some(root) => root,
+        None => WorkspaceInput::from_argument(&start.to_string_lossy())
+            .base_directory()
+            .ok_or_else(|| FacetError::invalid_arguments("env set needs a collection on disk"))?,
+    };
+    let store = open_store(&root, &ConfigOverrides::default())?;
+    let machine = open_machine(&store.config().clone())?;
+    if secret {
+        // Fail before writing when the backend cannot hold a secret.
+        SecretConfig::from_env()
+            .map_err(|error| FacetError::lattice(LatticeError::Secret(error)))?;
+    }
+    machine
+        .set_environment(store.workspace_id(), environment, name, value, secret)
+        .map_err(FacetError::lattice)?;
+    let row = machine
+        .environments(store.workspace_id())
+        .map_err(FacetError::lattice)?
+        .into_iter()
+        .find(|row| row.name == environment && row.key == name)
+        .unwrap_or_else(|| lattice::EnvironmentRow {
+            name: environment.to_owned(),
+            key: name.to_owned(),
+            secret,
+            updated_at: lattice::now_ms(),
+        });
+    Ok(CommandOutput::new(
+        format!(
+            "{}/{} set ({}) for workspace {}\n",
+            row.name,
+            row.key,
+            if row.secret { "secret" } else { "plain" },
+            store.workspace_id()
+        ),
+        json!({
+            "workspace": workspace_json(&store),
+            "entry": entry_json(&row),
+        }),
+    ))
+}
+
+fn list(args: &[String]) -> Result<CommandOutput, FacetError> {
+    let parsed = args::parse(args, &["--environment"], &[])?;
+    let path = single_optional_path(parsed.positionals(), "env list")?;
+    let filter = parsed.value("--environment")?;
+    let (_, root) = locate_root(path);
+    let Some(root) = root else {
+        return Ok(CommandOutput::new(
+            "No Lattice store found; nothing set.\n",
+            json!({ "workspace": Value::Null, "entries": [] }),
+        ));
+    };
+    let store = open_store(&root, &ConfigOverrides::default())?;
+    let machine = open_machine(&store.config().clone())?;
+    let rows: Vec<_> = machine
+        .environments(store.workspace_id())
+        .map_err(FacetError::lattice)?
+        .into_iter()
+        .filter(|row| filter.is_none_or(|name| row.name == name))
+        .collect();
+    let mut lines = vec!["ENVIRONMENT\tNAME\tSECRET\tUPDATED".to_owned()];
+    for row in &rows {
+        lines.push(format!(
+            "{}\t{}\t{}\t{}",
+            row.name,
+            row.key,
+            if row.secret { "yes" } else { "no" },
+            format_utc(row.updated_at)
+        ));
+    }
+    Ok(CommandOutput::new(
+        format!("{}\n", lines.join("\n")),
+        json!({
+            "workspace": workspace_json(&store),
+            "entries": rows.iter().map(entry_json).collect::<Vec<_>>(),
+        }),
+    ))
+}
+
+fn delete(args: &[String]) -> Result<CommandOutput, FacetError> {
+    let parsed = args::parse(args, &["--environment", "--name"], &[])?;
+    let path = single_optional_path(parsed.positionals(), "env delete")?;
+    let environment = required(&parsed, "--environment")?;
+    let name = required(&parsed, "--name")?;
+    let (start, root) = locate_root(path);
+    let root = root.ok_or_else(|| FacetError::lattice_not_found(&start))?;
+    let store = open_store(&root, &ConfigOverrides::default())?;
+    let machine = open_machine(&store.config().clone())?;
+    let deleted = machine
+        .delete_environment(store.workspace_id(), environment, name)
+        .map_err(FacetError::lattice)?;
+    Ok(CommandOutput::new(
+        if deleted {
+            format!("{environment}/{name} deleted\n")
+        } else {
+            format!("{environment}/{name} was not set\n")
+        },
+        json!({
+            "workspace": workspace_json(&store),
+            "environment": environment,
+            "name": name,
+            "deleted": deleted,
+        }),
+    ))
+}
+
+fn open_machine(config: &LatticeConfig) -> Result<MachineStore, FacetError> {
+    MachineStore::open(config).map_err(FacetError::lattice)
+}
+
+fn required<'a>(parsed: &'a args::Parsed, flag: &str) -> Result<&'a str, FacetError> {
+    parsed
+        .value(flag)?
+        .ok_or_else(|| FacetError::invalid_arguments(format!("{flag} is required")))
+}
+
+fn single_optional_path<'a>(
+    positionals: &'a [String],
+    command: &str,
+) -> Result<Option<&'a str>, FacetError> {
+    match positionals {
+        [] => Ok(None),
+        [path] => Ok(Some(path.as_str())),
+        _ => Err(FacetError::invalid_arguments(format!(
+            "{command} accepts at most one <path>"
+        ))),
+    }
+}
+
+fn workspace_json(store: &lattice::WorkspaceStore) -> Value {
+    json!({
+        "id": store.workspace_id(),
+        "path": store.root().to_string_lossy(),
+    })
+}
+
+/// Metadata only. There is no field for the value and there never will be.
+fn entry_json(row: &lattice::EnvironmentRow) -> Value {
+    json!({
+        "environment": row.name,
+        "name": row.key,
+        "secret": row.secret,
+        "updatedAt": row.updated_at,
+    })
+}

--- a/crates/facet/src/error.rs
+++ b/crates/facet/src/error.rs
@@ -3,6 +3,7 @@
 //! `blob_not_found`, `run_not_found`, `session_not_found`, `session_not_set`,
 //! `invalid_sql`, and `sql_read_only`.
 
+use facet_record::HydrateError;
 use lattice::LatticeError;
 use probe_core::EnvironmentResolutionError;
 use probe_http::HttpError;
@@ -152,7 +153,27 @@ impl FacetError {
                 error.to_string(),
                 INVALID_ARGUMENTS_EXIT_CODE,
             ),
+            // The secrets layer cannot serve: configuration family, so the
+            // caller fixes inputs (set FACET_SECRET_KEY / keyring) and retries.
+            LatticeError::Secret(error) => Self::new(
+                "secret_backend_unavailable",
+                error.to_string(),
+                CONFIGURATION_EXIT_CODE,
+            ),
             error => Self::new("lattice_error", error.to_string(), LATTICE_EXIT_CODE),
+        }
+    }
+
+    /// Secret hydration could not proceed for a declared secret.
+    pub(crate) fn hydrate(error: HydrateError) -> Self {
+        match error {
+            HydrateError::BackendUnavailable { name, reason } => Self::new(
+                "secret_backend_unavailable",
+                format!("secret backend unavailable for {name}: {reason}"),
+                CONFIGURATION_EXIT_CODE,
+            )
+            .with_details(json!({ "variable": name })),
+            HydrateError::Lattice(error) => Self::lattice(error),
         }
     }
 

--- a/crates/facet/src/lib.rs
+++ b/crates/facet/src/lib.rs
@@ -9,6 +9,7 @@
 //! - `history`, `blob`, and `gc` read and maintain that store.
 //! - `session` starts, ends, lists, and shows agent sessions in the machine store.
 //! - `replay` re-sends a recorded run from the current YAML; `diff` compares two runs.
+//! - `env` sets and lists machine-store environment values (metadata only on read).
 //! - `tui` opens the terminal UI.
 //!
 //! Contract details for the Facet-only commands live in `docs/FACET.md`.
@@ -21,6 +22,7 @@ use serde_json::{Value, json};
 
 mod args;
 mod diff;
+mod env;
 mod error;
 mod history;
 mod presentation;
@@ -170,6 +172,10 @@ pub const fn help() -> &'static str {
         "  session show <id>|current           Show one session\n",
         "  replay <runId> [<path>]             Re-send a recorded run from the current YAML\n",
         "  diff <idA> <idB> [<path>]           Compare two recorded runs, hashes first (exit 1 if different)\n",
+        "  env set [<path>] --environment <e> --name <k> --value <v> [--secret]\n",
+        "                                      Store a value in the Facet machine store (hydrated at resolve)\n",
+        "  env list [<path>] [--environment <e>] List stored values (metadata only, never values)\n",
+        "  env delete [<path>] --environment <e> --name <k>\n",
         "  blob <hash> [<path>]                Fetch one stored body by SHA-256\n",
         "  gc [<path>] [--yes]                 Expire old runs and sweep orphaned blobs\n",
         "  tui [<path>]                        Open the terminal UI\n",
@@ -190,6 +196,7 @@ pub const fn help() -> &'static str {
         "      --id <ulid>             One run by id (exclusive with the filters above)\n",
         "      --bodies                Include inline bodies in history JSON; unified body diff for diff\n",
         "      --frozen                Refuse to replay when the request hash changed (exit 1)\n",
+        "      --secret                Store the env value through the secrets layer (env set)\n",
         "      --meta <json>           Session metadata object (session start)\n",
         "      --open                  Only sessions still open (session list)\n",
         "      --output <file>         Write a blob to a file instead of stdout\n",
@@ -201,7 +208,8 @@ pub const fn help() -> &'static str {
         "  -V, --version               Print version\n",
         "\n",
         "Environment: FACET_ACTOR (run actor, default human), FACET_SESSION (session id),\n",
-        "FACET_NO_RECORD=1 (never record), FACET_DATA_DIR / FACET_CONFIG_DIR (machine store paths).\n",
+        "FACET_NO_RECORD=1 (never record), FACET_DATA_DIR / FACET_CONFIG_DIR (machine store paths),\n",
+        "FACET_SECRET_KEY (encrypted secrets instead of the OS keyring).\n",
     )
 }
 
@@ -237,8 +245,8 @@ where
     let owned = match args.first().map(String::as_str) {
         None => true,
         Some(
-            "history" | "session" | "replay" | "diff" | "blob" | "gc" | "tui" | "-V" | "--version"
-            | "-h" | "--help",
+            "history" | "session" | "replay" | "diff" | "env" | "blob" | "gc" | "tui" | "-V"
+            | "--version" | "-h" | "--help",
         ) => true,
         Some("request") => args.get(1).map(String::as_str) == Some("run"),
         Some(_) => false,
@@ -285,6 +293,7 @@ where
         "session" => session::session(&args[1..]),
         "replay" => replay::replay(&args[1..], stdin),
         "diff" => diff::diff(&args[1..]),
+        "env" => env::env(&args[1..]),
         "blob" => history::blob(&args[1..]),
         "gc" => history::gc(&args[1..]),
         "tui" => Err(FacetError::invalid_arguments(

--- a/crates/facet/src/replay.rs
+++ b/crates/facet/src/replay.rs
@@ -19,7 +19,10 @@ use serde_json::json;
 
 use crate::{
     CommandOutput, FacetError, args,
-    run::{execute, parse_vars, render, selected_request, var_names},
+    run::{
+        execute, hydrate, lookup_request, parse_vars, render, resolve_selected, var_names,
+        with_secrets,
+    },
     workspace::{WorkspaceInput, load, open_store, overrides_from_parsed},
 };
 
@@ -100,11 +103,20 @@ pub(crate) fn replay(args: &[String], stdin: &mut impl Read) -> Result<CommandOu
 
     // 4. Resolve the current YAML and compare hashes before any network.
     let loaded = load(&input, stdin)?;
-    let request = selected_request(
-        &loaded,
-        selector,
+    let raw = lookup_request(&loaded, selector)
+        .map_err(|error| error.with_details(json!({ "replayedFrom": row.id })))?;
+    let hydration = hydrate(
+        Some(&base),
         environment.as_deref(),
+        raw,
+        &loaded,
         &variables,
+    )?;
+    let request = resolve_selected(
+        &loaded,
+        raw,
+        environment.as_deref(),
+        &hydration.merged(&variables),
         strict_variables,
     )
     .map_err(|error| error.with_details(json!({ "replayedFrom": row.id })))?;
@@ -147,6 +159,7 @@ pub(crate) fn replay(args: &[String], stdin: &mut impl Read) -> Result<CommandOu
             session: session.as_deref(),
             replayed_from: Some(&row.id),
             var_names: &var_names(&variables),
+            redact: &hydration.redact,
         })
     } else {
         Recording::Skipped("disabled")
@@ -155,12 +168,16 @@ pub(crate) fn replay(args: &[String], stdin: &mut impl Read) -> Result<CommandOu
         warnings.push(warning);
     }
 
-    let mut lattice_json = recording.json();
+    let (mut lattice_json, lattice_human) = with_secrets(
+        recording.json(),
+        recording.human(),
+        &hydration,
+        environment.is_some(),
+    );
     lattice_json["replayedFrom"] = json!(row.id);
     lattice_json["hashChanged"] = json!(hash_changed);
     let lattice_human = format!(
-        "{} · replayed from {} ({})",
-        recording.human(),
+        "{lattice_human} · replayed from {} ({})",
         row.id,
         if hash_changed {
             "request changed"

--- a/crates/facet/src/run.rs
+++ b/crates/facet/src/run.rs
@@ -10,7 +10,8 @@ use std::{
 };
 
 use facet_record::{
-    RecordRequest, Recording, actor_from_env, record, recording_disabled, session_from_env,
+    Hydration, RecordRequest, Recording, actor_from_env, overlay_secrets, record,
+    recording_disabled, session_from_env,
 };
 use lattice::now_ms;
 use probe_core::{
@@ -64,11 +65,20 @@ pub(crate) fn run(args: &[String], stdin: &mut impl Read) -> Result<CommandOutpu
     let overrides = overrides_from_parsed(&parsed)?;
 
     let loaded = load(&input, stdin)?;
-    let request = selected_request(
-        &loaded,
-        selector,
+    let base = input.base_directory();
+    let raw = lookup_request(&loaded, selector)?;
+    let hydration = hydrate(
+        base.as_deref(),
         environment.as_deref(),
+        raw,
+        &loaded,
         &variables,
+    )?;
+    let request = resolve_selected(
+        &loaded,
+        raw,
+        environment.as_deref(),
+        &hydration.merged(&variables),
         strict_variables,
     )?;
     let execution = execute(&request, input.base_directory(), output.as_deref())?;
@@ -92,19 +102,63 @@ pub(crate) fn run(args: &[String], stdin: &mut impl Read) -> Result<CommandOutpu
             session: session.as_deref(),
             replayed_from: None,
             var_names: &var_names(&variables),
+            redact: &hydration.redact,
         })
     } else {
         Recording::Skipped("disabled")
     };
 
+    let (lattice_json, lattice_human) = with_secrets(
+        recording.json(),
+        recording.human(),
+        &hydration,
+        environment.is_some(),
+    );
     render(
         &request,
         execution,
         output.as_deref(),
-        recording.json(),
-        recording.human(),
+        lattice_json,
+        lattice_human,
         recording.warning().into_iter().collect(),
     )
+}
+
+/// Secret hydration (Goal 5): Lattice environment values for the names the
+/// request references, placed before the user's `--var` so those win.
+/// Only with `--environment`; otherwise an empty overlay.
+pub(crate) fn hydrate(
+    base: Option<&Path>,
+    environment: Option<&str>,
+    request: &HttpRequest,
+    loaded: &LoadedWorkspace,
+    variables: &[(String, String)],
+) -> Result<Hydration, FacetError> {
+    overlay_secrets(
+        base,
+        environment,
+        request,
+        loaded.workspace().environments(),
+        variables,
+    )
+    .map_err(FacetError::hydrate)
+}
+
+/// Adds `lattice.secrets` (names only) whenever an environment was selected,
+/// and the human note when something was hydrated.
+pub(crate) fn with_secrets(
+    mut lattice_json: Value,
+    mut lattice_human: String,
+    hydration: &Hydration,
+    environment_selected: bool,
+) -> (Value, String) {
+    if environment_selected {
+        lattice_json["secrets"] = hydration.json();
+    }
+    if let Some(note) = hydration.human() {
+        lattice_human = format!("{lattice_human} · {note}");
+    }
+    (lattice_json, lattice_human)
 }
 
 /// Parses repeated `--var NAME=VALUE` flags in order.
@@ -200,21 +254,30 @@ pub(crate) fn render(
     }
 }
 
-/// Mirrors `probe-cli`'s selection and interpolation rules.
-pub(crate) fn selected_request<'a>(
+/// The unresolved request behind a selector.
+pub(crate) fn lookup_request<'a>(
     loaded: &'a LoadedWorkspace,
     selector: &str,
+) -> Result<&'a HttpRequest, FacetError> {
+    let key = loaded
+        .request_key(selector)
+        .ok_or_else(|| FacetError::request_not_found(selector))?;
+    Ok(loaded
+        .workspace()
+        .request(key)
+        .expect("repository request key must resolve"))
+}
+
+/// Mirrors `probe-cli`'s interpolation rules over an already looked-up
+/// request. `variables` are applied last, so the caller decides precedence.
+pub(crate) fn resolve_selected<'a>(
+    loaded: &LoadedWorkspace,
+    request: &'a HttpRequest,
     environment: Option<&str>,
     variables: &[(String, String)],
     strict_variables: bool,
 ) -> Result<Cow<'a, HttpRequest>, FacetError> {
-    let key = loaded
-        .request_key(selector)
-        .ok_or_else(|| FacetError::request_not_found(selector))?;
     let workspace = loaded.workspace();
-    let request = workspace
-        .request(key)
-        .expect("repository request key must resolve");
     if environment.is_some() || !variables.is_empty() || strict_variables {
         let environment =
             resolve_environment_with_overrides(workspace.environments(), environment, variables)

--- a/crates/facet/tests/common/mod.rs
+++ b/crates/facet/tests/common/mod.rs
@@ -26,6 +26,19 @@ impl Sandbox {
         self.dir.path()
     }
 
+    /// A bundled collection whose request references a declared secret
+    /// (`token`, `secret: true`) in its URL query, a custom header, and its
+    /// body, so the mock server sees the hydrated value, nothing but Lattice
+    /// can supply it, and every stored text column is exercised by scrubbing.
+    pub(crate) fn secret_workspace(&self, server_url: &str) -> PathBuf {
+        let source = format!(
+            "opencollection: 1.0.0\ninfo:\n  name: Secret fixture\nbundled: true\nconfig:\n  environments:\n    - name: local\n      variables:\n        - name: serverUrl\n          value: {server_url}\n        - secret: true\n          name: token\n          type: string\nitems:\n  - info:\n      name: Echo secret\n      type: http\n      seq: 1\n    http:\n      method: POST\n      url: \"{{{{serverUrl}}}}/echo?t={{{{token}}}}\"\n      headers:\n        - name: X-Token\n          value: \"{{{{token}}}}\"\n      body:\n        type: json\n        data: '{{\"token\":\"{{{{token}}}}\"}}'\n"
+        );
+        let path = self.root().join("workspace.yml");
+        fs::write(&path, source).unwrap();
+        path
+    }
+
     /// Writes the phase-5 HTTP fixture with `__SERVER_URL__` replaced.
     pub(crate) fn workspace(&self, server_url: &str) -> PathBuf {
         let source = fs::read_to_string(fixture("phase5-http.yml")).unwrap();
@@ -43,6 +56,8 @@ impl Sandbox {
             .env_remove("FACET_ACTOR")
             .env_remove("FACET_SESSION")
             .env_remove("FACET_NO_RECORD")
+            // Encrypted secrets backend: deterministic, no OS keyring prompts.
+            .env("FACET_SECRET_KEY", "test-master-key")
             // Session metadata picks these up when present; goldens must not.
             .env_remove("HERDR_WORKSPACE_ID")
             .env_remove("HERDR_TAB_ID")
@@ -228,7 +243,7 @@ pub(crate) fn normalize(value: Value) -> Value {
                         "version" | "probeVersion" => json!("<version>"),
                         "id" | "runId" | "workspaceId" => json!("<ulid>"),
                         "sessionId" | "replayedFrom" if value.is_string() => json!("<ulid>"),
-                        "startedAt" | "durationMs" => json!("<int>"),
+                        "startedAt" | "durationMs" | "updatedAt" => json!("<int>"),
                         "endedAt" if value.is_number() => json!("<int>"),
                         "requestHash" | "recordedHash" | "currentHash" => json!("<sha256>"),
                         "hash" if value.is_string() => json!("<sha256>"),

--- a/crates/facet/tests/facet_commands.rs
+++ b/crates/facet/tests/facet_commands.rs
@@ -1067,3 +1067,318 @@ fn diff_is_hash_first_and_exit_1_when_different() {
     let (code, _) = sandbox.run_error_json(&["diff", &id_a]);
     assert_eq!(code, 2);
 }
+
+const SECRET_VALUE: &str = "hunter2-never-in-history";
+
+/// Every read surface an agent has must be free of the secret value.
+fn assert_no_secret_anywhere(sandbox: &Sandbox, ws: &str) {
+    let surfaces = [
+        sandbox.run_json(&["history", ws, "--bodies"]).to_string(),
+        sandbox
+            .run_json(&["history", ws, "--sql", "SELECT * FROM runs"])
+            .to_string(),
+        sandbox.run_json(&["env", "list", ws]).to_string(),
+        sandbox.run_json(&["session", "list"]).to_string(),
+    ];
+    for surface in surfaces {
+        assert!(!surface.contains(SECRET_VALUE), "secret leaked: {surface}");
+        assert!(!surface.contains("enc:v1:"), "secret ref leaked: {surface}");
+        assert!(
+            !surface.contains("test-master-key"),
+            "key leaked: {surface}"
+        );
+    }
+}
+
+#[test]
+fn secret_hydration_overlays_lattice_values_before_resolve() {
+    let sandbox = Sandbox::new();
+    let (url, first) = serve_once(ECHO_BODY.to_vec(), "application/json");
+    let workspace = sandbox.secret_workspace(&url);
+    let ws = workspace.to_str().unwrap();
+    let run = ["request", "run", ws, "items/0", "--environment", "local"];
+
+    // Declared secret, no value anywhere: core refuses, never sends empty.
+    let (code, error) = sandbox.run_error_json(&run);
+    assert_eq!(code, 5);
+    assert_eq!(error["error"]["category"], "secret_variable_unavailable");
+
+    // `facet env set --secret` stores through the secrets layer; list is
+    // metadata only.
+    let set = sandbox.run_json(&[
+        "env",
+        "set",
+        ws,
+        "--environment",
+        "local",
+        "--name",
+        "token",
+        "--value",
+        SECRET_VALUE,
+        "--secret",
+    ]);
+    assert_eq!(set["entry"]["secret"], true);
+    assert_eq!(set["entry"]["name"], "token");
+    assert!(!set.to_string().contains(SECRET_VALUE));
+    assert_golden("env_set.json", &normalize(set));
+    let list = sandbox.run_json(&["env", "list", ws]);
+    assert_eq!(list["entries"].as_array().unwrap().len(), 1);
+    assert_eq!(list["entries"][0]["secret"], true);
+    assert!(list["entries"][0].get("value").is_none());
+    assert_golden("env_list.json", &normalize(list));
+    let human = sandbox.facet().args(["env", "list", ws]).output().unwrap();
+    assert!(!String::from_utf8_lossy(&human.stdout).contains(SECRET_VALUE));
+
+    // The run now hydrates: the server sees the value; JSON carries names.
+    let hydrated = sandbox.run_json(&run);
+    let sent = String::from_utf8(first.join().unwrap()).unwrap();
+    assert_eq!(sent, format!(r#"{{"token":"{SECRET_VALUE}"}}"#));
+    assert_eq!(hydrated["lattice"]["secrets"]["hydrated"], json!(["token"]));
+    assert_eq!(hydrated["lattice"]["secrets"]["source"], "encrypted");
+    // The live document shows what was sent (upstream shape); Lattice's
+    // part of it carries names only.
+    assert!(!hydrated["lattice"].to_string().contains(SECRET_VALUE));
+    assert_golden("run_hydrated.json", &normalize(hydrated.clone()));
+    let run_id = hydrated["lattice"]["runId"].as_str().unwrap().to_owned();
+    let row = sandbox.run_json(&["history", ws, "--id", &run_id]);
+    assert_eq!(row["run"]["varNames"], json!([]), "hydration is not --var");
+    // Scrubbed at record time: URL query and the custom header.
+    assert!(row["run"]["url"].as_str().unwrap().contains("t=<redacted>"));
+    let headers = row["run"]["request"]["headers"].as_array().unwrap();
+    let x_token = headers.iter().find(|h| h["name"] == "X-Token").unwrap();
+    assert_eq!(x_token["value"], "<redacted>");
+    assert_no_secret_anywhere(&sandbox, ws);
+    let human = sandbox.facet().args(run).output().unwrap();
+    assert_eq!(
+        human.status.code(),
+        Some(6),
+        "server gone: transport failure"
+    );
+
+    // replay hydrates too (same URL live again, so the hash is unchanged).
+    let again = serve_again(&url, ECHO_BODY.to_vec());
+    let replayed = sandbox.run_json(&["replay", &run_id, ws]);
+    assert_eq!(
+        String::from_utf8(again.join().unwrap()).unwrap(),
+        format!(r#"{{"token":"{SECRET_VALUE}"}}"#)
+    );
+    assert_eq!(replayed["lattice"]["secrets"]["hydrated"], json!(["token"]));
+    assert_eq!(replayed["lattice"]["replayedFrom"], run_id);
+    assert_no_secret_anywhere(&sandbox, ws);
+
+    // --var wins and is not reported as hydrated.
+    let (url2, second) = serve_once(ECHO_BODY.to_vec(), "application/json");
+    let workspace = sandbox.secret_workspace(&url2);
+    let ws = workspace.to_str().unwrap();
+    let overridden = sandbox.run_json(&[
+        "request",
+        "run",
+        ws,
+        "items/0",
+        "--environment",
+        "local",
+        "--var",
+        "token=from-var",
+    ]);
+    assert_eq!(second.join().unwrap(), br#"{"token":"from-var"}"#);
+    assert_eq!(overridden["lattice"]["secrets"]["hydrated"], json!([]));
+    assert!(overridden["lattice"]["secrets"]["source"].is_null());
+    let overridden_id = overridden["lattice"]["runId"].as_str().unwrap();
+    let row = sandbox.run_json(&["history", ws, "--id", overridden_id]);
+    assert!(
+        row["run"]["url"].as_str().unwrap().contains("t=<redacted>"),
+        "--var secret scrubbed"
+    );
+    assert_eq!(row["run"]["varNames"], json!(["token"]));
+    let dump = sandbox.run_json(&[
+        "history",
+        ws,
+        "--sql",
+        "SELECT url, req_headers, error FROM runs",
+    ]);
+    assert!(!dump.to_string().contains("from-var"), "{dump}");
+
+    // Backend down (empty FACET_SECRET_KEY) with a declared secret referenced:
+    // one clear exit 5, before any network.
+    let output = sandbox
+        .facet()
+        .env("FACET_SECRET_KEY", "")
+        .args([
+            "request",
+            "run",
+            ws,
+            "items/0",
+            "--environment",
+            "local",
+            "--json",
+        ])
+        .output()
+        .unwrap();
+    assert_eq!(output.status.code(), Some(5));
+    let error: Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(error["error"]["category"], "secret_backend_unavailable");
+    assert_eq!(error["error"]["details"]["variable"], "token");
+    assert_golden(
+        "error_secret_backend_unavailable.json",
+        &normalize_error(error),
+    );
+    let output = sandbox
+        .facet()
+        .env("FACET_SECRET_KEY", "")
+        .args([
+            "env",
+            "set",
+            ws,
+            "--environment",
+            "local",
+            "--name",
+            "other",
+            "--value",
+            "x",
+            "--secret",
+            "--json",
+        ])
+        .output()
+        .unwrap();
+    assert_eq!(output.status.code(), Some(5));
+    assert_eq!(
+        sandbox.run_json(&["env", "list", ws])["entries"]
+            .as_array()
+            .unwrap()
+            .len(),
+        1
+    );
+
+    // Wrong key: also backend unavailable, never an empty substitution.
+    let output = sandbox
+        .facet()
+        .env("FACET_SECRET_KEY", "another-key")
+        .args([
+            "request",
+            "run",
+            ws,
+            "items/0",
+            "--environment",
+            "local",
+            "--json",
+        ])
+        .output()
+        .unwrap();
+    assert_eq!(output.status.code(), Some(5));
+
+    // Delete, then the declared secret is unavailable again.
+    let deleted = sandbox.run_json(&[
+        "env",
+        "delete",
+        ws,
+        "--environment",
+        "local",
+        "--name",
+        "token",
+    ]);
+    assert_eq!(deleted["deleted"], true);
+    let (code, error) = sandbox.run_error_json(&run);
+    assert_eq!(code, 5);
+    assert_eq!(error["error"]["category"], "secret_variable_unavailable");
+    let (code, _) = sandbox.run_error_json(&["env", "set", ws, "--name", "x", "--value", "y"]);
+    assert_eq!(code, 2);
+}
+
+#[test]
+fn plain_lattice_values_hydrate_silently_and_yaml_only_runs_are_unchanged() {
+    let sandbox = Sandbox::new();
+    let (url, server) = serve_once(ECHO_BODY.to_vec(), "application/json");
+    let workspace = sandbox.workspace(&url);
+    let ws = workspace.to_str().unwrap();
+    let plain = sandbox.run_json(&["request", "run", ws, "items/0", "--environment", "local"]);
+    server.join().unwrap();
+    assert_eq!(
+        plain["lattice"]["secrets"],
+        json!({ "hydrated": [], "source": null })
+    );
+    // No environment selected: upstream sends the literal template (and
+    // fails to build the URL); there is no hydration and no `secrets` field.
+    let (code, bare) = sandbox.run_error_json(&["request", "run", ws, "items/0"]);
+    assert_eq!(code, 5);
+    assert_eq!(bare["error"]["category"], "request_configuration");
+    assert!(bare["error"]["details"]["lattice"].get("secrets").is_none());
+
+    // A plain Lattice value for a referenced, non-secret variable overlays
+    // the YAML value, and works even with no secrets backend at all.
+    let (moved_url, moved) = serve_once(ECHO_BODY.to_vec(), "application/json");
+    sandbox.run_json(&[
+        "env",
+        "set",
+        ws,
+        "--environment",
+        "local",
+        "--name",
+        "serverUrl",
+        "--value",
+        &moved_url,
+    ]);
+    let output = sandbox
+        .facet()
+        .env("FACET_SECRET_KEY", "")
+        .args([
+            "request",
+            "run",
+            ws,
+            "items/0",
+            "--environment",
+            "local",
+            "--json",
+        ])
+        .output()
+        .unwrap();
+    moved.join().unwrap();
+    assert!(
+        output.status.success(),
+        "{}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let value: Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(
+        value["lattice"]["secrets"]["hydrated"],
+        json!(["serverUrl"])
+    );
+    assert_eq!(value["lattice"]["secrets"]["source"], "plain");
+    assert!(
+        value["request"]["url"]
+            .as_str()
+            .unwrap()
+            .starts_with(&moved_url)
+    );
+
+    // A Lattice value for a name the request does not reference is ignored.
+    sandbox.run_json(&[
+        "env",
+        "delete",
+        ws,
+        "--environment",
+        "local",
+        "--name",
+        "serverUrl",
+    ]);
+    sandbox.run_json(&[
+        "env",
+        "set",
+        ws,
+        "--environment",
+        "local",
+        "--name",
+        "unused",
+        "--value",
+        "z",
+    ]);
+    let (url3, third) = serve_once(ECHO_BODY.to_vec(), "application/json");
+    let workspace = sandbox.workspace(&url3);
+    let ws = workspace.to_str().unwrap();
+    let value = sandbox.run_json(&["request", "run", ws, "items/0", "--environment", "local"]);
+    third.join().unwrap();
+    assert_eq!(value["lattice"]["secrets"]["hydrated"], json!([]));
+    let list = sandbox.run_json(&["env", "list", ws, "--environment", "local"]);
+    assert_eq!(list["entries"][0]["name"], "unused");
+    let none = sandbox.run_json(&["env", "list", ws, "--environment", "prod"]);
+    assert_eq!(none["entries"], json!([]));
+}

--- a/crates/facet/tests/golden/env_list.json
+++ b/crates/facet/tests/golden/env_list.json
@@ -1,0 +1,15 @@
+{
+  "entries": [
+    {
+      "environment": "local",
+      "name": "token",
+      "secret": true,
+      "updatedAt": "<int>"
+    }
+  ],
+  "schemaVersion": 1,
+  "workspace": {
+    "id": "<ulid>",
+    "path": "<path>"
+  }
+}

--- a/crates/facet/tests/golden/env_set.json
+++ b/crates/facet/tests/golden/env_set.json
@@ -1,0 +1,13 @@
+{
+  "entry": {
+    "environment": "local",
+    "name": "token",
+    "secret": true,
+    "updatedAt": "<int>"
+  },
+  "schemaVersion": 1,
+  "workspace": {
+    "id": "<ulid>",
+    "path": "<path>"
+  }
+}

--- a/crates/facet/tests/golden/error_secret_backend_unavailable.json
+++ b/crates/facet/tests/golden/error_secret_backend_unavailable.json
@@ -1,0 +1,11 @@
+{
+  "error": {
+    "category": "secret_backend_unavailable",
+    "details": {
+      "variable": "token"
+    },
+    "exitCode": 5,
+    "message": "<message>"
+  },
+  "schemaVersion": 1
+}

--- a/crates/facet/tests/golden/run.json
+++ b/crates/facet/tests/golden/run.json
@@ -9,6 +9,10 @@
       "sizeBytes": 12
     },
     "runId": "<ulid>",
+    "secrets": {
+      "hydrated": [],
+      "source": null
+    },
     "workspaceId": "<ulid>"
   },
   "request": {

--- a/crates/facet/tests/golden/run_hydrated.json
+++ b/crates/facet/tests/golden/run_hydrated.json
@@ -1,9 +1,7 @@
 {
   "lattice": {
-    "hashChanged": false,
     "indexed": true,
     "recorded": true,
-    "replayedFrom": "<ulid>",
     "requestHash": "<sha256>",
     "responseBody": {
       "hash": null,
@@ -12,8 +10,10 @@
     },
     "runId": "<ulid>",
     "secrets": {
-      "hydrated": [],
-      "source": null
+      "hydrated": [
+        "token"
+      ],
+      "source": "encrypted"
     },
     "workspaceId": "<ulid>"
   },

--- a/docs/FACET.md
+++ b/docs/FACET.md
@@ -251,6 +251,9 @@ facet session list [--limit <n>] [--actor <name>] [--open] [--json]
 facet session show <id>|current [--json]
 facet replay <runId> [<path>] [--frozen] [--environment <name>] [--var k=v]... [--tag <tag>]... [--strict-variables] [--no-record] [--json]
 facet diff <idA> <idB> [<path>] [--bodies] [--json]
+facet env set [<path>] --environment <name> --name <key> --value <value> [--secret] [--json]
+facet env list [<path>] [--environment <name>] [--json]
+facet env delete [<path>] --environment <name> --name <key> [--json]
 facet blob <hash> [<path>] [--output <file>] [--json]
 facet gc [<path>] [--history-retention <r>] [--yes] [--json]
 facet tui [<path>] [--appearance graphite|porcelain]
@@ -463,6 +466,66 @@ Exit **0** equal, **1** different, **4** a run missing
 (`run_not_found`, `details.missing: ["01K…"]`), **9** no store. `--quiet`
 keeps the exit code.
 
+### Secret hydration and `env`
+
+Three layers, and the order is the design:
+
+1. OpenCollection YAML declares variables, plain or `secret: true`. Core
+   refuses to interpolate a declared secret with no value:
+   `secret_variable_unavailable` (exit 5). That stays the floor.
+2. The Facet machine store holds values keyed `(workspace, environment, key)`,
+   plain or through the secrets layer (Surface 3). `facet env set` writes them.
+3. `--var` is the runtime override channel. Last one wins.
+
+On `request run`, `replay`, and a TUI send, when an environment is selected,
+Facet overlays layer 2 as overrides **before** the user's `--var`: only for
+variable names the request references (`discover_request_variables`), never
+the whole environment, never an empty value, never the name. A user `--var`
+for the same name is used instead and the Lattice value is not read. YAML-only
+runs (no `--environment`) are untouched and carry no `secrets` field.
+
+`lattice.secrets` reports names only:
+
+```json
+"lattice": { "…": "…", "secrets": { "hydrated": ["token"], "source": "keyring" | "encrypted" | "plain" } }
+```
+
+`source` is the secrets backend when a secret was read, `plain` when only
+plaintext rows were used, `null` when nothing was hydrated. Human:
+`… · hydrated 1 secret from encrypted`. Hydrated names are **not** `varNames`
+(those are the user's `--var`).
+
+Failure rules: a referenced variable declared `secret` whose backend cannot
+serve it (no keyring and no `FACET_SECRET_KEY`, empty or wrong key, keyring
+error) is `secret_backend_unavailable` (exit 5, `details.variable`) before
+any network. When no referenced variable is declared secret, backend
+problems are silent and the YAML value applies. A Lattice row for a name the
+request does not reference is ignored.
+
+`facet env` is Facet's machine-store CLI, not Probe's `environment` (which
+edits YAML and rejects secrets). `set` stores one value (`--secret` routes it
+through the secrets layer and fails with `secret_backend_unavailable` when no
+backend can hold it); it creates the workspace store beside `<path>` when
+none exists. `list` and `set` return metadata only:
+
+```json
+{ "schemaVersion": 1, "workspace": { "id": "…", "path": "…" },
+  "entries": [ { "environment": "local", "name": "token", "secret": true, "updatedAt": 1757250000123 } ] }
+```
+
+There is no field for the value and there never will be. **Never in
+`history --json`, `--sql`, `session`, or `env list`:** Lattice environment
+values, `--var` values for declared secrets, `FACET_SECRET_KEY`, or `kr:` /
+`enc:v1:` references. Facet knows the values of declared secrets at record
+time (hydrated or passed with `--var`), so it scrubs them from the stored
+URL, request and response header values, and transport error text before
+the row is written (`<redacted>`; values shorter than 4 bytes are left
+alone). The live `request run` document still shows what was sent.
+`--sql` opens the workspace store only; the machine store (where
+`environments` lives) is never attached. Request bodies remain content-
+addressed blobs that may hold what the YAML put there; `facet blob` is the
+one place a human knowingly opens one.
+
 ### `blob`
 
 Writes the raw bytes to stdout. With `--json`:
@@ -499,8 +562,9 @@ Facet extends the upstream table; it never renumbers it.
 | 9 | Lattice store failure (`lattice_error`, `lattice_not_found`) |
 
 Additional stable categories: `blob_not_found`, `run_not_found`, and
-`session_not_found` (exit 4, "not found"); `session_not_set` (exit 5,
-configuration); `invalid_sql` and `sql_read_only` (exit 2). Every JSON document carries `schemaVersion: 1`;
+`session_not_found` (exit 4, "not found"); `session_not_set` and
+`secret_backend_unavailable` (exit 5, configuration); `invalid_sql` and
+`sql_read_only` (exit 2). Every JSON document carries `schemaVersion: 1`;
 fields are added compatibly and never removed or retyped within a version.
 
 ## Tests


### PR DESCRIPTION
## Summary

Goal 5 of deep dive §2.3: Lattice machine-store environment values overlay as `--var` **before** resolve on `request run`, `replay`, and TUI send. Plus `facet env set|list|delete`. Nothing in `probe-*`.

**Overlay (`facet_record::overlay_secrets`)**
- Only when an environment is selected. Only variable names the request references (`discover_request_variables`). Never the whole environment, never an empty value, never the name.
- Lattice values are placed before the user's `--var`, so `--var` wins (core's `raw.insert` keeps the last). A user `--var` for a name skips the Lattice read entirely and is not reported as hydrated.
- Missing Lattice value + YAML `secret: true` → core's `secret_variable_unavailable` (exit 5), unchanged floor. Plain YAML value with no Lattice row → YAML value, silent.
- Backend down (no keyring + no `FACET_SECRET_KEY`, empty key, wrong key, keyring failure) → `secret_backend_unavailable` (exit 5, `details.variable`) **only if** a referenced variable is declared secret; otherwise silent. Checked before any network.
- JSON: `lattice.secrets: { "hydrated": ["token"], "source": "keyring" | "encrypted" | "plain" }`, names only; present whenever an environment was selected (empty list + `null` when nothing hydrated), absent on YAML-only runs. Human: `· hydrated 1 secret from encrypted`. Hydrated names are not `varNames`.
- TUI send uses the same function (`prepared_request_with_redact`); a hydration error lands in the status line.

**Scrubbing at record time (found in the shell smoke)**
- A YAML that interpolates a secret into a query string or a custom header would have stored the value in `runs.url` / `req_headers` / transport `error` text. Facet knows declared-secret values at record time (hydrated, or passed with `--var` for a declared secret), so `facet_record::scrub` replaces them with `<redacted>` in stored URL, request and response header values, and error text (values under 4 bytes are left alone to avoid mangling). Bodies stay content-addressed blobs. The live `request run` document still shows what was sent.
- Test `assert_no_secret_anywhere` checks `history --bodies`, `--sql SELECT *`, `env list`, and `session list` for the value, the `enc:v1:` ref, and the key.

**`facet env`**
- `env set [<path>] --environment <e> --name <k> --value <v> [--secret]` (creates the workspace store beside `<path>` if needed; `--secret` fails fast with `secret_backend_unavailable` when no backend can hold it). `env list [--environment]` and `env delete`. Metadata only: `{ environment, name, secret, updatedAt }`; no value field, ever. Not Probe's `environment` (different store, no collision).
- `--sql` untouched: workspace store only, machine store never attached.
- `LatticeError::Secret` now maps to `secret_backend_unavailable` (5) instead of `lattice_error` (9).

**Not in this PR:** `facet doctor` (backend is taking it on this branch as a follow-up commit if it lands before merge), `--expect` (Goal 6), pins.

## Test plan

On apiary (`~/src/facet`, cargo 1.95), head of this branch:

- [x] `cargo test -p lattice -p facet-record -p facet-cli -p facet-tui`: all green (facet-cli 24/24 incl. `secret_hydration_overlays_lattice_values_before_resolve` and `plain_lattice_values_hydrate_silently_and_yaml_only_runs_are_unchanged`; facet-record 9 unit incl. scrub + hydration; facet-tui 55; lattice 37).
- [x] Tests run with `FACET_SECRET_KEY=test-master-key` (encrypted backend, no keyring prompts); backend-down cases use an empty key and a wrong key.
- [x] Goldens: new `env_set`, `env_list`, `run_hydrated`, `error_secret_backend_unavailable`; `run.json` / `replay.json` gain only `secrets: { hydrated: [], source: null }`.
- [x] Release build + shell smoke: declared secret with no value → exit 5; `env set --secret` → `env list` shows metadata; run hydrates (`hydrated 1 secret from encrypted`); `history --json --bodies` and `--sql SELECT *` contain neither the value nor `enc:v1:`; empty `FACET_SECRET_KEY` → `secret_backend_unavailable` exit 5; `--var token=…` wins with `hydrated: []`.
- [x] `cargo fmt --check` clean on touched files (pre-existing `lattice/tests/{duckdb,turso}.rs` debt remains). No new clippy warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01E3MvVHmyGKQdu6CRignmME
