### PR TITLE
feat: --expect and --dry-run on request run (Goal 6)

### DIFF
--- a/crates/facet-record/src/lib.rs
+++ b/crates/facet-record/src/lib.rs
@@ -401,6 +401,56 @@ fn url_encode(value: &str) -> String {
     out
 }
 
+/// What `--dry-run` shows: the resolved request as it would be sent, with
+/// the same redactions Lattice applies (sensitive header names, URL
+/// userinfo, known secret values) so a preview is safe to paste. Bodies are
+/// shown inline when UTF-8 and under `MAX_PREVIEW_BODY`, else by size only.
+#[must_use]
+pub fn request_preview_json(request: &HttpRequest, redact: &[String]) -> Value {
+    const MAX_PREVIEW_BODY: usize = 64 * 1024;
+    let body = request_body_bytes(request);
+    let body_json = match body.as_deref() {
+        None => {
+            json!({ "content": Value::Null, "sizeBytes": Value::Null, "omitted": false, "omissionReason": Value::Null })
+        }
+        Some(bytes) if bytes.len() > MAX_PREVIEW_BODY => json!({
+            "content": Value::Null, "sizeBytes": bytes.len(), "omitted": true, "omissionReason": "too_large",
+        }),
+        Some(bytes) => match std::str::from_utf8(bytes) {
+            Ok(text) => json!({
+                "content": scrub(text, redact), "sizeBytes": bytes.len(), "omitted": false, "omissionReason": Value::Null,
+            }),
+            Err(_) => json!({
+                "content": Value::Null, "sizeBytes": bytes.len(), "omitted": true, "omissionReason": "binary",
+            }),
+        },
+    };
+    let headers: Value = serde_json::from_str(&scrub(
+        &request_headers_json(&request.headers).to_string(),
+        redact,
+    ))
+    .unwrap_or(Value::Null);
+    let query: Vec<Value> = request
+        .query_parameters
+        .iter()
+        .map(|parameter| {
+            json!({
+                "disabled": parameter.disabled,
+                "name": parameter.name,
+                "value": scrub(&parameter.value, redact),
+            })
+        })
+        .collect();
+    json!({
+        "method": request.method,
+        "url": scrub(&redact_url(request.url.as_deref().unwrap_or("")), redact),
+        "query": query,
+        "headers": headers,
+        "body": body_json,
+        "requestHash": request_hash(request, body.as_deref()),
+    })
+}
+
 /// The `request_hash` Lattice would store for `request` as resolved now.
 /// `facet replay` compares this against the recorded row before sending.
 #[must_use]

--- a/crates/facet/src/doctor.rs
+++ b/crates/facet/src/doctor.rs
@@ -9,7 +9,7 @@ use lattice::{
 };
 use serde_json::{Value, json};
 
-use crate::{CommandOutput, FacetError, LATTICE_EXIT_CODE, ASSERTION_EXIT_CODE, args};
+use crate::{ASSERTION_EXIT_CODE, CommandOutput, FacetError, LATTICE_EXIT_CODE, args};
 
 const DOCTOR_FLAGS: &[&str] = &[];
 const DOCTOR_SWITCHES: &[&str] = &["--probe"];
