### PR TITLE
feat: git HEAD auto-tag on record (Facet rest 2)

### DIFF
--- a/crates/facet-record/Cargo.toml
+++ b/crates/facet-record/Cargo.toml
@@ -14,3 +14,6 @@ serde_json = "1"
 
 [lints]
 workspace = true
+
+[dev-dependencies]
+tempfile = "3"

--- a/crates/facet-record/src/lib.rs
+++ b/crates/facet-record/src/lib.rs
@@ -263,10 +263,18 @@ pub fn record(req: &RecordRequest<'_>) -> Recording {
             .find(|header| header.name.eq_ignore_ascii_case("content-type"))
             .map(|header| header.value.clone())
     });
-    let tags_json = if tags.is_empty() {
+    // Auto-tags ride beside the caller's tags: `git:<sha>[-dirty]` for the
+    // workspace's repository, best effort, never a column.
+    let mut all_tags: Vec<String> = tags.to_vec();
+    if let Some(tag) = git_tag(root)
+        && !all_tags.contains(&tag)
+    {
+        all_tags.push(tag);
+    }
+    let tags_json = if all_tags.is_empty() {
         None
     } else {
-        Some(json!(tags).to_string())
+        Some(json!(all_tags).to_string())
     };
     let redacted_url = scrub(&redact_url(request.url.as_deref().unwrap_or("")), redact);
     // Always written post-0003 so `[]` (none) stays distinct from NULL (unknown).
@@ -510,6 +518,53 @@ fn response_headers_json(headers: &[ResponseHeader]) -> Value {
     )
 }
 
+/// Prefixes of tags Facet writes itself (`git:<sha>[-dirty]`, `expect:fail`).
+/// They describe one run and are never copied onto a replay.
+pub const AUTO_TAG_PREFIXES: &[&str] = &["git:", "expect:"];
+
+/// Whether `tag` is one Facet wrote itself.
+#[must_use]
+pub fn is_auto_tag(tag: &str) -> bool {
+    AUTO_TAG_PREFIXES
+        .iter()
+        .any(|prefix| tag.starts_with(prefix))
+}
+
+/// `git:<sha>` or `git:<sha>-dirty` for the repository containing `dir`
+/// (the workspace root, beside the collection), or `None` outside a
+/// repository, without `git`, or on any failure. Local only: `rev-parse
+/// HEAD` plus `status --porcelain --untracked-files=no`, so "dirty" means
+/// tracked changes (staged or unstaged); untracked files do not count, or a
+/// fresh `.facet/workspace.toml` would flag every first run.
+#[must_use]
+pub fn git_tag(dir: &Path) -> Option<String> {
+    let git = |args: &[&str]| {
+        std::process::Command::new("git")
+            .arg("-C")
+            .arg(dir)
+            .args(args)
+            .stdin(std::process::Stdio::null())
+            .stderr(std::process::Stdio::null())
+            .output()
+            .ok()
+            .filter(|output| output.status.success())
+            .map(|output| String::from_utf8_lossy(&output.stdout).into_owned())
+    };
+    let sha = git(&["rev-parse", "HEAD"])?;
+    let sha = sha.trim();
+    if sha.len() != 40 || !sha.bytes().all(|byte| byte.is_ascii_hexdigit()) {
+        return None;
+    }
+    let dirty = !git(&["status", "--porcelain", "--untracked-files=no"])?
+        .trim()
+        .is_empty();
+    Some(if dirty {
+        format!("git:{sha}-dirty")
+    } else {
+        format!("git:{sha}")
+    })
+}
+
 /// Shortest secret value that is scrubbed from stored text. Shorter values
 /// would mangle unrelated text (and are not secrets in any useful sense).
 pub const MIN_REDACT_LEN: usize = 4;
@@ -604,6 +659,15 @@ mod tests {
         assert_eq!(first, same);
         assert_ne!(first, other);
         assert_eq!(first.len(), 64);
+    }
+
+    #[test]
+    fn auto_tags_are_recognized_and_git_tag_is_none_outside_a_repo() {
+        assert!(super::is_auto_tag("git:0123abcd"));
+        assert!(super::is_auto_tag("expect:fail"));
+        assert!(!super::is_auto_tag("smoke"));
+        let dir = tempfile::tempdir().unwrap();
+        assert_eq!(super::git_tag(dir.path()), None);
     }
 
     #[test]

--- a/crates/facet/src/replay.rs
+++ b/crates/facet/src/replay.rs
@@ -214,11 +214,16 @@ pub(crate) fn replay(args: &[String], stdin: &mut impl Read) -> Result<CommandOu
     })
 }
 
