### PR TITLE
feat: facet mcp, MCP tools over stdio (Facet rest 1)

### DIFF
--- a/crates/facet/src/error.rs
+++ b/crates/facet/src/error.rs
@@ -38,6 +38,23 @@ impl FacetError {
         }
     }
 
+    /// The versioned JSON error document (`schemaVersion` + `error`).
+    #[must_use]
+    pub fn envelope(&self) -> Value {
+        let mut value = json!({
+            "schemaVersion": crate::JSON_SCHEMA_VERSION,
+            "error": {
+                "category": self.category,
+                "exitCode": self.exit_code,
+                "message": self.message,
+            }
+        });
+        if let Some(details) = &self.details {
+            value["error"]["details"] = details.clone();
+        }
+        value
+    }
+
     /// Attaches structured details.
     #[must_use]
     pub fn with_details(mut self, details: Value) -> Self {

--- a/crates/facet/src/lib.rs
+++ b/crates/facet/src/lib.rs
@@ -11,6 +11,7 @@
 //! - `replay` re-sends a recorded run from the current YAML; `diff` compares two runs.
 //! - `env` sets and lists machine-store environment values (metadata only on read).
 //! - `request run --expect` / `--dry-run`: the assertion (exit 1) and the preview.
+//! - `mcp` serves the same functions as Model Context Protocol tools over stdio.
 //! - `tui` opens the terminal UI.
 //!
 //! Contract details for the Facet-only commands live in `docs/FACET.md`.
@@ -28,6 +29,7 @@ mod env;
 mod error;
 mod expect;
 mod history;
+mod mcp;
 mod presentation;
 mod replay;
 mod run;
@@ -36,6 +38,7 @@ mod tui;
 mod workspace;
 
 pub use error::FacetError;
+pub use mcp::{TOOLS as MCP_TOOLS, run_mcp};
 pub use probe_cli::{
     CONFIGURATION_EXIT_CODE, EXECUTION_EXIT_CODE, IMPORT_EXIT_CODE, INVALID_ARGUMENTS_EXIT_CODE,
     INVALID_WORKSPACE_EXIT_CODE, JSON_SCHEMA_VERSION, PERSISTENCE_EXIT_CODE,
@@ -76,19 +79,8 @@ impl RunOutput {
 
     fn failure(error: FacetError, json_output: bool) -> Self {
         if json_output {
-            let mut value = json!({
-                "schemaVersion": JSON_SCHEMA_VERSION,
-                "error": {
-                    "category": error.category,
-                    "exitCode": error.exit_code,
-                    "message": error.message,
-                }
-            });
-            if let Some(details) = error.details {
-                value["error"]["details"] = details;
-            }
             Self {
-                stdout: pretty_json(&value).into_bytes(),
+                stdout: pretty_json(&error.envelope()).into_bytes(),
                 stderr: String::new(),
                 exit_code: error.exit_code,
             }
@@ -150,6 +142,12 @@ impl CommandOutput {
     pub(crate) fn warn(mut self, warning: impl Into<String>) -> Self {
         self.warnings.push(warning.into());
         self
+    }
+
+    /// The JSON document, warnings, and exit code, for adapters that do not
+    /// print (the MCP server).
+    pub(crate) fn into_parts(self) -> (Value, Vec<String>, u8) {
+        (self.json, self.warnings, self.exit_code)
     }
 
     /// A successful document that still signals an assertion outcome
@@ -214,6 +212,7 @@ pub const fn help() -> &'static str {
         "  blob <hash> [<path>]                Fetch one stored body by SHA-256\n",
         "  gc [<path>] [--yes]                 Expire old runs and sweep orphaned blobs\n",
         "  tui [<path>]                        Open the terminal UI\n",
+        "  mcp                                 Serve the same commands as MCP tools over stdio\n",
         "\n",
         "Options:\n",
         "      --no-record             Execute without writing to Lattice\n",
@@ -282,8 +281,8 @@ where
     let owned = match args.first().map(String::as_str) {
         None => true,
         Some(
-            "history" | "session" | "replay" | "diff" | "env" | "doctor" | "blob" | "gc" | "tui"
-            | "-V" | "--version" | "-h" | "--help",
+            "history" | "mcp" | "session" | "replay" | "diff" | "env" | "doctor" | "blob" | "gc"
+            | "tui" | "-V" | "--version" | "-h" | "--help",
         ) => true,
         Some("request") => args.get(1).map(String::as_str) == Some("run"),
         Some(_) => false,
@@ -337,6 +336,9 @@ where
         "tui" => Err(FacetError::invalid_arguments(
             "tui is interactive and must be started from the facet binary",
         )),
+        "mcp" => Err(FacetError::invalid_arguments(
+            "mcp serves stdio and must be started from the facet binary",
+        )),
         _ => unreachable!("owned commands are routed above"),
     };
     match result {
@@ -381,7 +383,7 @@ fn remove_flags(args: &mut Vec<String>, flags: &[&str]) -> usize {
     count
 }
 
-fn versioned_json(mut value: Value) -> Value {
+pub(crate) fn versioned_json(mut value: Value) -> Value {
     value
         .as_object_mut()
         .expect("command JSON output must be an object")

--- a/crates/facet/src/main.rs
+++ b/crates/facet/src/main.rs
@@ -9,6 +9,9 @@ fn main() -> ExitCode {
     if args.first().map(String::as_str) == Some("tui") {
         return ExitCode::from(facet_cli::run_tui(&args[1..]));
     }
+    if args.first().map(String::as_str) == Some("mcp") {
+        return ExitCode::from(facet_cli::run_mcp(&args[1..]));
+    }
     let mut stdin = io::stdin().lock();
     let output = facet_cli::run_with_stdin(args, &mut stdin);
     let mut stdout = io::stdout().lock();

--- a/crates/facet/src/mcp.rs
+++ b/crates/facet/src/mcp.rs
@@ -1,0 +1,763 @@
+//! `facet mcp`: a Model Context Protocol server over stdio.
+//!
+//! A typed adapter over the same functions the CLI uses. Every tool maps its
+//! arguments onto the command function (`run::run`, `history::history`,
+//! `session::session`, …) and returns that function's JSON document as the
+//! tool result: the existing `schemaVersion: 1` envelopes, byte for byte the
+//! same as `facet <command> --json`. Errors are the same
+//! `error.{category, exitCode, message, details}` object. There are no
+//! MCP-only fields and there is never a `std::process::Command`.
+//!
+//! `request_list` / `request_get` are Probe's commands; Facet delegates them
+//! to `probe_cli::run` in-process, exactly as the CLI does, and returns the
+//! upstream document unchanged.
+//!
+//! Transport: JSON-RPC 2.0, one message per line, stdin → stdout. Logging
+//! goes to stderr only. No HTTP transport in v1.
+
+use std::io::{self, BufRead, Write};
+
+use lattice::{LatticeConfig, MachineStore, WorkspaceStore};
+use serde_json::{Map, Value, json};
+
+use crate::{
+    CommandOutput, FacetError, diff, history, replay, run, session, version, versioned_json,
+    workspace::WorkspaceInput,
+};
+
+/// Protocol version answered when the client's is unknown.
+const PROTOCOL_VERSION: &str = "2025-06-18";
+
+/// Serves MCP over the process's stdin/stdout until EOF. Exit code 0 on a
+/// clean EOF, 1 on an I/O failure.
+#[must_use]
+pub fn run_mcp(args: &[String]) -> u8 {
+    if args.iter().any(|arg| arg == "-h" || arg == "--help") {
+        println!(
+            "facet mcp: Model Context Protocol server over stdio (JSON-RPC 2.0, one message per line).\n\
+             Tools: {}.\nSee docs/FACET.md § mcp.",
+            TOOLS.join(", ")
+        );
+        return 0;
+    }
+    if !args.is_empty() {
+        eprintln!("error[invalid_arguments]: mcp takes no arguments");
+        return 2;
+    }
+    let stdin = io::stdin().lock();
+    let stdout = io::stdout().lock();
+    match serve(stdin, stdout) {
+        Ok(()) => 0,
+        Err(error) => {
+            eprintln!("error[mcp_io]: {error}");
+            1
+        }
+    }
+}
+
+/// Tool names, in the order `tools/list` reports them.
+pub const TOOLS: &[&str] = &[
+    "session_start",
+    "session_end",
+    "request_list",
+    "request_get",
+    "request_run",
+    "history_list",
+    "history_get",
+    "blob_get",
+    "run_diff",
+    "run_replay",
+    "sql_query",
+];
+
+/// Reads JSON-RPC messages from `input` and writes responses to `output`.
+pub(crate) fn serve<R: BufRead, W: Write>(input: R, mut output: W) -> io::Result<()> {
+    for line in input.lines() {
+        let line = line?;
+        if line.trim().is_empty() {
+            continue;
+        }
+        let message: Value = match serde_json::from_str(&line) {
+            Ok(message) => message,
+            Err(error) => {
+                write_message(
+                    &mut output,
+                    &rpc_error(Value::Null, -32700, format!("parse error: {error}")),
+                )?;
+                continue;
+            }
+        };
+        if let Some(response) = handle(&message) {
+            write_message(&mut output, &response)?;
+        }
+    }
+    Ok(())
+}
+
+fn write_message<W: Write>(output: &mut W, message: &Value) -> io::Result<()> {
+    let mut text = serde_json::to_string(message).expect("JSON value serialization cannot fail");
+    text.push('\n');
+    output.write_all(text.as_bytes())?;
+    output.flush()
+}
+
+/// Handles one message. `None` for notifications (no `id`).
+pub(crate) fn handle(message: &Value) -> Option<Value> {
+    let id = message.get("id").cloned();
+    let method = message.get("method").and_then(Value::as_str).unwrap_or("");
+    let params = message.get("params").cloned().unwrap_or(Value::Null);
+    if method.starts_with("notifications/") {
+        return None;
+    }
+    let Some(id) = id else {
+        // A request without an id is a notification we do not know; ignore.
+        return None;
+    };
+    Some(match method {
+        "initialize" => rpc_result(id, initialize_result(&params)),
+        "ping" => rpc_result(id, json!({})),
+        "tools/list" => rpc_result(id, json!({ "tools": tool_descriptions() })),
+        "tools/call" => {
+            let name = params.get("name").and_then(Value::as_str).unwrap_or("");
+            let arguments = params
+                .get("arguments")
+                .and_then(Value::as_object)
+                .cloned()
+                .unwrap_or_default();
+            if !TOOLS.contains(&name) {
+                return Some(rpc_error(id, -32602, format!("unknown tool: {name}")));
+            }
+            let (document, is_error) = call_tool(name, &arguments);
+            rpc_result(
+                id,
+                json!({
+                    "content": [{ "type": "text", "text": pretty(&document) }],
+                    "structuredContent": document,
+                    "isError": is_error,
+                }),
+            )
+        }
+        other => rpc_error(id, -32601, format!("method not found: {other}")),
+    })
+}
+
+fn initialize_result(params: &Value) -> Value {
+    let protocol = params
+        .get("protocolVersion")
+        .and_then(Value::as_str)
+        .unwrap_or(PROTOCOL_VERSION);
+    json!({
+        "protocolVersion": protocol,
+        "capabilities": { "tools": { "listChanged": false } },
+        "serverInfo": { "name": "facet", "version": version() },
+        "instructions": concat!(
+            "Facet: run, recall, replay HTTP requests with a Lattice history. ",
+            "Every tool result is the same schemaVersion 1 JSON as `facet <command> --json`; ",
+            "errors carry error.{category, exitCode, message, details}. ",
+            "Bodies are explicit pulls (blob_get). Never pass secret values as arguments; ",
+            "store them with `facet env set` and let hydration supply them."
+        ),
+    })
+}
+
+fn rpc_result(id: Value, result: Value) -> Value {
+    json!({ "jsonrpc": "2.0", "id": id, "result": result })
+}
+
+fn rpc_error(id: Value, code: i64, message: String) -> Value {
+    json!({ "jsonrpc": "2.0", "id": id, "error": { "code": code, "message": message } })
+}
+
+fn pretty(value: &Value) -> String {
+    serde_json::to_string_pretty(value).expect("JSON value serialization cannot fail")
+}
+
+/// Runs one tool. Returns the versioned document and whether it is an error
+/// (a `FacetError`, or a success document that carries `error`, such as an
+/// `--expect` miss).
+fn call_tool(name: &str, arguments: &Map<String, Value>) -> (Value, bool) {
+    match dispatch(name, arguments) {
+        Ok(output) => {
+            let (json, _warnings, _exit_code) = output.into_parts();
+            let document = versioned_json(json);
+            let is_error = document.get("error").is_some();
+            (document, is_error)
+        }
+        Err(error) => (error.envelope(), true),
+    }
+}
+
+fn dispatch(name: &str, arguments: &Map<String, Value>) -> Result<CommandOutput, FacetError> {
+    let args = Args(arguments);
+    match name {
+        "session_start" => {
+            let mut argv = vec!["start".to_owned()];
+            push_value(&mut argv, "--actor", args.string("actor")?);
+            if let Some(meta) = args.object("meta")? {
+                argv.push("--meta".to_owned());
+                argv.push(Value::Object(meta).to_string());
+            }
+            session::session(&argv)
+        }
+        "session_end" => {
+            let mut argv = vec!["end".to_owned()];
+            if let Some(id) = args.string("id")? {
+                argv.push(id);
+            }
+            session::session(&argv)
+        }
+        "request_list" => {
+            let path = args.required("path")?;
+            delegate(&["request", "list", &path])
+        }
+        "request_get" => {
+            let path = args.required("path")?;
+            let selector = args.required("selector")?;
+            let mut argv = vec!["request", "get", path.as_str(), selector.as_str()];
+            let environment = args.string("environment")?;
+            if let Some(environment) = &environment {
+                argv.push("--environment");
+                argv.push(environment);
+            }
+            if args.bool("strictVariables")? {
+                argv.push("--strict-variables");
+            }
+            delegate(&argv)
+        }
+        "request_run" => {
+            let path = args.required("path")?;
+            let selector = args.required("selector")?;
+            let environment = args.string("environment")?;
+            let vars = args.vars("var")?;
+            reject_lattice_backed_vars(&path, environment.as_deref(), &vars)?;
+            let mut argv = vec![path, selector];
+            push_value(&mut argv, "--environment", environment);
+            push_vars(&mut argv, &vars);
+            push_list(&mut argv, "--tag", args.strings("tag")?);
+            push_value(&mut argv, "--expect", args.expect()?);
+            if args.bool("dryRun")? {
+                argv.push("--dry-run".to_owned());
+            }
+            if args.bool("strictVariables")? {
+                argv.push("--strict-variables".to_owned());
+            }
+            if args.bool("noRecord")? {
+                argv.push("--no-record".to_owned());
+            }
+            run::run(&argv, &mut io::empty())
+        }
+        "history_list" => {
+            let mut argv = Vec::new();
+            if let Some(path) = args.string("path")? {
+                argv.push(path);
+            }
+            push_value(
+                &mut argv,
+                "--limit",
+                args.integer("limit")?.map(|n| n.to_string()),
+            );
+            push_value(&mut argv, "--request", args.string("request")?);
+            push_value(
+                &mut argv,
+                "--status",
+                args.integer("status")?.map(|n| n.to_string()),
+            );
+            push_value(&mut argv, "--actor", args.string("actor")?);
+            push_value(
+                &mut argv,
+                "--since",
+                args.integer("since")?.map(|n| n.to_string()),
+            );
+            push_value(&mut argv, "--session", args.string("session")?);
+            push_value(&mut argv, "--environment", args.string("environment")?);
+            push_list(&mut argv, "--tag", args.strings("tag")?);
+            push_value(&mut argv, "--hash", args.string("hash")?);
+            if args.bool("bodies")? {
+                argv.push("--bodies".to_owned());
+            }
+            history::history(&argv)
+        }
+        "history_get" => {
+            let mut argv = Vec::new();
+            if let Some(path) = args.string("path")? {
+                argv.push(path);
+            }
+            argv.push("--id".to_owned());
+            argv.push(args.required("id")?);
+            if args.bool("bodies")? {
+                argv.push("--bodies".to_owned());
+            }
+            history::history(&argv)
+        }
+        "blob_get" => {
+            let mut argv = vec![args.required("hash")?];
+            if let Some(path) = args.string("path")? {
+                argv.push(path);
+            }
+            history::blob(&argv)
+        }
+        "run_diff" => {
+            let mut argv = vec![args.required("a")?, args.required("b")?];
+            if let Some(path) = args.string("path")? {
+                argv.push(path);
+            }
+            if args.bool("bodies")? {
+                argv.push("--bodies".to_owned());
+            }
+            diff::diff(&argv)
+        }
+        "run_replay" => {
+            let id = args.required("id")?;
+            let path = args.string("path")?.unwrap_or_else(|| ".".to_owned());
+            let environment = args.string("environment")?;
+            let vars = args.vars("var")?;
+            reject_lattice_backed_vars(&path, environment.as_deref(), &vars)?;
+            let mut argv = vec![id, path];
+            push_value(&mut argv, "--environment", environment);
+            push_vars(&mut argv, &vars);
+            push_list(&mut argv, "--tag", args.strings("tag")?);
+            push_value(&mut argv, "--expect", args.expect()?);
+            if args.bool("frozen")? {
+                argv.push("--frozen".to_owned());
+            }
+            replay::replay(&argv, &mut io::empty())
+        }
+        "sql_query" => {
+            let mut argv = Vec::new();
+            if let Some(path) = args.string("path")? {
+                argv.push(path);
+            }
+            argv.push("--sql".to_owned());
+            argv.push(args.required("sql")?);
+            history::history(&argv)
+        }
+        other => Err(FacetError::invalid_arguments(format!(
+            "unknown tool: {other}"
+        ))),
+    }
+}
+
+/// Probe's own commands, in-process, the upstream document unchanged.
+fn delegate(argv: &[&str]) -> Result<CommandOutput, FacetError> {
+    let mut args: Vec<String> = argv.iter().map(|item| (*item).to_owned()).collect();
+    args.push("--json".to_owned());
+    let output = probe_cli::run(args);
+    let document: Value = serde_json::from_str(&output.stdout).map_err(|error| {
+        FacetError::invalid_arguments(format!("upstream did not return JSON: {error}"))
+    })?;
+    // Upstream's error envelope (non-zero exit) passes through unchanged;
+    // `call_tool` flags it by its `error` key. `versioned_json` re-inserts
+    // the schemaVersion upstream already set.
+    Ok(CommandOutput::new(Vec::new(), document))
+}
+
+/// MCP must not take raw secrets as tool arguments when a Lattice env key
+/// exists: the value would sit in the client's transcript. Hydration
+/// supplies stored values; `facet env set` changes them.
+fn reject_lattice_backed_vars(
+    path: &str,
+    environment: Option<&str>,
+    vars: &[(String, String)],
+) -> Result<(), FacetError> {
+    if vars.is_empty() {
+        return Ok(());
+    }
+    let Some(base) = WorkspaceInput::from_argument(path).base_directory() else {
+        return Ok(());
+    };
+    let Some(root) = WorkspaceStore::discover(&base) else {
+        return Ok(());
+    };
+    let Ok(Some(store)) = LatticeConfig::load(&root)
+        .map_err(lattice::LatticeError::from)
+        .and_then(|config| WorkspaceStore::open_existing(&root, config))
+    else {
+        return Ok(());
+    };
+    let Ok(machine) = MachineStore::open(store.config()) else {
+        return Ok(());
+    };
+    let Ok(rows) = machine.environments(store.workspace_id()) else {
+        return Ok(());
+    };
+    for (name, _) in vars {
+        let stored = rows
+            .iter()
+            .any(|row| row.key == *name && environment.is_none_or(|env| row.name == env));
+        if stored {
+            return Err(FacetError::invalid_arguments(format!(
+                "`{name}` is stored in the Facet machine store; MCP tools must not receive its \
+                 value as an argument. Let hydration supply it, or change it with `facet env set`."
+            )));
+        }
+    }
+    Ok(())
+}
+
+fn push_value(argv: &mut Vec<String>, flag: &str, value: Option<String>) {
+    if let Some(value) = value {
+        argv.push(flag.to_owned());
+        argv.push(value);
+    }
+}
+
+fn push_list(argv: &mut Vec<String>, flag: &str, values: Vec<String>) {
+    for value in values {
+        argv.push(flag.to_owned());
+        argv.push(value);
+    }
+}
+
+fn push_vars(argv: &mut Vec<String>, vars: &[(String, String)]) {
+    for (name, value) in vars {
+        argv.push("--var".to_owned());
+        argv.push(format!("{name}={value}"));
+    }
+}
+
+/// Typed access to a tool's `arguments` object.
+struct Args<'a>(&'a Map<String, Value>);
+
+impl Args<'_> {
+    fn required(&self, key: &str) -> Result<String, FacetError> {
+        self.string(key)?
+            .ok_or_else(|| FacetError::invalid_arguments(format!("{key} is required")))
+    }
+
+    fn string(&self, key: &str) -> Result<Option<String>, FacetError> {
+        match self.0.get(key) {
+            None | Some(Value::Null) => Ok(None),
+            Some(Value::String(text)) => Ok(Some(text.clone())),
+            Some(other) => Err(FacetError::invalid_arguments(format!(
+                "{key} must be a string, got {other}"
+            ))),
+        }
+    }
+
+    fn integer(&self, key: &str) -> Result<Option<i64>, FacetError> {
+        match self.0.get(key) {
+            None | Some(Value::Null) => Ok(None),
+            Some(Value::Number(number)) if number.is_i64() => Ok(number.as_i64()),
+            Some(other) => Err(FacetError::invalid_arguments(format!(
+                "{key} must be an integer, got {other}"
+            ))),
+        }
+    }
+
+    fn bool(&self, key: &str) -> Result<bool, FacetError> {
+        match self.0.get(key) {
+            None | Some(Value::Null) => Ok(false),
+            Some(Value::Bool(flag)) => Ok(*flag),
+            Some(other) => Err(FacetError::invalid_arguments(format!(
+                "{key} must be a boolean, got {other}"
+            ))),
+        }
+    }
+
+    fn strings(&self, key: &str) -> Result<Vec<String>, FacetError> {
+        match self.0.get(key) {
+            None | Some(Value::Null) => Ok(Vec::new()),
+            Some(Value::Array(items)) => items
+                .iter()
+                .map(|item| {
+                    item.as_str().map(str::to_owned).ok_or_else(|| {
+                        FacetError::invalid_arguments(format!(
+                            "{key} must be an array of strings, got {item}"
+                        ))
+                    })
+                })
+                .collect(),
+            Some(other) => Err(FacetError::invalid_arguments(format!(
+                "{key} must be an array of strings, got {other}"
+            ))),
+        }
+    }
+
+    fn object(&self, key: &str) -> Result<Option<Map<String, Value>>, FacetError> {
+        match self.0.get(key) {
+            None | Some(Value::Null) => Ok(None),
+            Some(Value::Object(map)) => Ok(Some(map.clone())),
+            Some(other) => Err(FacetError::invalid_arguments(format!(
+                "{key} must be an object, got {other}"
+            ))),
+        }
+    }
+
+    /// `{ "name": "value" }` → `--var name=value` pairs, in key order.
+    fn vars(&self, key: &str) -> Result<Vec<(String, String)>, FacetError> {
+        let Some(map) = self.object(key)? else {
+            return Ok(Vec::new());
+        };
+        map.into_iter()
+            .map(|(name, value)| match value {
+                Value::String(text) => Ok((name, text)),
+                Value::Number(number) => Ok((name, number.to_string())),
+                Value::Bool(flag) => Ok((name, flag.to_string())),
+                other => Err(FacetError::invalid_arguments(format!(
+                    "{key}.{name} must be a string, got {other}"
+                ))),
+            })
+            .collect()
+    }
+
+    /// `expect`: a string spec (`"2xx"`, `"200,201"`) or an array of codes
+    /// and class strings, joined into the CLI spec.
+    fn expect(&self) -> Result<Option<String>, FacetError> {
+        match self.0.get("expect") {
+            None | Some(Value::Null) => Ok(None),
+            Some(Value::String(text)) => Ok(Some(text.clone())),
+            Some(Value::Array(items)) => {
+                let tokens = items
+                    .iter()
+                    .map(|item| match item {
+                        Value::Number(number) => Ok(number.to_string()),
+                        Value::String(text) => Ok(text.clone()),
+                        other => Err(FacetError::invalid_arguments(format!(
+                            "expect entries must be codes or classes, got {other}"
+                        ))),
+                    })
+                    .collect::<Result<Vec<_>, _>>()?;
+                Ok(Some(tokens.join(",")))
+            }
+            Some(other) => Err(FacetError::invalid_arguments(format!(
+                "expect must be a string or an array, got {other}"
+            ))),
+        }
+    }
+}
+
+/// `tools/list` entries: name, description, JSON Schema for the arguments.
+pub(crate) fn tool_descriptions() -> Vec<Value> {
+    let string = |description: &str| json!({ "type": "string", "description": description });
+    let integer = |description: &str| json!({ "type": "integer", "description": description });
+    let boolean = |description: &str| json!({ "type": "boolean", "description": description });
+    let strings = |description: &str| json!({ "type": "array", "items": { "type": "string" }, "description": description });
+    let path_optional = string(
+        "File or directory inside the workspace (default: current directory); Facet walks up to .facet/lattice.db",
+    );
+    let path_required =
+        string("Collection path: an OpenCollection YAML file or an unbundled workspace directory");
+    let expect = json!({
+        "description": "Assert the status after a real run: \"2xx\", \"200,201\", or an array like [200, \"3xx\"]. Miss → exit 1 expect_failed with the full document.",
+        "oneOf": [ { "type": "string" }, { "type": "array", "items": { "oneOf": [ { "type": "integer" }, { "type": "string" } ] } } ]
+    });
+    let var = json!({
+        "type": "object",
+        "additionalProperties": { "type": "string" },
+        "description": "Variable overrides (--var). Never a secret: names stored in the Facet machine store are refused; hydration supplies them."
+    });
+    let schema = |properties: Value, required: &[&str]| {
+        json!({
+            "type": "object",
+            "properties": properties,
+            "required": required,
+            "additionalProperties": false,
+        })
+    };
+    let tool = |name: &str, description: &str, input_schema: Value| json!({ "name": name, "description": description, "inputSchema": input_schema });
+    vec![
+        tool(
+            "session_start",
+            "Start a session in the machine store and return it ({ session: { id, actor, startedAt, endedAt, meta, runs? } }). Export the id as FACET_SESSION for the runs that follow.",
+            schema(
+                json!({
+                    "actor": string("Agent name (default: FACET_ACTOR, else human)"),
+                    "meta": json!({ "type": "object", "description": "Pointers only (harness ids, cwd); merged over Herdr ids. Never transcripts or secrets." }),
+                }),
+                &[],
+            ),
+        ),
+        tool(
+            "session_end",
+            "End a session (default: FACET_SESSION). Idempotent: alreadyEnded says whether it was already closed.",
+            schema(json!({ "id": string("Session ULID, or `current`") }), &[]),
+        ),
+        tool(
+            "request_list",
+            "Probe's request list for a collection: { requests: [ { selector, name, method, url, … } ] }. Use selectors, never names.",
+            schema(json!({ "path": path_required.clone() }), &["path"]),
+        ),
+        tool(
+            "request_get",
+            "Probe's request get: one request as stored, or resolved with an environment.",
+            schema(
+                json!({
+                    "path": path_required.clone(),
+                    "selector": string("Request selector from request_list"),
+                    "environment": string("Environment name to resolve with"),
+                    "strictVariables": boolean("Fail on any unresolved variable"),
+                }),
+                &["path", "selector"],
+            ),
+        ),
+        tool(
+            "request_run",
+            "Execute a request through Facet and record it in Lattice. Result is Probe's request-run document plus lattice { runId, requestHash, secrets, … }. With dryRun the request is resolved and previewed, nothing sent or recorded.",
+            schema(
+                json!({
+                    "path": path_required.clone(),
+                    "selector": string("Request selector"),
+                    "environment": string("Environment name; enables secret hydration from the machine store"),
+                    "var": var.clone(),
+                    "tag": strings("Tags to store with the run"),
+                    "expect": expect.clone(),
+                    "dryRun": boolean("Preview only: resolve, redact, do not send"),
+                    "strictVariables": boolean("Fail on any unresolved variable"),
+                    "noRecord": boolean("Execute without writing to Lattice"),
+                }),
+                &["path", "selector"],
+            ),
+        ),
+        tool(
+            "history_list",
+            "Recorded runs, newest first, metadata only (bodies are explicit pulls). Filters AND together.",
+            schema(
+                json!({
+                    "path": path_optional.clone(),
+                    "limit": integer("Maximum rows (default 50)"),
+                    "request": string("Only runs of this selector"),
+                    "status": integer("Only runs with this HTTP status"),
+                    "actor": string("Only runs by this actor"),
+                    "since": integer("Only runs started at or after this Unix millisecond time"),
+                    "session": string("Session ULID, or `current` for FACET_SESSION"),
+                    "environment": string("Only runs resolved with this environment"),
+                    "tag": strings("Every listed tag must be present"),
+                    "hash": string("Request hash, request body hash, or response body hash; rows say matchedHash"),
+                    "bodies": boolean("Include inline bodies"),
+                }),
+                &[],
+            ),
+        ),
+        tool(
+            "history_get",
+            "One recorded run by id: { workspace, run }. run_not_found (exit 4) when unknown.",
+            schema(
+                json!({
+                    "id": string("Run ULID"),
+                    "path": path_optional.clone(),
+                    "bodies": boolean("Include inline bodies"),
+                }),
+                &["id"],
+            ),
+        ),
+        tool(
+            "blob_get",
+            "One stored body by SHA-256: { blob: { hash, sizeBytes, contentType, body } }. Bodies may contain secrets the redaction list cannot see.",
+            schema(
+                json!({
+                    "hash": string("SHA-256 hex from a history row"),
+                    "path": path_optional.clone(),
+                }),
+                &["hash"],
+            ),
+        ),
+        tool(
+            "run_diff",
+            "Hash-first comparison of two recorded runs: changes by field, request.hash, both bodies. durationMs, actor, and tags never flip equal.",
+            schema(
+                json!({
+                    "a": string("Run ULID"),
+                    "b": string("Run ULID"),
+                    "path": path_optional.clone(),
+                    "bodies": boolean("Unified diff for differing inline UTF-8 response bodies"),
+                }),
+                &["a", "b"],
+            ),
+        ),
+        tool(
+            "run_replay",
+            "Re-send a recorded run from the current YAML at the recorded environment; the new run carries replayedFrom. frozen refuses when the request hash changed (exit 1 replay_changed).",
+            schema(
+                json!({
+                    "id": string("Run ULID to replay"),
+                    "path": string("Collection path (default: current directory)"),
+                    "environment": string("Override the recorded environment"),
+                    "var": var,
+                    "tag": strings("Extra tags (the recorded ones carry over)"),
+                    "expect": expect,
+                    "frozen": boolean("Refuse when the resolved request differs from the recorded hash"),
+                }),
+                &["id"],
+            ),
+        ),
+        tool(
+            "sql_query",
+            "Read-only SQL over the workspace store (runs, blobs). Writes fail with sql_read_only. The machine store is never attached.",
+            schema(
+                json!({
+                    "sql": string("One SELECT statement"),
+                    "path": path_optional,
+                }),
+                &["sql"],
+            ),
+        ),
+    ]
+}
+
+#[cfg(test)]
+mod tests {
+    use serde_json::json;
+
+    use super::{TOOLS, handle, serve, tool_descriptions};
+
+    #[test]
+    fn lists_every_tool_with_a_schema() {
+        let tools = tool_descriptions();
+        assert_eq!(tools.len(), TOOLS.len());
+        for (tool, name) in tools.iter().zip(TOOLS) {
+            assert_eq!(tool["name"], *name);
+            assert_eq!(tool["inputSchema"]["type"], "object");
+            assert_eq!(tool["inputSchema"]["additionalProperties"], false);
+        }
+    }
+
+    #[test]
+    fn initialize_ping_and_unknown_method() {
+        let init = handle(&json!({ "jsonrpc": "2.0", "id": 1, "method": "initialize",
+            "params": { "protocolVersion": "2024-11-05" } }))
+        .unwrap();
+        assert_eq!(init["result"]["protocolVersion"], "2024-11-05");
+        assert_eq!(init["result"]["serverInfo"]["name"], "facet");
+        assert!(
+            handle(&json!({ "jsonrpc": "2.0", "method": "notifications/initialized" })).is_none()
+        );
+        let pong = handle(&json!({ "jsonrpc": "2.0", "id": 2, "method": "ping" })).unwrap();
+        assert_eq!(pong["result"], json!({}));
+        let missing = handle(&json!({ "jsonrpc": "2.0", "id": 3, "method": "nope" })).unwrap();
+        assert_eq!(missing["error"]["code"], -32601);
+        let unknown_tool = handle(&json!({ "jsonrpc": "2.0", "id": 4, "method": "tools/call",
+            "params": { "name": "gc_apply", "arguments": {} } }))
+        .unwrap();
+        assert_eq!(unknown_tool["error"]["code"], -32602);
+    }
+
+    #[test]
+    fn serve_reports_parse_errors_and_keeps_going() {
+        let input = b"not json\n{\"jsonrpc\":\"2.0\",\"id\":9,\"method\":\"ping\"}\n";
+        let mut output = Vec::new();
+        serve(&input[..], &mut output).unwrap();
+        let lines: Vec<serde_json::Value> = String::from_utf8(output)
+            .unwrap()
+            .lines()
+            .map(|line| serde_json::from_str(line).unwrap())
+            .collect();
+        assert_eq!(lines.len(), 2);
+        assert_eq!(lines[0]["error"]["code"], -32700);
+        assert_eq!(lines[1]["id"], 9);
+    }
+
+    #[test]
+    fn tool_errors_are_facet_envelopes() {
+        let response = handle(&json!({ "jsonrpc": "2.0", "id": 5, "method": "tools/call",
+            "params": { "name": "history_get", "arguments": { "id": 42 } } }))
+        .unwrap();
+        let result = &response["result"];
+        assert_eq!(result["isError"], true);
+        assert_eq!(result["structuredContent"]["schemaVersion"], 1);
+        assert_eq!(
+            result["structuredContent"]["error"]["category"],
+            "invalid_arguments"
+        );
+        assert_eq!(result["structuredContent"]["error"]["exitCode"], 2);
+    }
+}

--- a/crates/facet/tests/golden/mcp_tools.json
+++ b/crates/facet/tests/golden/mcp_tools.json
@@ -1,0 +1,377 @@
+{
+  "tools": [
+    {
+      "description": "Start a session in the machine store and return it ({ session: { id, actor, startedAt, endedAt, meta, runs? } }). Export the id as FACET_SESSION for the runs that follow.",
+      "inputSchema": {
+        "additionalProperties": false,
+        "properties": {
+          "actor": {
+            "description": "Agent name (default: FACET_ACTOR, else human)",
+            "type": "string"
+          },
+          "meta": {
+            "description": "Pointers only (harness ids, cwd); merged over Herdr ids. Never transcripts or secrets.",
+            "type": "object"
+          }
+        },
+        "required": [],
+        "type": "object"
+      },
+      "name": "session_start"
+    },
+    {
+      "description": "End a session (default: FACET_SESSION). Idempotent: alreadyEnded says whether it was already closed.",
+      "inputSchema": {
+        "additionalProperties": false,
+        "properties": {
+          "id": {
+            "description": "Session ULID, or `current`",
+            "type": "string"
+          }
+        },
+        "required": [],
+        "type": "object"
+      },
+      "name": "session_end"
+    },
+    {
+      "description": "Probe's request list for a collection: { requests: [ { selector, name, method, url, … } ] }. Use selectors, never names.",
+      "inputSchema": {
+        "additionalProperties": false,
+        "properties": {
+          "path": {
+            "description": "Collection path: an OpenCollection YAML file or an unbundled workspace directory",
+            "type": "string"
+          }
+        },
+        "required": [
+          "path"
+        ],
+        "type": "object"
+      },
+      "name": "request_list"
+    },
+    {
+      "description": "Probe's request get: one request as stored, or resolved with an environment.",
+      "inputSchema": {
+        "additionalProperties": false,
+        "properties": {
+          "environment": {
+            "description": "Environment name to resolve with",
+            "type": "string"
+          },
+          "path": {
+            "description": "Collection path: an OpenCollection YAML file or an unbundled workspace directory",
+            "type": "string"
+          },
+          "selector": {
+            "description": "Request selector from request_list",
+            "type": "string"
+          },
+          "strictVariables": {
+            "description": "Fail on any unresolved variable",
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "path",
+          "selector"
+        ],
+        "type": "object"
+      },
+      "name": "request_get"
+    },
+    {
+      "description": "Execute a request through Facet and record it in Lattice. Result is Probe's request-run document plus lattice { runId, requestHash, secrets, … }. With dryRun the request is resolved and previewed, nothing sent or recorded.",
+      "inputSchema": {
+        "additionalProperties": false,
+        "properties": {
+          "dryRun": {
+            "description": "Preview only: resolve, redact, do not send",
+            "type": "boolean"
+          },
+          "environment": {
+            "description": "Environment name; enables secret hydration from the machine store",
+            "type": "string"
+          },
+          "expect": {
+            "description": "Assert the status after a real run: \"2xx\", \"200,201\", or an array like [200, \"3xx\"]. Miss → exit 1 expect_failed with the full document.",
+            "oneOf": [
+              {
+                "type": "string"
+              },
+              {
+                "items": {
+                  "oneOf": [
+                    {
+                      "type": "integer"
+                    },
+                    {
+                      "type": "string"
+                    }
+                  ]
+                },
+                "type": "array"
+              }
+            ]
+          },
+          "noRecord": {
+            "description": "Execute without writing to Lattice",
+            "type": "boolean"
+          },
+          "path": {
+            "description": "Collection path: an OpenCollection YAML file or an unbundled workspace directory",
+            "type": "string"
+          },
+          "selector": {
+            "description": "Request selector",
+            "type": "string"
+          },
+          "strictVariables": {
+            "description": "Fail on any unresolved variable",
+            "type": "boolean"
+          },
+          "tag": {
+            "description": "Tags to store with the run",
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "var": {
+            "additionalProperties": {
+              "type": "string"
+            },
+            "description": "Variable overrides (--var). Never a secret: names stored in the Facet machine store are refused; hydration supplies them.",
+            "type": "object"
+          }
+        },
+        "required": [
+          "path",
+          "selector"
+        ],
+        "type": "object"
+      },
+      "name": "request_run"
+    },
+    {
+      "description": "Recorded runs, newest first, metadata only (bodies are explicit pulls). Filters AND together.",
+      "inputSchema": {
+        "additionalProperties": false,
+        "properties": {
+          "actor": {
+            "description": "Only runs by this actor",
+            "type": "string"
+          },
+          "bodies": {
+            "description": "Include inline bodies",
+            "type": "boolean"
+          },
+          "environment": {
+            "description": "Only runs resolved with this environment",
+            "type": "string"
+          },
+          "hash": {
+            "description": "Request hash, request body hash, or response body hash; rows say matchedHash",
+            "type": "string"
+          },
+          "limit": {
+            "description": "Maximum rows (default 50)",
+            "type": "integer"
+          },
+          "path": {
+            "description": "File or directory inside the workspace (default: current directory); Facet walks up to .facet/lattice.db",
+            "type": "string"
+          },
+          "request": {
+            "description": "Only runs of this selector",
+            "type": "string"
+          },
+          "session": {
+            "description": "Session ULID, or `current` for FACET_SESSION",
+            "type": "string"
+          },
+          "since": {
+            "description": "Only runs started at or after this Unix millisecond time",
+            "type": "integer"
+          },
+          "status": {
+            "description": "Only runs with this HTTP status",
+            "type": "integer"
+          },
+          "tag": {
+            "description": "Every listed tag must be present",
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          }
+        },
+        "required": [],
+        "type": "object"
+      },
+      "name": "history_list"
+    },
+    {
+      "description": "One recorded run by id: { workspace, run }. run_not_found (exit 4) when unknown.",
+      "inputSchema": {
+        "additionalProperties": false,
+        "properties": {
+          "bodies": {
+            "description": "Include inline bodies",
+            "type": "boolean"
+          },
+          "id": {
+            "description": "Run ULID",
+            "type": "string"
+          },
+          "path": {
+            "description": "File or directory inside the workspace (default: current directory); Facet walks up to .facet/lattice.db",
+            "type": "string"
+          }
+        },
+        "required": [
+          "id"
+        ],
+        "type": "object"
+      },
+      "name": "history_get"
+    },
+    {
+      "description": "One stored body by SHA-256: { blob: { hash, sizeBytes, contentType, body } }. Bodies may contain secrets the redaction list cannot see.",
+      "inputSchema": {
+        "additionalProperties": false,
+        "properties": {
+          "hash": {
+            "description": "SHA-256 hex from a history row",
+            "type": "string"
+          },
+          "path": {
+            "description": "File or directory inside the workspace (default: current directory); Facet walks up to .facet/lattice.db",
+            "type": "string"
+          }
+        },
+        "required": [
+          "hash"
+        ],
+        "type": "object"
+      },
+      "name": "blob_get"
+    },
+    {
+      "description": "Hash-first comparison of two recorded runs: changes by field, request.hash, both bodies. durationMs, actor, and tags never flip equal.",
+      "inputSchema": {
+        "additionalProperties": false,
+        "properties": {
+          "a": {
+            "description": "Run ULID",
+            "type": "string"
+          },
+          "b": {
+            "description": "Run ULID",
+            "type": "string"
+          },
+          "bodies": {
+            "description": "Unified diff for differing inline UTF-8 response bodies",
+            "type": "boolean"
+          },
+          "path": {
+            "description": "File or directory inside the workspace (default: current directory); Facet walks up to .facet/lattice.db",
+            "type": "string"
+          }
+        },
+        "required": [
+          "a",
+          "b"
+        ],
+        "type": "object"
+      },
+      "name": "run_diff"
+    },
+    {
+      "description": "Re-send a recorded run from the current YAML at the recorded environment; the new run carries replayedFrom. frozen refuses when the request hash changed (exit 1 replay_changed).",
+      "inputSchema": {
+        "additionalProperties": false,
+        "properties": {
+          "environment": {
+            "description": "Override the recorded environment",
+            "type": "string"
+          },
+          "expect": {
+            "description": "Assert the status after a real run: \"2xx\", \"200,201\", or an array like [200, \"3xx\"]. Miss → exit 1 expect_failed with the full document.",
+            "oneOf": [
+              {
+                "type": "string"
+              },
+              {
+                "items": {
+                  "oneOf": [
+                    {
+                      "type": "integer"
+                    },
+                    {
+                      "type": "string"
+                    }
+                  ]
+                },
+                "type": "array"
+              }
+            ]
+          },
+          "frozen": {
+            "description": "Refuse when the resolved request differs from the recorded hash",
+            "type": "boolean"
+          },
+          "id": {
+            "description": "Run ULID to replay",
+            "type": "string"
+          },
+          "path": {
+            "description": "Collection path (default: current directory)",
+            "type": "string"
+          },
+          "tag": {
+            "description": "Extra tags (the recorded ones carry over)",
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "var": {
+            "additionalProperties": {
+              "type": "string"
+            },
+            "description": "Variable overrides (--var). Never a secret: names stored in the Facet machine store are refused; hydration supplies them.",
+            "type": "object"
+          }
+        },
+        "required": [
+          "id"
+        ],
+        "type": "object"
+      },
+      "name": "run_replay"
+    },
+    {
+      "description": "Read-only SQL over the workspace store (runs, blobs). Writes fail with sql_read_only. The machine store is never attached.",
+      "inputSchema": {
+        "additionalProperties": false,
+        "properties": {
+          "path": {
+            "description": "File or directory inside the workspace (default: current directory); Facet walks up to .facet/lattice.db",
+            "type": "string"
+          },
+          "sql": {
+            "description": "One SELECT statement",
+            "type": "string"
+          }
+        },
+        "required": [
+          "sql"
+        ],
+        "type": "object"
+      },
+      "name": "sql_query"
+    }
+  ]
+}

--- a/crates/facet/tests/mcp.rs
+++ b/crates/facet/tests/mcp.rs
@@ -1,0 +1,336 @@
+//! `facet mcp` through the binary: JSON-RPC over stdio, every tool result
+//! the same `schemaVersion: 1` document the CLI prints, errors the same
+//! envelope, and the secret-argument refusal.
+
+#[allow(dead_code, unused_imports)]
+mod common;
+
+use std::{
+    io::{BufRead, BufReader, Write},
+    process::{Child, ChildStdin, ChildStdout, Stdio},
+};
+
+use common::*;
+
+const ECHO_BODY: &[u8] = br#"{"users":[]}"#;
+
+struct Mcp {
+    child: Child,
+    stdin: ChildStdin,
+    stdout: BufReader<ChildStdout>,
+    next_id: u64,
+}
+
+impl Mcp {
+    fn start(sandbox: &Sandbox, env: &[(&str, &str)]) -> Self {
+        let mut command = sandbox.facet();
+        for (name, value) in env {
+            command.env(name, value);
+        }
+        let mut child = command
+            .arg("mcp")
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .spawn()
+            .expect("facet mcp should start");
+        let stdin = child.stdin.take().unwrap();
+        let stdout = BufReader::new(child.stdout.take().unwrap());
+        Self {
+            child,
+            stdin,
+            stdout,
+            next_id: 1,
+        }
+    }
+
+    fn send(&mut self, message: &Value) {
+        let mut text = message.to_string();
+        text.push('\n');
+        self.stdin.write_all(text.as_bytes()).unwrap();
+        self.stdin.flush().unwrap();
+    }
+
+    fn receive(&mut self) -> Value {
+        let mut line = String::new();
+        let read = self.stdout.read_line(&mut line).unwrap();
+        assert!(read > 0, "server closed stdout");
+        serde_json::from_str(&line).unwrap_or_else(|error| panic!("{error}: {line}"))
+    }
+
+    fn request(&mut self, method: &str, params: Value) -> Value {
+        let id = self.next_id;
+        self.next_id += 1;
+        self.send(&json!({ "jsonrpc": "2.0", "id": id, "method": method, "params": params }));
+        let response = self.receive();
+        assert_eq!(response["id"], id, "{response}");
+        response
+    }
+
+    /// Calls a tool and returns `(structuredContent, isError)`.
+    fn call(&mut self, name: &str, arguments: Value) -> (Value, bool) {
+        let response = self.request(
+            "tools/call",
+            json!({ "name": name, "arguments": arguments }),
+        );
+        let result = &response["result"];
+        assert!(result.is_object(), "expected a result: {response}");
+        let text: Value =
+            serde_json::from_str(result["content"][0]["text"].as_str().unwrap()).unwrap();
+        assert_eq!(
+            text, result["structuredContent"],
+            "text and structured content agree"
+        );
+        (
+            result["structuredContent"].clone(),
+            result["isError"] == true,
+        )
+    }
+
+    fn ok(&mut self, name: &str, arguments: Value) -> Value {
+        let (document, is_error) = self.call(name, arguments);
+        assert!(!is_error, "{name} failed: {document}");
+        assert_eq!(document["schemaVersion"], 1);
+        document
+    }
+
+    fn err(&mut self, name: &str, arguments: Value) -> Value {
+        let (document, is_error) = self.call(name, arguments);
+        assert!(is_error, "{name} should fail: {document}");
+        assert_eq!(document["schemaVersion"], 1);
+        document
+    }
+
+    fn finish(mut self) {
+        drop(self.stdin);
+        let status = self.child.wait().unwrap();
+        assert!(status.success(), "clean EOF exits 0");
+    }
+}
+
+#[test]
+fn mcp_handshake_and_tool_list_are_golden() {
+    let sandbox = Sandbox::new();
+    let mut mcp = Mcp::start(&sandbox, &[]);
+    let init = mcp.request(
+        "initialize",
+        json!({ "protocolVersion": "2025-06-18",
+        "capabilities": {}, "clientInfo": { "name": "test", "version": "0" } }),
+    );
+    assert_eq!(init["result"]["protocolVersion"], "2025-06-18");
+    assert_eq!(init["result"]["serverInfo"]["name"], "facet");
+    assert!(init["result"]["capabilities"]["tools"].is_object());
+    mcp.send(&json!({ "jsonrpc": "2.0", "method": "notifications/initialized" }));
+    let pong = mcp.request("ping", json!({}));
+    assert_eq!(pong["result"], json!({}));
+
+    let list = mcp.request("tools/list", json!({}));
+    let tools = list["result"]["tools"].as_array().unwrap();
+    assert_eq!(tools.len(), 11);
+    let names: Vec<&str> = tools
+        .iter()
+        .map(|tool| tool["name"].as_str().unwrap())
+        .collect();
+    assert_eq!(
+        names,
+        [
+            "session_start",
+            "session_end",
+            "request_list",
+            "request_get",
+            "request_run",
+            "history_list",
+            "history_get",
+            "blob_get",
+            "run_diff",
+            "run_replay",
+            "sql_query",
+        ]
+    );
+    assert_golden("mcp_tools.json", &list["result"]);
+
+    let missing = mcp.request("resources/list", json!({}));
+    assert_eq!(missing["error"]["code"], -32601);
+    let unknown = mcp.request("tools/call", json!({ "name": "gc_apply", "arguments": {} }));
+    assert_eq!(unknown["error"]["code"], -32602);
+    mcp.finish();
+}
+
+#[test]
+fn mcp_tools_return_the_cli_documents() {
+    let sandbox = Sandbox::new();
+    let (url, server) = serve_once(ECHO_BODY.to_vec(), "application/json");
+    let workspace = sandbox.workspace(&url);
+    let ws = workspace.to_str().unwrap();
+    let mut mcp = Mcp::start(&sandbox, &[("FACET_ACTOR", "mcp-test")]);
+
+    let session = mcp.ok("session_start", json!({ "meta": { "note": "mcp" } }));
+    assert_eq!(session["session"]["actor"], "mcp-test");
+    assert_eq!(session["session"]["meta"]["note"], "mcp");
+    assert!(lattice::is_ulid(session["session"]["id"].as_str().unwrap()));
+
+    let list = mcp.ok("request_list", json!({ "path": ws }));
+    assert_eq!(list["requests"][0]["selector"], "items/0");
+    let get = mcp.ok(
+        "request_get",
+        json!({ "path": ws, "selector": "items/0", "environment": "local" }),
+    );
+    assert_eq!(get["method"], "POST");
+    assert!(get["url"].as_str().unwrap().starts_with(&url), "{get}");
+    let missing = mcp.err("request_get", json!({ "path": ws, "selector": "items/99" }));
+    assert_eq!(missing["error"]["category"], "request_not_found");
+    assert_eq!(missing["error"]["exitCode"], 4);
+
+    let run = mcp.ok(
+        "request_run",
+        json!({
+            "path": ws, "selector": "items/0", "environment": "local",
+            "tag": ["mcp"], "expect": [200, "3xx"],
+        }),
+    );
+    assert_eq!(server.join().unwrap(), br#"{"source":"cli"}"#);
+    assert_eq!(run["response"]["status"], 200);
+    assert_eq!(run["lattice"]["recorded"], true);
+    assert!(run.get("error").is_none());
+    let run_id = run["lattice"]["runId"].as_str().unwrap().to_owned();
+
+    let history = mcp.ok("history_list", json!({ "path": ws, "tag": ["mcp"] }));
+    assert_eq!(history["runs"].as_array().unwrap().len(), 1);
+    assert_eq!(history["runs"][0]["id"], run_id);
+    let one = mcp.ok(
+        "history_get",
+        json!({ "id": run_id, "path": ws, "bodies": true }),
+    );
+    assert_eq!(one["run"]["response"]["body"]["content"], r#"{"users":[]}"#);
+    let request_hash = one["run"]["request"]["body"]["hash"]
+        .as_str()
+        .unwrap()
+        .to_owned();
+    let blob = mcp.ok("blob_get", json!({ "hash": request_hash, "path": ws }));
+    assert_eq!(blob["blob"]["body"]["content"], r#"{"source":"cli"}"#);
+    let count = mcp.ok(
+        "sql_query",
+        json!({ "sql": "SELECT count(*) FROM runs", "path": ws }),
+    );
+    assert_eq!(count["rows"][0][0], 1);
+    let write = mcp.err(
+        "sql_query",
+        json!({ "sql": "DELETE FROM runs", "path": ws }),
+    );
+    assert_eq!(write["error"]["category"], "sql_read_only");
+    let nope = mcp.err(
+        "history_get",
+        json!({ "id": "01ARZ3NDEKTSV4RRFFQ69G5FAV", "path": ws }),
+    );
+    assert_eq!(nope["error"]["category"], "run_not_found");
+    assert_eq!(nope["error"]["exitCode"], 4);
+
+    // Replay and diff through the same functions.
+    let again = serve_again(&url, ECHO_BODY.to_vec());
+    let replayed = mcp.ok(
+        "run_replay",
+        json!({ "id": run_id, "path": ws, "expect": "2xx" }),
+    );
+    again.join().unwrap();
+    assert_eq!(replayed["lattice"]["replayedFrom"], run_id);
+    let replay_id = replayed["lattice"]["runId"].as_str().unwrap().to_owned();
+    let diff = mcp.ok(
+        "run_diff",
+        json!({ "a": run_id, "b": replay_id, "path": ws }),
+    );
+    assert_eq!(diff["equal"], true);
+
+    // An --expect miss is a success document that carries `error`, isError.
+    let miss_server = serve_again(&url, ECHO_BODY.to_vec());
+    let miss = mcp.err(
+        "request_run",
+        json!({
+            "path": ws, "selector": "items/0", "environment": "local", "expect": "404",
+        }),
+    );
+    miss_server.join().unwrap();
+    assert_eq!(miss["response"]["status"], 200);
+    assert_eq!(miss["error"]["category"], "expect_failed");
+    assert_eq!(miss["error"]["exitCode"], 1);
+    assert!(miss["lattice"]["runId"].is_string());
+
+    // Dry run sends nothing.
+    let preview = mcp.ok(
+        "request_run",
+        json!({
+            "path": ws, "selector": "items/0", "environment": "local", "dryRun": true,
+        }),
+    );
+    assert_eq!(preview["dryRun"], true);
+    assert_eq!(preview["lattice"]["reason"], "dry_run");
+
+    // Transport failure keeps the upstream envelope and exit 6.
+    let dead = mcp.err(
+        "request_run",
+        json!({
+            "path": ws, "selector": "items/0", "environment": "local",
+            "var": { "serverUrl": "http://127.0.0.1:9" },
+        }),
+    );
+    assert_eq!(dead["error"]["category"], "network_execution");
+    assert_eq!(dead["error"]["exitCode"], 6);
+
+    // Session end via argument, then with nothing set.
+    let ended = mcp.ok("session_end", json!({ "id": session["session"]["id"] }));
+    assert_eq!(ended["alreadyEnded"], false);
+    let unset = mcp.err("session_end", json!({}));
+    assert_eq!(unset["error"]["category"], "session_not_set");
+    assert_eq!(unset["error"]["exitCode"], 5);
+    mcp.finish();
+}
+
+#[test]
+fn mcp_refuses_secret_values_as_arguments() {
+    let sandbox = Sandbox::new();
+    let workspace = sandbox.secret_workspace("http://127.0.0.1:9");
+    let ws = workspace.to_str().unwrap();
+    sandbox.run_json(&[
+        "env",
+        "set",
+        ws,
+        "--environment",
+        "local",
+        "--name",
+        "token",
+        "--value",
+        "stored-secret",
+        "--secret",
+    ]);
+    let mut mcp = Mcp::start(&sandbox, &[]);
+    let refused = mcp.err(
+        "request_run",
+        json!({
+            "path": ws, "selector": "items/0", "environment": "local",
+            "var": { "token": "leaked-in-transcript" },
+        }),
+    );
+    assert_eq!(refused["error"]["category"], "invalid_arguments");
+    assert!(
+        refused["error"]["message"]
+            .as_str()
+            .unwrap()
+            .contains("facet env set")
+    );
+    // The refusal happens before any run: nothing recorded.
+    let history = mcp.ok("history_list", json!({ "path": ws }));
+    assert_eq!(history["runs"], json!([]));
+    // A name with no stored value is an ordinary override.
+    let other = mcp.err(
+        "request_run",
+        json!({
+            "path": ws, "selector": "items/0", "environment": "local",
+            "var": { "serverUrl": "http://127.0.0.1:9" },
+        }),
+    );
+    assert_eq!(other["error"]["category"], "network_execution");
+    assert_eq!(
+        other["error"]["details"]["lattice"]["secrets"]["hydrated"],
+        json!(["token"])
+    );
+    mcp.finish();
+}

--- a/docs/FACET.md
+++ b/docs/FACET.md
@@ -279,6 +279,7 @@ facet blob <hash> [<path>] [--output <file>] [--json]
 facet gc [<path>] [--history-retention <r>] [--yes] [--json]
 facet doctor [--probe] [--json]
 facet tui [<path>] [--appearance graphite|porcelain]
+facet mcp
 ```
 
 Graphite Honey is the TUI default. `:theme` (bare) toggles Porcelain Honey;
@@ -633,6 +634,51 @@ orphans. Nothing is deleted without `--yes`.
   "retention": "unlimited", "runsExpired": 0,
   "orphans": [ { "hash": "…", "sizeBytes": 3 } ], "registryOrphans": 0, "bytesReclaimable": 3 }
 ```
+
+### `mcp`
+
+`facet mcp` serves the Facet commands as Model Context Protocol tools over
+stdio (JSON-RPC 2.0, one message per line; no HTTP transport in v1). It is a
+typed adapter over the **same functions** the CLI calls (`lattice`,
+`facet-record`, and the command functions themselves); it never spawns
+`facet` and never parses terminal output. Every tool result is the existing
+`schemaVersion: 1` document, byte for byte what `facet <command> --json`
+prints, delivered as `structuredContent` (and as pretty text in `content`).
+Errors are the same `error.{category, exitCode, message, details}` envelope
+with `isError: true`; a success document that carries `error` (an `--expect`
+miss) is also `isError: true`. There are no MCP-only fields.
+
+| Tool | Arguments | Same as |
+| --- | --- | --- |
+| `session_start` | `actor?`, `meta?` | `session start` |
+| `session_end` | `id?` (or `current`) | `session end` |
+| `request_list` | `path` | `request list` (Probe, in-process) |
+| `request_get` | `path`, `selector`, `environment?`, `strictVariables?` | `request get` (Probe, in-process) |
+| `request_run` | `path`, `selector`, `environment?`, `var?`, `tag?`, `expect?`, `dryRun?`, `strictVariables?`, `noRecord?` | `request run` |
+| `history_list` | `path?`, `limit?`, `request?`, `status?`, `actor?`, `since?`, `session?`, `environment?`, `tag?`, `hash?`, `bodies?` | `history` |
+| `history_get` | `id`, `path?`, `bodies?` | `history --id` |
+| `blob_get` | `hash`, `path?` | `blob` |
+| `run_diff` | `a`, `b`, `path?`, `bodies?` | `diff` |
+| `run_replay` | `id`, `path?`, `environment?`, `var?`, `tag?`, `expect?`, `frozen?` | `replay` |
+| `sql_query` | `sql`, `path?` | `history --sql` (read-only) |
+
+`expect` is a string spec (`"2xx"`, `"200,201"`) or an array like
+`[200, "3xx"]`. `var` is an object of overrides. **MCP never takes secret
+values as arguments:** a `var` whose name is stored in the Facet machine
+store for that workspace is refused (`invalid_arguments`) before anything
+runs; hydration supplies it, `facet env set` changes it. Not in v1: collection
+writes, `env set`, `gc --yes`, resources. Auth inherits the process
+environment (`FACET_SECRET_KEY`, keyring, `FACET_ACTOR`, `FACET_SESSION`).
+
+Claude Code (`.mcp.json`):
+
+```json
+{ "mcpServers": { "facet": { "command": "facet", "args": ["mcp"], "env": { "FACET_ACTOR": "claude.halo-fullstack" } } } }
+```
+
+The CLI remains the contract; the shell-out path in `docs/FACET.md` and the
+skill template need no MCP. Use `mcp` when a harness wants typed tools and
+`structuredContent` instead of parsing stdout.
 
 ## Exit codes and error categories
 


### PR DESCRIPTION
## Summary

Facet rest 1: `facet mcp`, the Model Context Protocol server over stdio, from the and-more sketch. Nothing in `probe-*`.

**Adapter, not a second door**
- JSON-RPC 2.0, one message per line, stdin → stdout, stderr for logs. `initialize`, `ping`, `tools/list`, `tools/call`; notifications ignored; unknown method `-32601`, unknown tool `-32602`, parse error `-32700`.
- Each tool maps its arguments onto the **same command function the CLI calls** (`run::run`, `history::history`, `session::session`, `diff::diff`, `replay::replay`, …) and returns that function's JSON `Value` as `structuredContent` (plus pretty text in `content`). Every result is the existing `schemaVersion: 1` document, byte for byte what `facet <command> --json` prints. Errors are the same `error.{category, exitCode, message, details}` envelope with `isError: true`; a success document that carries `error` (an `--expect` miss) is `isError: true` too. No MCP-only fields. Never `std::process::Command`, never stdout parsing.
- `request_list` / `request_get` are Probe's commands: delegated to `probe_cli::run` **in-process**, exactly as `facet request list` already does, with the upstream document passed through unchanged (including upstream error envelopes).

**Tools (11)**: `session_start {actor?, meta?}`, `session_end {id?}`, `request_list {path}`, `request_get {path, selector, environment?, strictVariables?}`, `request_run {path, selector, environment?, var?, tag?, expect?, dryRun?, strictVariables?, noRecord?}`, `history_list {path?, limit?, request?, status?, actor?, since?, session?, environment?, tag?, hash?, bodies?}`, `history_get {id, path?, bodies?}`, `blob_get {hash, path?}`, `run_diff {a, b, path?, bodies?}`, `run_replay {id, path?, environment?, var?, tag?, expect?, frozen?}`, `sql_query {sql, path?}`. `expect` accepts `"2xx"`, `"200,201"`, or `[200, "3xx"]`. Schemas have `additionalProperties: false`; golden `mcp_tools.json`.

**Rules from the sketch**
- `sql_query` read-only (same path as `history --sql`; the machine store is never attached).
- Not in v1: collection writes, `env set`, `gc --yes`, resources.
- **No secret values as tool arguments**: a `var` whose name is stored in the Facet machine store for that workspace (and environment, when given) is refused with `invalid_arguments` before anything runs; hydration supplies it, `facet env set` changes it. Test `mcp_refuses_secret_values_as_arguments`.
- Auth inherits the process environment (`FACET_SECRET_KEY`, keyring, `FACET_ACTOR`, `FACET_SESSION`).

**Plumbing**: `CommandOutput::into_parts`, `FacetError::envelope` (now also used by the JSON error path), `versioned_json` shared; `main.rs` starts the server like `tui`. Docs: `docs/FACET.md` § `mcp` with the tool table and a `.mcp.json` example for Claude Code. Skill/rule files are not frozen here (sketch says wait).

## Test plan

On apiary (`~/src/facet`, cargo 1.95), head of this branch:

- [x] `cargo test -p lattice -p facet-record -p facet-cli -p facet-tui`: all green. New: `crates/facet/tests/mcp.rs` (three tests through the binary: handshake + golden tool list + JSON-RPC errors; every tool round-trip incl. expect miss, dry run, transport failure, session_not_set; the secret-argument refusal) and four unit tests in `mcp.rs`.
- [x] Golden `mcp_tools.json`; no existing golden changed.
- [x] Release build + raw JSON-RPC smoke piped into `facet mcp` against python's `http.server` (501 for POST): initialize → 11 tools → `session_start` uses `FACET_ACTOR` → `request_run --expect 2xx` returns the full document with `expect_failed`, `isError: true` → `history_list` sees the run; stderr empty; exit 0 on EOF.
- [x] No new clippy warnings; fmt clean on touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01E3MvVHmyGKQdu6CRignmME