@@ -88,7 +88,11 @@ pub(crate) fn doctor(args: &[String]) -> Result<CommandOutput, FacetError> {
     // as usable=false rather than an error.
     let (backend, usable): (&'static str, Option<bool>) = match SecretConfig::from_env() {
         Ok(secret_config) => {
-            let backend = if secret_config.is_encrypted() { "encrypted" } else { "keyring" };
+            let backend = if secret_config.is_encrypted() {
+                "encrypted"
+            } else {
+                "keyring"
+            };
             let usable = if probe {
                 Some(probe_secret_usable(&secret_config, &mut warnings))
             } else {
@@ -122,7 +126,11 @@ pub(crate) fn doctor(args: &[String]) -> Result<CommandOutput, FacetError> {
         "secrets": secrets_json,
         "env": env_json(),
     });
-    let exit_code = if warnings.is_empty() { 0 } else { ASSERTION_EXIT_CODE };
+    let exit_code = if warnings.is_empty() {
+        0
+    } else {
+        ASSERTION_EXIT_CODE
+    };
     Ok(finish(doctor_json, warnings, exit_code))
 }
 
@@ -170,9 +178,11 @@ fn probe_secret_usable(config: &SecretConfig, warnings: &mut Vec<String>) -> boo
 
 fn finish(doctor_json: Value, warnings: Vec<String>, exit_code: u8) -> CommandOutput {
     let human = doctor_human(&doctor_json, &warnings);
-    let mut output = CommandOutput::new(human, json!({ "doctor": doctor_json }))
-        .with_exit_code(exit_code);
-    output = warnings.iter().fold(output, |acc, warning| acc.warn(warning.clone()));
+    let mut output =
+        CommandOutput::new(human, json!({ "doctor": doctor_json })).with_exit_code(exit_code);
+    output = warnings
+        .iter()
+        .fold(output, |acc, warning| acc.warn(warning.clone()));
     output
 }
 

--- a/crates/facet/src/expect.rs
+++ b/crates/facet/src/expect.rs
@@ -1,0 +1,132 @@
+//! `--expect <codes>`: the assertion an agent asks for after a real run.
+//!
+//! Exit **1** (`expect_failed`) when the HTTP exchange completed and the
+//! status is not in the set. Transport, timeout, and cancel stay 6 so a
+//! harness that maps "6 → retry" never retries a 404, and one that maps
+//! "1 → stop, read the run" never parses a category first. The full success
+//! document is still emitted (run id in hand), plus `error`.
+
+use serde_json::{Value, json};
+
+use crate::{ASSERTION_EXIT_CODE, FacetError};
+
+/// Tag stamped on a recorded run that missed its expectation.
+pub(crate) const EXPECT_FAIL_TAG: &str = "expect:fail";
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+enum Token {
+    Code(u16),
+    Class(u16),
+}
+
+/// A parsed `--expect` specification.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) struct Expectation {
+    tokens: Vec<Token>,
+}
+
+impl Expectation {
+    /// Parses `200,201` or class shorthands `2xx`, `3xx` (mixable).
+    pub(crate) fn parse(spec: &str) -> Result<Self, FacetError> {
+        let mut tokens = Vec::new();
+        for raw in spec.split(',') {
+            let item = raw.trim();
+            let token = match item.strip_suffix("xx") {
+                Some(class) => class
+                    .parse::<u16>()
+                    .ok()
+                    .filter(|class| (1..=5).contains(class))
+                    .map(Token::Class),
+                None => item
+                    .parse::<u16>()
+                    .ok()
+                    .filter(|code| (100..=599).contains(code))
+                    .map(Token::Code),
+            };
+            let Some(token) = token else {
+                return Err(FacetError::invalid_arguments(format!(
+                    "--expect expects HTTP status codes or classes like 200,201 or 2xx, got {item:?}"
+                )));
+            };
+            tokens.push(token);
+        }
+        Ok(Self { tokens })
+    }
+
+    /// Whether `status` satisfies the expectation.
+    pub(crate) fn matches(&self, status: u16) -> bool {
+        self.tokens.iter().any(|token| match token {
+            Token::Code(code) => *code == status,
+            Token::Class(class) => status / 100 == *class,
+        })
+    }
+
+    /// The tokens as given: numbers for codes, strings for classes.
+    pub(crate) fn json(&self) -> Value {
+        Value::Array(
+            self.tokens
+                .iter()
+                .map(|token| match token {
+                    Token::Code(code) => json!(code),
+                    Token::Class(class) => json!(format!("{class}xx")),
+                })
+                .collect(),
+        )
+    }
+
+    /// The `expect_failed` error for a completed exchange with `status`.
+    pub(crate) fn failure(&self, status: u16) -> FacetError {
+        FacetError::expect_failed(
+            format!("expected status in {}, got {status}", self.json()),
+            json!({ "expected": self.json(), "actual": status }),
+        )
+    }
+
+    /// `None` when the exchange did not complete (transport family keeps its
+    /// own exit code) or the status is in the set.
+    pub(crate) fn miss(&self, status: Option<u16>) -> Option<FacetError> {
+        match status {
+            Some(status) if !self.matches(status) => Some(self.failure(status)),
+            _ => None,
+        }
+    }
+}
+
+impl FacetError {
+    pub(crate) fn expect_failed(message: String, details: Value) -> Self {
+        Self {
+            category: "expect_failed",
+            message,
+            exit_code: ASSERTION_EXIT_CODE,
+            details: Some(details),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Expectation;
+
+    #[test]
+    fn parses_codes_and_classes() {
+        let expect = Expectation::parse("200, 201,3xx").unwrap();
+        assert!(expect.matches(200));
+        assert!(expect.matches(201));
+        assert!(expect.matches(302));
+        assert!(!expect.matches(204));
+        assert_eq!(expect.json().to_string(), r#"[200,201,"3xx"]"#);
+        assert!(expect.miss(None).is_none(), "transport stays 6");
+        assert!(expect.miss(Some(200)).is_none());
+        let error = expect.miss(Some(500)).unwrap();
+        assert_eq!(error.category, "expect_failed");
+        assert_eq!(error.exit_code, 1);
+        assert_eq!(error.details.unwrap()["actual"], 500);
+    }
+
+    #[test]
+    fn rejects_bad_tokens() {
+        for bad in ["20x", "6xx", "0xx", "999", "", "200,", "ok"] {
+            assert!(Expectation::parse(bad).is_err(), "{bad:?}");
+        }
+    }
+}

--- a/crates/facet/src/lib.rs
+++ b/crates/facet/src/lib.rs
@@ -10,6 +10,7 @@
 //! - `session` starts, ends, lists, and shows agent sessions in the machine store.
 //! - `replay` re-sends a recorded run from the current YAML; `diff` compares two runs.
 //! - `env` sets and lists machine-store environment values (metadata only on read).
+//! - `request run --expect` / `--dry-run`: the assertion (exit 1) and the preview.
 //! - `tui` opens the terminal UI.
 //!
 //! Contract details for the Facet-only commands live in `docs/FACET.md`.
@@ -25,6 +26,7 @@ mod diff;
 mod doctor;
 mod env;
 mod error;
+mod expect;
 mod history;
 mod presentation;
 mod replay;
@@ -106,6 +108,8 @@ pub(crate) struct CommandOutput {
     human: Vec<u8>,
     json: Value,
     warnings: Vec<String>,
+    /// `error[category]: message` lines for stderr (suppressed by --quiet).
+    errors: Vec<String>,
     exit_code: u8,
 }
 
@@ -115,8 +119,32 @@ impl CommandOutput {
             human: human.into(),
             json,
             warnings: Vec::new(),
+            errors: Vec::new(),
             exit_code: 0,
         }
+    }
+
+    /// A complete success document that nonetheless failed the caller's
+    /// assertion (`--expect`): the document stays, `error` is added to the
+    /// JSON, the human view gains an `error[...]` line on stderr, and the
+    /// process exits with the error's code.
+    pub(crate) fn fail(mut self, error: FacetError) -> Self {
+        let mut envelope = json!({
+            "category": error.category,
+            "exitCode": error.exit_code,
+            "message": error.message,
+        });
+        if let Some(details) = error.details {
+            envelope["details"] = details;
+        }
+        self.errors.push(format!(
+            "error[{}]: {}
+",
+            error.category, error.message
+        ));
+        self.json["error"] = envelope;
+        self.exit_code = error.exit_code;
+        self
     }
 
     pub(crate) fn warn(mut self, warning: impl Into<String>) -> Self {
@@ -139,11 +167,15 @@ impl CommandOutput {
         } else {
             self.human
         };
-        let stderr = self
+        let mut stderr: String = self
             .warnings
             .iter()
             .map(|warning| format!("warning: {warning}\n"))
             .collect();
+        // The JSON document carries `error`; the human view says it on stderr.
+        if !quiet && !json_output {
+            stderr.extend(self.errors.iter().map(String::as_str));
+        }
         RunOutput {
             stdout,
             stderr,
@@ -164,6 +196,7 @@ pub const fn help() -> &'static str {
         "\n",
         "Commands:\n",
         "  request run <path> <selector>       Execute an HTTP request and record it in Lattice\n",
+        "      [--expect <codes>] [--dry-run]  Assert the status (exit 1 on miss) or preview only\n",
         "  history [<path>]                    List recorded runs, newest first (metadata only)\n",
         "  history [<path>] --id <ulid>        Show one recorded run by id\n",
         "  history [<path>] --sql <query>      Run read-only SQL against the workspace store\n",
@@ -184,6 +217,8 @@ pub const fn help() -> &'static str {
         "\n",
         "Options:\n",
         "      --no-record             Execute without writing to Lattice\n",
+        "      --expect <codes>        Assert the status: 200,201 or 2xx; miss is exit 1 expect_failed\n",
+        "      --dry-run               Resolve and preview the request without sending or recording\n",
         "      --tag <tag>             Tag the recorded run, or filter history by tag (AND); may be repeated\n",
         "      --inline-body-max <n>   Inline bodies at or under this size (e.g. 64KiB)\n",
         "      --history-retention <r> Retention window for gc (unlimited or e.g. 30d)\n",
@@ -247,8 +282,8 @@ where
     let owned = match args.first().map(String::as_str) {
         None => true,
         Some(
-            "history" | "session" | "replay" | "diff" | "env" | "doctor" | "blob" | "gc"
-            | "tui" | "-V" | "--version" | "-h" | "--help",
+            "history" | "session" | "replay" | "diff" | "env" | "doctor" | "blob" | "gc" | "tui"
+            | "-V" | "--version" | "-h" | "--help",
         ) => true,
         Some("request") => args.get(1).map(String::as_str) == Some("run"),
         Some(_) => false,

--- a/crates/facet/src/replay.rs
+++ b/crates/facet/src/replay.rs
@@ -19,6 +19,7 @@ use serde_json::json;
 
 use crate::{
     CommandOutput, FacetError, args,
+    expect::{EXPECT_FAIL_TAG, Expectation},
     run::{
         execute, hydrate, lookup_request, parse_vars, render, resolve_selected, var_names,
         with_secrets,
@@ -30,6 +31,7 @@ const VALUE_FLAGS: &[&str] = &[
     "--environment",
     "--var",
     "--tag",
+    "--expect",
     "--inline-body-max",
     "--history-retention",
 ];
@@ -57,6 +59,10 @@ pub(crate) fn replay(args: &[String], stdin: &mut impl Read) -> Result<CommandOu
     let should_record = !parsed.switch("--no-record") && !recording_disabled();
     let overrides = overrides_from_parsed(&parsed)?;
     let variables = parse_vars(&parsed)?;
+    let expect = parsed
+        .value("--expect")?
+        .map(Expectation::parse)
+        .transpose()?;
     let extra_tags: Vec<String> = parsed
         .values("--tag")
         .into_iter()
@@ -140,7 +146,16 @@ pub(crate) fn replay(args: &[String], stdin: &mut impl Read) -> Result<CommandOu
 
     // 5. Send and record with lineage.
     let execution = execute(&request, input.base_directory(), None)?;
-    let tags = merged_tags(row.tags.as_deref(), &extra_tags);
+    let status = execution
+        .result
+        .as_ref()
+        .ok()
+        .map(|response| response.status);
+    let miss = expect.as_ref().and_then(|expect| expect.miss(status));
+    let mut tags = merged_tags(row.tags.as_deref(), &extra_tags);
+    if miss.is_some() && !tags.iter().any(|tag| tag == EXPECT_FAIL_TAG) {
+        tags.push(EXPECT_FAIL_TAG.to_owned());
+    }
     let recording = if should_record {
         let actor = actor_from_env();
         let session = session_from_env();
@@ -185,14 +200,18 @@ pub(crate) fn replay(args: &[String], stdin: &mut impl Read) -> Result<CommandOu
             "request unchanged"
         }
     );
-    render(
+    let rendered = render(
         &request,
         execution,
         None,
         lattice_json,
         lattice_human,
         warnings,
-    )
+    )?;
+    Ok(match miss {
+        Some(error) => rendered.fail(error),
+        None => rendered,
+    })
 }
 
 /// Recorded tags first, then `--tag` additions, without duplicates.

--- a/crates/facet/src/run.rs
+++ b/crates/facet/src/run.rs
@@ -11,7 +11,7 @@ use std::{
 
 use facet_record::{
     Hydration, RecordRequest, Recording, actor_from_env, overlay_secrets, record,
-    recording_disabled, session_from_env,
+    recording_disabled, request_preview_json, session_from_env,
 };
 use lattice::now_ms;
 use probe_core::{
@@ -23,6 +23,7 @@ use serde_json::{Value, json};
 
 use crate::{
     CommandOutput, FacetError, args,
+    expect::{EXPECT_FAIL_TAG, Expectation},
     presentation::{response_human, response_json},
     workspace::{WorkspaceInput, load, overrides_from_parsed},
 };
@@ -32,10 +33,11 @@ const VALUE_FLAGS: &[&str] = &[
     "--output",
     "--var",
     "--tag",
+    "--expect",
     "--inline-body-max",
     "--history-retention",
 ];
-const SWITCH_FLAGS: &[&str] = &["--strict-variables", "--no-record"];
+const SWITCH_FLAGS: &[&str] = &["--strict-variables", "--no-record", "--dry-run"];
 
 /// One executed request: when it started, how long it took, and the outcome.
 pub(crate) struct Execution {
@@ -56,13 +58,23 @@ pub(crate) fn run(args: &[String], stdin: &mut impl Read) -> Result<CommandOutpu
     let output = parsed.value("--output")?.map(PathBuf::from);
     let strict_variables = parsed.switch("--strict-variables");
     let variables = parse_vars(&parsed)?;
-    let tags: Vec<String> = parsed
+    let mut tags: Vec<String> = parsed
         .values("--tag")
         .into_iter()
         .map(str::to_owned)
         .collect();
     let should_record = !parsed.switch("--no-record") && !recording_disabled();
     let overrides = overrides_from_parsed(&parsed)?;
+    let expect = parsed
+        .value("--expect")?
+        .map(Expectation::parse)
+        .transpose()?;
+    let dry_run = parsed.switch("--dry-run");
+    if dry_run && (expect.is_some() || output.is_some()) {
+        return Err(FacetError::invalid_arguments(
+            "--dry-run sends nothing; it cannot be combined with --expect or --output",
+        ));
+    }
 
     let loaded = load(&input, stdin)?;
     let base = input.base_directory();
@@ -81,7 +93,21 @@ pub(crate) fn run(args: &[String], stdin: &mut impl Read) -> Result<CommandOutpu
         &hydration.merged(&variables),
         strict_variables,
     )?;
+    if dry_run {
+        return Ok(dry_run_output(&request, &hydration, environment.is_some()));
+    }
     let execution = execute(&request, input.base_directory(), output.as_deref())?;
+    let status = execution
+        .result
+        .as_ref()
+        .ok()
+        .map(|response| response.status);
+    let miss = expect.as_ref().and_then(|expect| expect.miss(status));
+    if miss.is_some() {
+        // Auto-tag, no schema: `history --tag expect:fail` answers "what
+        // failed this session" without --sql.
+        tags.push(EXPECT_FAIL_TAG.to_owned());
+    }
 
     let recording = if should_record {
         let root = input.base_directory();
@@ -114,14 +140,103 @@ pub(crate) fn run(args: &[String], stdin: &mut impl Read) -> Result<CommandOutpu
         &hydration,
         environment.is_some(),
     );
-    render(
+    let rendered = render(
         &request,
         execution,
         output.as_deref(),
         lattice_json,
         lattice_human,
         recording.warning().into_iter().collect(),
-    )
+    )?;
+    Ok(match miss {
+        Some(error) => rendered.fail(error),
+        None => rendered,
+    })
+}
+
+/// `--dry-run`: the resolved request (hydration included), nothing sent,
+/// nothing recorded. `lattice.requestHash` is what a real run would store,
+/// so an agent can compare it against a recorded run before firing.
+pub(crate) fn dry_run_output(
+    request: &HttpRequest,
+    hydration: &Hydration,
+    environment_selected: bool,
+) -> CommandOutput {
+    let preview = request_preview_json(request, &hydration.redact);
+    // Human view shows enabled query parameters on the URL line, as sent.
+    let query: Vec<String> = preview["query"]
+        .as_array()
+        .map(|items| {
+            items
+                .iter()
+                .filter(|item| item["disabled"] != true)
+                .map(|item| {
+                    format!(
+                        "{}={}",
+                        item["name"].as_str().unwrap_or(""),
+                        item["value"].as_str().unwrap_or("")
+                    )
+                })
+                .collect()
+        })
+        .unwrap_or_default();
+    let url = preview["url"].as_str().unwrap_or("<unset>");
+    let url = if query.is_empty() {
+        url.to_owned()
+    } else {
+        format!("{url}?{}", query.join("&"))
+    };
+    let mut human = format!(
+        "{} {url}
+Headers:
+",
+        preview["method"].as_str().unwrap_or("<unset>")
+    );
+    match preview["headers"].as_array() {
+        Some(headers) if !headers.is_empty() => {
+            for header in headers {
+                human.push_str(&format!(
+                    "  {}: {}\n",
+                    header["name"].as_str().unwrap_or(""),
+                    header["value"].as_str().unwrap_or("")
+                ));
+            }
+        }
+        _ => human.push_str("  (none)\n"),
+    }
+    human.push('\n');
+    match (
+        preview["body"]["content"].as_str(),
+        preview["body"]["sizeBytes"].as_u64(),
+    ) {
+        (Some(content), _) => {
+            human.push_str(content);
+            if !content.ends_with('\n') {
+                human.push('\n');
+            }
+        }
+        (None, Some(size)) => human.push_str(&format!("Body omitted ({size} bytes)\n")),
+        (None, None) => human.push_str("(no body)\n"),
+    }
+    let mut lattice_json = json!({
+        "recorded": false,
+        "reason": "dry_run",
+        "requestHash": preview["requestHash"],
+    });
+    let (lattice_json, lattice_human) = with_secrets(
+        std::mem::take(&mut lattice_json),
+        "not recorded (dry_run)".to_owned(),
+        hydration,
+        environment_selected,
+    );
+    human.push_str(&format!("Lattice: {lattice_human}\n"));
+    let mut json = json!({ "dryRun": true, "request": preview });
+    json["request"]
+        .as_object_mut()
+        .expect("preview is an object")
+        .remove("requestHash");
+    json["lattice"] = lattice_json;
+    CommandOutput::new(human, json)
 }
 
 /// Secret hydration (Goal 5): Lattice environment values for the names the

--- a/crates/facet/tests/facet_commands.rs
+++ b/crates/facet/tests/facet_commands.rs
@@ -1391,7 +1391,11 @@ fn doctor_reports_stores_secrets_backend_and_env_presence() {
 
     let doctor = sandbox.run_json(&["doctor"]);
     assert_eq!(doctor["doctor"]["machine"]["opened"], true);
-    assert!(doctor["doctor"]["machine"]["schemaVersion"].as_i64().is_some());
+    assert!(
+        doctor["doctor"]["machine"]["schemaVersion"]
+            .as_i64()
+            .is_some()
+    );
     assert_eq!(doctor["doctor"]["workspace"]["found"], true);
     assert!(doctor["doctor"]["workspace"]["id"].as_str().is_some());
     assert_eq!(doctor["doctor"]["workspace"]["schemaVersion"], 3);
@@ -1430,7 +1434,11 @@ fn doctor_probe_round_trips_a_secret_and_marks_the_backend_usable() {
     assert_eq!(doctor["doctor"]["secrets"]["usable"], true);
     assert_eq!(doctor["doctor"]["secrets"]["probe"], true);
     // The probe must not leave the probe value anywhere in the output.
-    assert!(!doctor.to_string().contains("facet-doctor-probe-not-a-real-secret"));
+    assert!(
+        !doctor
+            .to_string()
+            .contains("facet-doctor-probe-not-a-real-secret")
+    );
     assert_golden("doctor_probe.json", &normalize(doctor));
 }
 
@@ -1456,7 +1464,11 @@ fn history_sql_cannot_reach_the_machine_store_or_any_secret_ref() {
     // The machine store lives under FACET_DATA_DIR (sandbox/machine/lattice.db).
     // `--sql` must not be able to ATTACH it.
     let machine_db = sandbox.root().join("machine").join("lattice.db");
-    assert!(machine_db.is_file(), "machine store exists at {}", machine_db.display());
+    assert!(
+        machine_db.is_file(),
+        "machine store exists at {}",
+        machine_db.display()
+    );
     let attach = format!("ATTACH 'file:{}' AS machine", machine_db.to_string_lossy());
     let (attach_code, attach_error) = sandbox.run_error_json(&["history", root, "--sql", &attach]);
     assert_eq!(attach_code, 2);
@@ -1468,8 +1480,12 @@ fn history_sql_cannot_reach_the_machine_store_or_any_secret_ref() {
 
     // The workspace store has no `environments` table (it lives in the
     // machine store); a query for it must fail.
-    let (env_code, env_error) =
-        sandbox.run_error_json(&["history", root, "--sql", "SELECT count(*) FROM environments"]);
+    let (env_code, env_error) = sandbox.run_error_json(&[
+        "history",
+        root,
+        "--sql",
+        "SELECT count(*) FROM environments",
+    ]);
     assert_eq!(env_code, 2);
     assert_eq!(env_error["error"]["category"], "invalid_sql");
 
@@ -1493,4 +1509,281 @@ fn history_sql_cannot_reach_the_machine_store_or_any_secret_ref() {
     assert!(!dump.to_string().contains("probe-secret-value"));
     assert!(!dump.to_string().contains("enc:v1:"));
     assert!(!dump.to_string().contains("kr:"));
+}
+
+#[test]
+fn expect_is_exit_1_on_a_miss_with_the_full_document() {
+    let sandbox = Sandbox::new();
+    let hit = record_one_run(&sandbox, &["--expect", "2xx"]);
+    assert_eq!(hit["response"]["status"], 200);
+    assert!(hit.get("error").is_none());
+    let hit = record_one_run(&sandbox, &["--expect", "201, 200"]);
+    assert!(hit.get("error").is_none());
+
+    // Miss: full success document plus `error`, exit 1, recorded and tagged.
+    let (url, server) = serve_once(ECHO_BODY.to_vec(), "application/json");
+    let workspace = sandbox.workspace(&url);
+    let ws = workspace.to_str().unwrap();
+    let output = sandbox
+        .facet()
+        .args([
+            "request",
+            "run",
+            ws,
+            "items/0",
+            "--environment",
+            "local",
+            "--expect",
+            "201,204",
+            "--tag",
+            "smoke",
+            "--json",
+        ])
+        .output()
+        .unwrap();
+    server.join().unwrap();
+    assert_eq!(output.status.code(), Some(1));
+    assert!(output.stderr.is_empty(), "json mode keeps stderr clean");
+    let miss: Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(miss["response"]["status"], 200);
+    assert_eq!(miss["response"]["body"]["content"], r#"{"users":[]}"#);
+    assert_eq!(miss["lattice"]["recorded"], true);
+    assert_eq!(miss["error"]["category"], "expect_failed");
+    assert_eq!(miss["error"]["exitCode"], 1);
+    assert_eq!(miss["error"]["details"]["expected"], json!([201, 204]));
+    assert_eq!(miss["error"]["details"]["actual"], 200);
+    assert_golden("run_expect_failed.json", &normalize(miss.clone()));
+    let run_id = miss["lattice"]["runId"].as_str().unwrap();
+    let failed = sandbox.run_json(&["history", ws, "--tag", "expect:fail"]);
+    assert_eq!(failed["runs"].as_array().unwrap().len(), 1);
+    assert_eq!(failed["runs"][0]["id"], run_id);
+    assert_eq!(failed["runs"][0]["tags"], json!(["smoke", "expect:fail"]));
+
+    // Human: response on stdout, error line on stderr; --quiet: nothing, 1.
+    let (url, server) = serve_once(ECHO_BODY.to_vec(), "application/json");
+    let workspace = sandbox.workspace(&url);
+    let ws = workspace.to_str().unwrap();
+    let human = sandbox
+        .facet()
+        .args([
+            "request",
+            "run",
+            ws,
+            "items/0",
+            "--environment",
+            "local",
+            "--expect",
+            "3xx",
+        ])
+        .output()
+        .unwrap();
+    server.join().unwrap();
+    assert_eq!(human.status.code(), Some(1));
+    assert!(String::from_utf8_lossy(&human.stdout).contains("200 OK"));
+    assert!(String::from_utf8_lossy(&human.stderr).starts_with("error[expect_failed]:"));
+    let (url, server) = serve_once(ECHO_BODY.to_vec(), "application/json");
+    let workspace = sandbox.workspace(&url);
+    let ws = workspace.to_str().unwrap();
+    let quiet = sandbox
+        .facet()
+        .args([
+            "request",
+            "run",
+            ws,
+            "items/0",
+            "--environment",
+            "local",
+            "--expect",
+            "500",
+            "--quiet",
+        ])
+        .output()
+        .unwrap();
+    server.join().unwrap();
+    assert_eq!(quiet.status.code(), Some(1));
+    assert!(quiet.stdout.is_empty());
+    assert!(quiet.stderr.is_empty());
+
+    // Transport failure keeps 6 even with --expect; bad specs are 2.
+    let dead = sandbox.workspace("http://127.0.0.1:9");
+    let (code, error) = sandbox.run_error_json(&[
+        "request",
+        "run",
+        dead.to_str().unwrap(),
+        "items/0",
+        "--environment",
+        "local",
+        "--expect",
+        "2xx",
+    ]);
+    assert_eq!(code, 6);
+    assert_eq!(error["error"]["category"], "network_execution");
+    assert!(error.get("response").is_none());
+    for bad in ["20x", "6xx", "ok", "200,"] {
+        let (code, error) = sandbox.run_error_json(&[
+            "request",
+            "run",
+            dead.to_str().unwrap(),
+            "items/0",
+            "--expect",
+            bad,
+        ]);
+        assert_eq!(code, 2, "{bad}");
+        assert_eq!(error["error"]["category"], "invalid_arguments");
+    }
+
+    // replay --expect: same contract, lineage kept. The workspace file was
+    // rewritten for the dead-port case; point it back at a live server.
+    let workspace = sandbox.workspace(&url);
+    let ws = workspace.to_str().unwrap();
+    let again = serve_again(&url, ECHO_BODY.to_vec());
+    let output = sandbox
+        .facet()
+        .args(["replay", run_id, ws, "--expect", "404", "--json"])
+        .output()
+        .unwrap();
+    again.join().unwrap();
+    assert_eq!(output.status.code(), Some(1));
+    let replayed: Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(replayed["error"]["category"], "expect_failed");
+    assert_eq!(replayed["lattice"]["replayedFrom"], run_id);
+    let tagged = sandbox.run_json(&["history", ws, "--tag", "expect:fail"]);
+    // Four misses so far (json, human, quiet, replay); the replay carries the
+    // source's tags and is tagged once, not twice.
+    assert_eq!(tagged["runs"].as_array().unwrap().len(), 4);
+    assert_eq!(tagged["runs"][0]["tags"], json!(["smoke", "expect:fail"]));
+}
+
+#[test]
+fn dry_run_previews_without_sending_or_recording() {
+    let sandbox = Sandbox::new();
+    // A dead port proves nothing is sent.
+    let workspace = sandbox.workspace("http://127.0.0.1:9");
+    let ws = workspace.to_str().unwrap();
+    let preview = sandbox.run_json(&[
+        "request",
+        "run",
+        ws,
+        "items/0",
+        "--environment",
+        "local",
+        "--dry-run",
+    ]);
+    assert_eq!(preview["dryRun"], true);
+    assert_eq!(preview["request"]["method"], "POST");
+    assert_eq!(preview["request"]["url"], "http://127.0.0.1:9/echo");
+    assert_eq!(
+        preview["request"]["query"],
+        json!([{ "disabled": false, "name": "mode", "value": "cli" }])
+    );
+    let headers = preview["request"]["headers"].as_array().unwrap();
+    assert!(
+        headers
+            .iter()
+            .any(|h| h["name"] == "X-Probe" && h["value"] == "phase-five")
+    );
+    assert!(
+        headers
+            .iter()
+            .all(|h| h["name"] != "Authorization" || h["value"] == "<redacted>"),
+        "{headers:?}"
+    );
+    assert_eq!(preview["request"]["body"]["content"], r#"{"source":"cli"}"#);
+    assert_eq!(preview["request"]["body"]["sizeBytes"], 16);
+    assert_eq!(preview["lattice"]["recorded"], false);
+    assert_eq!(preview["lattice"]["reason"], "dry_run");
+    assert_eq!(
+        preview["lattice"]["requestHash"].as_str().unwrap().len(),
+        64
+    );
+    assert_eq!(
+        preview["lattice"]["secrets"],
+        json!({ "hydrated": [], "source": null })
+    );
+    assert!(preview.get("response").is_none());
+    assert_golden("run_dry_run.json", &normalize(preview.clone()));
+    assert!(!sandbox.root().join(".facet").exists(), "nothing recorded");
+
+    // The hash is the one a real run stores.
+    let (url, server) = serve_once(ECHO_BODY.to_vec(), "application/json");
+    let workspace = sandbox.workspace(&url);
+    let ws = workspace.to_str().unwrap();
+    let again = sandbox.run_json(&[
+        "request",
+        "run",
+        ws,
+        "items/0",
+        "--environment",
+        "local",
+        "--dry-run",
+    ]);
+    let real = sandbox.run_json(&["request", "run", ws, "items/0", "--environment", "local"]);
+    server.join().unwrap();
+    assert_eq!(
+        again["lattice"]["requestHash"],
+        real["lattice"]["requestHash"]
+    );
+    assert_eq!(run_count(&sandbox, &["history", ws]), 1);
+
+    // Hydrated secrets are redacted in the preview.
+    let secret_ws = sandbox.secret_workspace("http://127.0.0.1:9");
+    let sws = secret_ws.to_str().unwrap();
+    sandbox.run_json(&[
+        "env",
+        "set",
+        sws,
+        "--environment",
+        "local",
+        "--name",
+        "token",
+        "--value",
+        SECRET_VALUE,
+        "--secret",
+    ]);
+    let hydrated = sandbox.run_json(&[
+        "request",
+        "run",
+        sws,
+        "items/0",
+        "--environment",
+        "local",
+        "--dry-run",
+    ]);
+    assert_eq!(hydrated["lattice"]["secrets"]["hydrated"], json!(["token"]));
+    assert!(!hydrated.to_string().contains(SECRET_VALUE), "{hydrated}");
+    assert!(
+        hydrated["request"]["url"]
+            .as_str()
+            .unwrap()
+            .contains("t=<redacted>")
+    );
+    assert_eq!(
+        hydrated["request"]["body"]["content"],
+        r#"{"token":"<redacted>"}"#
+    );
+
+    // Human mode and the two exclusions.
+    let human = sandbox
+        .facet()
+        .args([
+            "request",
+            "run",
+            ws,
+            "items/0",
+            "--environment",
+            "local",
+            "--dry-run",
+        ])
+        .output()
+        .unwrap();
+    assert!(human.status.success());
+    let text = String::from_utf8_lossy(&human.stdout);
+    assert!(text.starts_with("POST http://"), "{text}");
+    assert!(text.contains("Lattice: not recorded (dry_run)"), "{text}");
+    for extra in [["--expect", "2xx"], ["--output", "x"]] {
+        let mut arguments = vec!["request", "run", ws, "items/0", "--dry-run"];
+        arguments.extend_from_slice(&extra);
+        let (code, _) = sandbox.run_error_json(&arguments);
+        assert_eq!(code, 2);
+    }
 }

--- a/crates/facet/tests/golden/run_dry_run.json
+++ b/crates/facet/tests/golden/run_dry_run.json
@@ -1,0 +1,37 @@
+{
+  "dryRun": true,
+  "lattice": {
+    "reason": "dry_run",
+    "recorded": false,
+    "requestHash": "<sha256>",
+    "secrets": {
+      "hydrated": [],
+      "source": null
+    }
+  },
+  "request": {
+    "body": {
+      "content": "{\"source\":\"cli\"}",
+      "omissionReason": null,
+      "omitted": false,
+      "sizeBytes": 16
+    },
+    "headers": [
+      {
+        "disabled": false,
+        "name": "X-Probe",
+        "value": "phase-five"
+      }
+    ],
+    "method": "POST",
+    "query": [
+      {
+        "disabled": false,
+        "name": "mode",
+        "value": "cli"
+      }
+    ],
+    "url": "<url>"
+  },
+  "schemaVersion": 1
+}

--- a/crates/facet/tests/golden/run_expect_failed.json
+++ b/crates/facet/tests/golden/run_expect_failed.json
@@ -1,0 +1,63 @@
+{
+  "error": {
+    "category": "expect_failed",
+    "details": {
+      "actual": 200,
+      "expected": [
+        201,
+        204
+      ]
+    },
+    "exitCode": 1,
+    "message": "expected status in [201,204], got 200"
+  },
+  "lattice": {
+    "indexed": true,
+    "recorded": true,
+    "requestHash": "<sha256>",
+    "responseBody": {
+      "hash": null,
+      "retention": "inline",
+      "sizeBytes": 12
+    },
+    "runId": "<ulid>",
+    "secrets": {
+      "hydrated": [],
+      "source": null
+    },
+    "workspaceId": "<ulid>"
+  },
+  "request": {
+    "method": "POST",
+    "url": "<url>"
+  },
+  "response": {
+    "body": {
+      "content": "{\"users\":[]}",
+      "encoding": "utf8",
+      "omissionReason": null,
+      "omitted": false,
+      "outputPath": null
+    },
+    "durationMs": "<int>",
+    "headers": [
+      {
+        "name": "connection",
+        "value": "close"
+      },
+      {
+        "name": "content-length",
+        "value": "12"
+      },
+      {
+        "name": "content-type",
+        "value": "application/json"
+      }
+    ],
+    "reason": "OK",
+    "sizeBytes": 12,
+    "status": 200,
+    "url": "<url>"
+  },
+  "schemaVersion": 1
+}

--- a/docs/FACET.md
+++ b/docs/FACET.md
@@ -142,7 +142,7 @@ Ranked (fullstack, 2026-09-07). Smallest vertical slice first.
 | 3 | **Replay** | `facet replay <runId>` re-resolves **current** YAML at the recorded env; warn on `request_hash` change; `--frozen` refuses | Facet command; Probe engine untouched |
 | 4 | **Hash-first diff** | `facet diff <a> <b>`: hashes equal ⇒ bodies equal; exit 1 on mismatch, 9 if a run is missing | Facet-only |
 | 5 | **Secret hydration** | Overlay Lattice env as `--var` before resolve on `request run` / TUI send. `--var` still wins | Facet overlay now; secret-provider hook upstream later |
-| 6 | **Dry-run + `--expect`** | `--expect 200,201` after a real run; miss → exit **6** `expect_failed`; Lattice still records. `--dry-run` second | **Upstream-first** on `request run` |
+| 6 | **Dry-run + `--expect`** | `--expect 200,201` after a real run; miss → exit **1** `expect_failed` (decided; see § `--expect`); Lattice still records. `--dry-run` second | **Upstream-first** on `request run` |
 
 CLI is the harness contract. MCP wraps the same functions later and must
 not parse stdout. Sketch: `agents/fullstack/notes/2026-09-07-and-more.md`
@@ -241,7 +241,7 @@ in the Lapis vault for the full runbook.
 ## Commands
 
 ```text
-facet request run <path> <selector> [<probe request run flags>] [--no-record] [--tag <tag>]... [--inline-body-max <size>] [--json]
+facet request run <path> <selector> [<probe request run flags>] [--no-record] [--tag <tag>]... [--expect <codes>] [--dry-run] [--inline-body-max <size>] [--json]
 facet history [<path>] [--limit <n>] [--request <selector>] [--status <code>] [--actor <name>] [--since <unix-ms>] [--session <id>|current] [--environment <name>] [--tag <tag>]... [--hash <sha256>] [--bodies] [--json]
 facet history [<path>] --id <ulid> [--bodies] [--json]
 facet history [<path>] --sql "<query>" [--json]
@@ -249,7 +249,7 @@ facet session start [--actor <name>] [--meta <json>] [--json]
 facet session end [<id>|current] [--json]
 facet session list [--limit <n>] [--actor <name>] [--open] [--json]
 facet session show <id>|current [--json]
-facet replay <runId> [<path>] [--frozen] [--environment <name>] [--var k=v]... [--tag <tag>]... [--strict-variables] [--no-record] [--json]
+facet replay <runId> [<path>] [--frozen] [--environment <name>] [--var k=v]... [--tag <tag>]... [--expect <codes>] [--strict-variables] [--no-record] [--json]
 facet diff <idA> <idB> [<path>] [--bodies] [--json]
 facet env set [<path>] --environment <name> --name <key> --value <value> [--secret] [--json]
 facet env list [<path>] [--environment <name>] [--json]
@@ -298,6 +298,58 @@ A stdin (`-`) workspace has no root and is never recorded. A Lattice failure
 never changes the run's exit code; it is reported in `lattice` and on stderr.
 A transport failure is recorded with `status: null` and the error text, then
 the upstream error envelope is returned with `error.details.lattice`.
+
+### `--expect` and `--dry-run`
+
+`--expect <codes>` on `request run` and `replay` is the assertion an agent
+asks for after a real run: a comma list of status codes (`200,201`) and/or
+class shorthands (`2xx`, `3xx`), mixable. Absent means no assertion (today's
+behavior). `--expect 2xx` is what skill files should teach.
+
+| Outcome | Exit | Category | Agent should |
+| --- | ---: | --- | --- |
+| status in set | 0 | — | continue |
+| HTTP completed, status not in set | **1** | `expect_failed` | stop, read the run, do not retry |
+| transport / timeout / cancel | 6 | `network_execution` / `request_timeout` / `request_cancelled` | retry (bounded) |
+| config / env / secret missing | 5 | as today | fix inputs |
+| Lattice write failed | 0 + `lattice.recorded: false` | — | continue; warn |
+
+Why 1 and not 6: a harness mapping "6 → retry" (right for sockets) would
+retry a 404 forever, and one that parses the category first has reintroduced
+the JSON parse `--expect` exists to remove. Unix already gave `1` to "the
+assertion you asked for is false" (`test`, `grep`, `diff`, `cmp`); upstream's
+constants start at 2, so nothing collides. The same row is offered to Probe
+for `request run`; if upstream declines, `--expect` stays a Facet extension.
+
+On a miss with `--json` the **full success document** is emitted plus
+`error`, so the run id is in hand without a second call:
+
+```json
+{ "schemaVersion": 1, "request": { "…": "…" }, "response": { "status": 500, "…": "…" }, "lattice": { "runId": "01K…", "…": "…" },
+  "error": { "category": "expect_failed", "exitCode": 1, "message": "expected status in [200,201], got 500",
+             "details": { "expected": [200, 201], "actual": 500 } } }
+```
+
+Human mode prints the response as usual and `error[expect_failed]: …` on
+stderr. `--quiet` prints nothing and exits 1. Lattice records regardless and
+tags the run `expect:fail`, so `history --tag expect:fail --session current`
+answers "what failed this session" without `--sql`. Transport failures keep
+their own envelope and exit code; `--expect` never rewrites them.
+
+`--dry-run` resolves the request (secret hydration included) and shows what
+would be sent, without sending or recording. It cannot be combined with
+`--expect` or `--output`. The preview applies Lattice's redactions
+(sensitive header names, URL userinfo, known secret values), so it is safe to
+paste; `lattice.requestHash` is what a real run would store, so an agent can
+compare it against a recorded run (`history --id`, `diff`) before firing.
+
+```json
+{ "schemaVersion": 1, "dryRun": true,
+  "request": { "method": "POST", "url": "http://…/echo", "query": [ { "disabled": false, "name": "mode", "value": "cli" } ],
+               "headers": [ { "disabled": false, "name": "X-Probe", "value": "…" } ],
+               "body": { "content": "{\"source\":\"cli\"}", "sizeBytes": 16, "omitted": false, "omissionReason": null } },
+  "lattice": { "recorded": false, "reason": "dry_run", "requestHash": "9f…", "secrets": { "hydrated": [], "source": null } } }
+```
 
 ### `history`
 
@@ -558,7 +610,7 @@ Facet extends the upstream table; it never renumbers it.
 | Code | Category |
 | ---: | --- |
 | 0–8 | As in [CLI](CLI.md#exit-codes) |
-| 1 | Assertion failed (`replay_changed`; `diff` found differences) |
+| 1 | Assertion failed (`expect_failed`, `replay_changed`; `diff` found differences) |
 | 9 | Lattice store failure (`lattice_error`, `lattice_not_found`) |
 
 Additional stable categories: `blob_not_found`, `run_not_found`, and


### PR DESCRIPTION
## Summary

Goal 6 of deep dive §3: `--expect` and `--dry-run` on `request run` (and `--expect` on `replay`). Facet-only implementation in `crates/facet`; nothing in `probe-*`. The upstream offer to Probe is drafted at `agents/fullstack/notes/2026-09-07-upstream-expect-offer.md` in the vault and **not posted** (outward action; say go).

**`--expect <codes>`**
- Comma list and/or class shorthands, mixable: `200,201`, `2xx`, `2xx,404`. Absent = no assertion (today's behavior). Bad tokens are `invalid_arguments` (2).
- HTTP completed, status not in set → **exit 1**, `expect_failed`. With `--json` the **full success document** is emitted plus `error: { category, exitCode: 1, message, details: { expected, actual } }`, so the run id is in hand without a second call. Human mode prints the response on stdout and `error[expect_failed]: …` on stderr. `--quiet` prints nothing and exits 1.
- Transport / timeout / cancel keep exit 6 and their envelope; configuration keeps 5. `--expect` never rewrites another failure.
- Lattice records regardless and auto-tags `expect:fail` (no schema), so `history --tag expect:fail --session current` answers "what failed this session". A replay of a failed run keeps the source's tags and is tagged once, not twice.
- `replay --expect` shares the same path (`CommandOutput::fail`), lineage intact.

**`--dry-run`**
- Resolve (secret hydration included), send nothing, record nothing. Cannot combine with `--expect` or `--output`.
- JSON: `{ dryRun: true, request: { method, url, query, headers, body }, lattice: { recorded: false, reason: "dry_run", requestHash, secrets } }`. The preview applies Lattice's redactions (sensitive header names, URL userinfo, known secret values), so it is safe to paste. `requestHash` is what a real run stores (asserted in tests), so an agent can compare against `history --id` / `diff` before firing.
- Human: `METHOD url?query`, headers, body, `Lattice: not recorded (dry_run)`.

**Docs**: `docs/FACET.md` gains § `--expect` and `--dry-run` with the outcome table (why 1, not 6), the exit table row 1 now lists `expect_failed`, and the Next-slice ranking row 6 records the decision.

## Test plan

On apiary (`~/src/facet`, cargo 1.95), head of this branch:

- [x] `cargo test -p lattice -p facet-record -p facet-cli -p facet-tui`: 140 passed, 0 failed (facet-cli 29/29 incl. `expect_is_exit_1_on_a_miss_with_the_full_document` and `dry_run_previews_without_sending_or_recording`; `expect.rs` unit tests for parsing and the transport exemption).
- [x] Goldens: new `run_expect_failed.json`, `run_dry_run.json`; no existing golden changed.
- [x] Release build + shell smoke against python's `http.server` (answers POST with 501): `--dry-run` exit 0 with nothing on the wire; `--expect 2xx` → `error[expect_failed]` + exit 1 with the run recorded; `--expect 501,5xx --quiet` → 0; miss `--quiet` → silent 1; `history --tag expect:fail` lists the misses; dead port + `--expect` → `network_execution` exit 6.
- [x] `cargo fmt --check` clean on touched files (pre-existing `lattice/tests/{duckdb,turso}.rs` debt remains). No new clippy warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01E3MvVHmyGKQdu6CRignmME