-/// Recorded tags first, then `--tag` additions, without duplicates.
+/// Recorded user tags first, then `--tag` additions, without duplicates.
 fn merged_tags(recorded: Option<&str>, extra: &[String]) -> Vec<String> {
+    // The source's own tags carry over; Facet's auto-tags (`git:`,
+    // `expect:`) describe that run and are recomputed for this one.
     let mut tags: Vec<String> = recorded
-        .and_then(|text| serde_json::from_str(text).ok())
-        .unwrap_or_default();
+        .and_then(|text| serde_json::from_str::<Vec<String>>(text).ok())
+        .unwrap_or_default()
+        .into_iter()
+        .filter(|tag| !facet_record::is_auto_tag(tag))
+        .collect();
     for tag in extra {
         if !tags.contains(tag) {
             tags.push(tag.clone());

--- a/crates/facet/tests/common/mod.rs
+++ b/crates/facet/tests/common/mod.rs
@@ -135,6 +135,45 @@ impl Sandbox {
         (exit_code, value)
     }
 
+    /// Turns the sandbox root into a git repository with one commit holding
+    /// `workspace.yml`, returning HEAD's sha. Local only, no remote.
+    pub(crate) fn git_init(&self) -> String {
+        let git = |args: &[&str]| {
+            let output = Command::new("git")
+                .arg("-C")
+                .arg(self.root())
+                .args(args)
+                .output()
+                .expect("git should run");
+            assert!(
+                output.status.success(),
+                "git {args:?}: {}",
+                String::from_utf8_lossy(&output.stderr)
+            );
+            String::from_utf8_lossy(&output.stdout).trim().to_owned()
+        };
+        git(&["init", "-q"]);
+        git(&[
+            "-c",
+            "user.name=facet-test",
+            "-c",
+            "user.email=facet@test",
+            "add",
+            "workspace.yml",
+        ]);
+        git(&[
+            "-c",
+            "user.name=facet-test",
+            "-c",
+            "user.email=facet@test",
+            "commit",
+            "-q",
+            "-m",
+            "fixture",
+        ]);
+        git(&["rev-parse", "HEAD"])
+    }
+
     /// Rewrites `duration_ms` for one run so `diff` output is deterministic.
     pub(crate) fn set_duration_ms(&self, run_id: &str, duration_ms: i64) {
         let db = std::path::absolute(self.root().join(".facet/lattice.db"))

--- a/crates/facet/tests/facet_commands.rs
+++ b/crates/facet/tests/facet_commands.rs
@@ -1787,3 +1787,115 @@ fn dry_run_previews_without_sending_or_recording() {
         assert_eq!(code, 2);
     }
 }
+
+#[test]
+fn git_head_auto_tag_rides_on_record_and_not_on_replay() {
+    let sandbox = Sandbox::new();
+    let (url, server) = serve_once(ECHO_BODY.to_vec(), "application/json");
+    let workspace = sandbox.workspace(&url);
+    let ws = workspace.to_str().unwrap();
+    let sha = sandbox.git_init();
+    assert_eq!(sha.len(), 40);
+    let clean_tag = format!("git:{sha}");
+
+    let clean = sandbox.run_json(&[
+        "request",
+        "run",
+        ws,
+        "items/0",
+        "--environment",
+        "local",
+        "--tag",
+        "smoke",
+    ]);
+    server.join().unwrap();
+    let clean_id = clean["lattice"]["runId"].as_str().unwrap().to_owned();
+    let row = sandbox.run_json(&["history", ws, "--id", &clean_id]);
+    assert_eq!(row["run"]["tags"], json!(["smoke", clean_tag]));
+
+    // A tracked change makes the tree dirty; untracked `.facet/` never does.
+    // Appending a comment keeps the YAML (and the URL) intact.
+    let source = fs::read_to_string(&workspace).unwrap();
+    fs::write(
+        &workspace,
+        format!(
+            "{source}# dirty
+"
+        ),
+    )
+    .unwrap();
+    let again = serve_again(&url, ECHO_BODY.to_vec());
+    let dirty = sandbox.run_json(&["request", "run", ws, "items/0", "--environment", "local"]);
+    again.join().unwrap();
+    let dirty_id = dirty["lattice"]["runId"].as_str().unwrap().to_owned();
+    let row = sandbox.run_json(&["history", ws, "--id", &dirty_id]);
+    assert_eq!(row["run"]["tags"], json!([format!("git:{sha}-dirty")]));
+
+    // `history --tag git:…` is the query.
+    assert_eq!(
+        run_count(&sandbox, &["history", ws, "--tag", &clean_tag]),
+        1
+    );
+    assert_eq!(
+        run_count(
+            &sandbox,
+            &["history", ws, "--tag", &format!("git:{sha}-dirty")]
+        ),
+        1
+    );
+
+    // A replay keeps the source's user tags but recomputes auto-tags: the
+    // clean run's `git:<sha>` must not be copied onto a dirty-tree replay.
+    let again = serve_again(&url, ECHO_BODY.to_vec());
+    let replayed = sandbox.run_json(&["replay", &clean_id, ws, "--tag", "retry"]);
+    again.join().unwrap();
+    let replay_id = replayed["lattice"]["runId"].as_str().unwrap();
+    let row = sandbox.run_json(&["history", ws, "--id", replay_id]);
+    assert_eq!(
+        row["run"]["tags"],
+        json!(["smoke", "retry", format!("git:{sha}-dirty")])
+    );
+
+    // An expect:fail source does not taint a passing replay.
+    let again = serve_again(&url, ECHO_BODY.to_vec());
+    let output = sandbox
+        .facet()
+        .args([
+            "request",
+            "run",
+            ws,
+            "items/0",
+            "--environment",
+            "local",
+            "--expect",
+            "500",
+            "--json",
+        ])
+        .output()
+        .unwrap();
+    again.join().unwrap();
+    assert_eq!(output.status.code(), Some(1));
+    let failed: Value = serde_json::from_slice(&output.stdout).unwrap();
+    let failed_id = failed["lattice"]["runId"].as_str().unwrap();
+    let again = serve_again(&url, ECHO_BODY.to_vec());
+    let passing = sandbox.run_json(&["replay", failed_id, ws, "--expect", "200"]);
+    again.join().unwrap();
+    let row = sandbox.run_json(&[
+        "history",
+        ws,
+        "--id",
+        passing["lattice"]["runId"].as_str().unwrap(),
+    ]);
+    assert_eq!(row["run"]["tags"], json!([format!("git:{sha}-dirty")]));
+
+    // Outside a repository nothing is added (every other test relies on it).
+    let plain = Sandbox::new();
+    let value = record_one_run(&plain, &[]);
+    let row = plain.run_json(&[
+        "history",
+        plain.root().to_str().unwrap(),
+        "--id",
+        value["lattice"]["runId"].as_str().unwrap(),
+    ]);
+    assert_eq!(row["run"]["tags"], json!([]));
+}

--- a/docs/FACET.md
+++ b/docs/FACET.md
@@ -110,6 +110,16 @@ request and response headers, bodies, content type, actor, session, tags, and
 a `requestHash` (SHA-256 of a canonical view of the resolved request; bodies
 enter by hash, authentication by scheme only).
 
+Auto-tags ride beside `--tag` in the same `tags` array, no column:
+`git:<sha>` when the workspace root (the directory beside the collection) is
+inside a git repository, `git:<sha>-dirty` when that tree has tracked
+changes (staged or unstaged; untracked files do not count, so a fresh
+`.facet/workspace.toml` does not flag every first run), and `expect:fail`
+on an `--expect` miss. Local only (`git rev-parse HEAD`, `git status
+--porcelain --untracked-files=no`); no `git` binary or no repository means no
+tag, silently. `history --tag git:<sha>` answers "runs against this
+revision"; a replay copies the source's user tags but recomputes auto-tags.
+
 Redaction: `Authorization`, `Proxy-Authorization`, `Cookie`, `Set-Cookie`,
 `X-Api-Key`, `X-Auth-Token`, `Api-Key`, and `X-Amz-Security-Token` values are
 stored as `<redacted>`. URL userinfo (`user:pass@`) is redacted. Request bodies


### PR DESCRIPTION
## Summary

Facet rest 2: git HEAD auto-tag on record. No `git_head` column; `history --tag git:…` is the query. Nothing in `probe-*`.

- `facet_record::git_tag(dir)`: `git:<sha>` for the repository containing the **workspace root** (the directory beside the collection), `git:<sha>-dirty` when that tree has tracked changes (staged or unstaged). Untracked files do not count, so a fresh `.facet/workspace.toml` does not flag every first run. Local only: `git -C <root> rev-parse HEAD` + `git status --porcelain --untracked-files=no`. No `git` binary, no repository, or any failure → no tag, silently.
- Wired into `record()` beside the caller's `--tag`s (deduped). Same `tags` array, no schema.
- **Replay fix that fell out of it:** `facet_record::is_auto_tag` (`git:`, `expect:` prefixes). A replay now copies the source's user tags only and recomputes its own auto-tags. Before this PR a passing replay of an `expect:fail` run carried `expect:fail` forward, and with git tags it would have carried a stale sha. Covered by the test.
- Docs: `docs/FACET.md` § What is recorded.

**One reading to confirm:** the inbox says "when cwd is a git repo". I keyed on the workspace root rather than the process cwd, because `facet mcp` and harnesses run from arbitrary directories with `<path>` pointing at the collection, and the tag should describe the collection's revision. For the common case (cwd = workspace) they are the same. One-line change if cwd is preferred.

## Test plan

On apiary (`~/src/facet`, cargo 1.95, Apple git 2.50), head of this branch:

- [x] `cargo test -p lattice -p facet-record -p facet-cli -p facet-tui`: all green. New `git_head_auto_tag_rides_on_record_and_not_on_replay`: `git init` + commit in the sandbox → run tagged `git:<sha>`; edit a tracked file → `git:<sha>-dirty`; `history --tag` finds each; replay of the clean run on the dirty tree gets `smoke, retry, git:<sha>-dirty` (no stale sha); passing replay of an `expect:fail` run has no `expect:fail`; a non-repo sandbox gets no tag. Unit test: `git_tag` is `None` outside a repo.
- [x] No existing golden changed (test sandboxes are not repositories).
- [x] No new clippy warnings; fmt clean on touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01E3MvVHmyGKQdu6CRignmME
