### PR TITLE
feat: bells, facet last, facet pin, :history sparkline (Facet rest 3)

### DIFF
--- a/crates/facet-tui/src/app.rs
+++ b/crates/facet-tui/src/app.rs
@@ -543,6 +543,13 @@ pub struct HistoryGrid {
     pub(crate) g_pending: bool,
     /// Footer notice (`yanked 01K…`, hydrate errors). Cleared on move.
     pub(crate) notice: Option<String>,
+    /// Last ≤24 statuses of the focused row's selector, oldest → newest.
+    /// Sparkline paint only — refreshed when the focused selector changes,
+    /// never on a timer, never a verb.
+    pub(crate) sparkline: Vec<Option<i64>>,
+    /// Selector the sparkline was queried for. Dedupes requeries when
+    /// `j`/`k` moves between two rows of the same request.
+    pub(crate) sparkline_selector: Option<String>,
 }
 
 impl HistoryGrid {
@@ -556,6 +563,8 @@ impl HistoryGrid {
             session_only: false,
             g_pending: false,
             notice: None,
+            sparkline: Vec::new(),
+            sparkline_selector: None,
         }
     }
 
@@ -1324,6 +1333,7 @@ impl App {
                         self.help_open = false;
                         self.data_overlay = None;
                         self.history_grid = Some(HistoryGrid::new(root, rows));
+                        self.refresh_sparkline();
                     }
                     Err(error) => {
                         self.status = RunStatus::Failed(format!("history: {error}"));
@@ -1376,9 +1386,65 @@ impl App {
         }
     }
 
+    /// Runs the last-≤24-statuses query for the focused row's selector.
+    /// No-op when the grid is closed or the focused selector is unchanged,
+    /// so callers can invoke it after every grid key without thinking.
+    fn refresh_sparkline(&mut self) {
+        const SPARKLINE_RUNS: usize = 24;
+        let Some(grid) = self.history_grid.as_ref() else {
+            return;
+        };
+        let selector = grid.selected_row().map(|row| row.request_path.clone());
+        if selector == grid.sparkline_selector {
+            return;
+        }
+        let Some(selector) = selector else {
+            let grid = self.history_grid.as_mut().expect("grid");
+            grid.sparkline.clear();
+            grid.sparkline_selector = None;
+            return;
+        };
+        let root = grid.root.clone();
+        let session_only = grid.session_only;
+        // Newest-first from the store; reversed so the sparkline reads
+        // oldest → newest, rightmost cell = latest run.
+        let statuses = WorkspaceStore::open_existing(&root, LatticeConfig::default())
+            .ok()
+            .flatten()
+            .and_then(|store| {
+                store
+                    .history(&HistoryQuery {
+                        limit: SPARKLINE_RUNS,
+                        request_path: Some(selector.clone()),
+                        session_id: if session_only {
+                            facet_record::session_from_env()
+                        } else {
+                            None
+                        },
+                        ..HistoryQuery::default()
+                    })
+                    .ok()
+            })
+            .map(|rows| rows.iter().map(|row| row.status).collect::<Vec<_>>())
+            .unwrap_or_default()
+            .into_iter()
+            .rev()
+            .collect();
+        let grid = self.history_grid.as_mut().expect("grid");
+        grid.sparkline = statuses;
+        grid.sparkline_selector = Some(selector);
+    }
+
     /// Normal-mode keys while the `:history` grid is open. Esc closes the
     /// grid (or exits the `/` input); it never quits the app.
     fn handle_history_key(&mut self, code: KeyCode) -> Result<bool, TuiError> {
+        let consumed = self.handle_history_key_inner(code)?;
+        // Paint follows the focus; no-op unless the focused selector moved.
+        self.refresh_sparkline();
+        Ok(consumed)
+    }
+
+    fn handle_history_key_inner(&mut self, code: KeyCode) -> Result<bool, TuiError> {
         // Phase 1: the `/` filter input captures everything printable.
         {
             let grid = self.history_grid.as_mut().expect("grid");
@@ -2084,6 +2150,16 @@ impl App {
         self.help_open = false;
         self.data_overlay = None;
         self.history_grid = Some(HistoryGrid::new(PathBuf::from("."), rows));
+    }
+
+    /// Paints a canned sparkline onto the open grid for headless renders.
+    /// Not part of the product API.
+    #[doc(hidden)]
+    pub fn preview_sparkline(&mut self, statuses: Vec<Option<i64>>) {
+        if let Some(grid) = self.history_grid.as_mut() {
+            grid.sparkline_selector = grid.selected_row().map(|row| row.request_path.clone());
+            grid.sparkline = statuses;
+        }
     }
 
     /// Opens a data overlay for headless harnesses. Not part of the product API.
@@ -3145,6 +3221,67 @@ mod tests {
             );
             assert!(!grid.session_only);
         }
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[tokio::test]
+    async fn history_sparkline_follows_the_focused_selector() {
+        let (dir, mut app) = app_with_store().await;
+        // Two more "Pets/List pets" runs: a 500 and a transport error, so
+        // that selector has a three-cell line ending in stone.
+        let store = WorkspaceStore::open(&dir, LatticeConfig::default()).unwrap();
+        for (status, offset) in [(Some(500), 10), (None, 20)] {
+            store
+                .record_run(&lattice::NewRun {
+                    started_at: lattice::now_ms() + offset,
+                    duration_ms: Some(5),
+                    request_path: "Pets/List pets",
+                    request_hash: "abc",
+                    method: "GET",
+                    url: "https://example.com/pets",
+                    status,
+                    error: status.is_none().then_some("connection refused"),
+                    actor: "human",
+                    ..Default::default()
+                })
+                .unwrap();
+        }
+        drop(store);
+
+        app.command = "history".to_string();
+        app.execute_command().await.unwrap();
+        // Newest run overall is the error run of "Pets/List pets".
+        let grid = app.history_grid().expect("grid");
+        assert_eq!(grid.sparkline_selector.as_deref(), Some("Pets/List pets"));
+        assert_eq!(
+            grid.sparkline,
+            vec![Some(200), Some(500), None],
+            "oldest → newest, None = unrecorded"
+        );
+
+        // j within the same selector keeps the line; the next j lands on
+        // "Pets/Create pet" and repaints.
+        app.handle_key(KeyCode::Char('j'), KeyModifiers::NONE)
+            .await
+            .unwrap();
+        assert_eq!(
+            app.history_grid().unwrap().sparkline,
+            vec![Some(200), Some(500), None],
+            "same selector: no requery, no repaint"
+        );
+        app.handle_key(KeyCode::Char('j'), KeyModifiers::NONE)
+            .await
+            .unwrap();
+        let grid = app.history_grid().unwrap();
+        assert_eq!(grid.sparkline_selector.as_deref(), Some("Pets/Create pet"));
+        assert_eq!(grid.sparkline, vec![Some(500)]);
+
+        // Closing the grid clears nothing but never queries either.
+        app.handle_key(KeyCode::Esc, KeyModifiers::NONE)
+            .await
+            .unwrap();
+        assert!(app.history_grid().is_none());
+
         let _ = std::fs::remove_dir_all(&dir);
     }
 

--- a/crates/facet-tui/src/ui.rs
+++ b/crates/facet-tui/src/ui.rs
@@ -1117,7 +1117,8 @@ fn render_history_grid(frame: &mut Frame, area: Rect, app: &App, styles: Styles)
     const CHROME: usize = 1 + 6 + 1;
     let fixed = STARTED_W + STATUS_W + MS_W + METHOD_W + ACTOR_W + ID_W + CHROME + REQUEST_MIN;
     let width = ((fixed + 12) as u16).clamp(64, 110).min(area.width);
-    let height = (visible.len().max(1) as u16 + 4)
+    let sparkline_rows = u16::from(!grid.sparkline.is_empty());
+    let height = (visible.len().max(1) as u16 + 4 + sparkline_rows)
         .min(area.height.saturating_sub(2))
         .max(5);
     let overlay = centered(area, width, height);
@@ -1156,13 +1157,42 @@ fn render_history_grid(frame: &mut Frame, area: Rect, app: &App, styles: Styles)
         styles.muted,
     ));
 
-    let body_height = inner.height.saturating_sub(2) as usize; // header + footer
+    // Sparkline (Goal bells): the last ≤24 statuses of the focused row's
+    // selector, oldest → newest. Palette buckets, stone for unrecorded.
+    // Paint only — no key, no verb, flat fallback unaffected.
+    let sparkline = if grid.sparkline.is_empty() {
+        None
+    } else {
+        let mut spans = vec![Span::raw(" ")];
+        for status in &grid.sparkline {
+            let color = match status {
+                Some(code) => palette.response_status(u16::try_from(*code).unwrap_or(0)),
+                None => palette.text_placeholder, // stone
+            };
+            spans.push(Span::styled("●", styles.base.fg(color)));
+        }
+        let label = match &grid.sparkline_selector {
+            Some(selector) => format!("  last {} · {}", grid.sparkline.len(), selector),
+            None => format!("  last {}", grid.sparkline.len()),
+        };
+        let used = 1 + grid.sparkline.len();
+        spans.push(Span::styled(
+            cell(&label, (inner.width as usize).saturating_sub(used)),
+            styles.muted,
+        ));
+        Some(Line::from(spans))
+    };
+
+    let body_height = inner.height.saturating_sub(2 + sparkline_rows) as usize;
     let offset = if grid.selected >= body_height {
         grid.selected + 1 - body_height
     } else {
         0
     };
     let mut lines = vec![header];
+    if let Some(sparkline) = sparkline {
+        lines.push(sparkline);
+    }
     if visible.is_empty() {
         let empty = if grid.filter.is_empty() {
             " (no runs)"
@@ -1539,6 +1569,7 @@ mod tests {
             replayed_from: None,
             var_names: None,
         }]);
+        app.preview_sparkline(vec![Some(200), Some(200), Some(500), None]);
         let backend = TestBackend::new(120, 32);
         let mut terminal = Terminal::new(backend).expect("backend");
         app.render_to(&mut terminal).expect("render");
@@ -1557,6 +1588,12 @@ mod tests {
         assert!(
             text.contains("history · Enter hydrate · y yank"),
             "footer hints: {text}"
+        );
+        // Sparkline: four nodes for four runs, labeled with the selector.
+        assert!(text.contains("●●●●"), "sparkline nodes: {text}");
+        assert!(
+            text.contains("last 4 · Pets/List pets"),
+            "sparkline label: {text}"
         );
     }
 

--- a/crates/facet/src/error.rs
+++ b/crates/facet/src/error.rs
@@ -122,6 +122,20 @@ impl FacetError {
         }))
     }
 
+    /// `pin get <name>` with no such pin (exit 4).
+    pub(crate) fn pin_not_found(name: &str) -> Self {
+        Self::new(
+            "pin_not_found",
+            format!("pin not found: {name}"),
+            REQUEST_NOT_FOUND_EXIT_CODE,
+        )
+    }
+
+    /// A stored value Facet wrote itself cannot be read back (exit 9).
+    pub(crate) fn lattice_corrupt(message: impl Into<String>) -> Self {
+        Self::new("lattice_error", message, LATTICE_EXIT_CODE)
+    }
+
     /// `session end|show <id>` with an unknown session id (exit 4).
     pub(crate) fn session_not_found(id: &str) -> Self {
         Self::new(

--- a/crates/facet/src/history.rs
+++ b/crates/facet/src/history.rs
@@ -89,6 +89,36 @@ pub(crate) fn history(args: &[String]) -> Result<CommandOutput, FacetError> {
         ));
     }
 
+    let (query, hash) = parse_filters(&parsed)?;
+
+    let Some(root) = root else {
+        return Ok(CommandOutput::new(
+            "No Lattice store found; run a request with facet first.\n",
+            json!({ "workspace": Value::Null, "runs": [] }),
+        ));
+    };
+    let store = open_store(&root, &ConfigOverrides::default())?;
+    let rows = store.history(&query).map_err(FacetError::lattice)?;
+
+    let mut lines = vec![HISTORY_HEADER.to_owned()];
+    let mut runs = Vec::with_capacity(rows.len());
+    for row in &rows {
+        lines.push(history_line(row));
+        let mut run = run_json(&store, row, include_bodies)?;
+        if let Some(hash) = &hash {
+            run["matchedHash"] = matched_hash(row, hash);
+        }
+        runs.push(run);
+    }
+    Ok(CommandOutput::new(
+        format!("{}\n", lines.join("\n")),
+        json!({ "workspace": workspace_json(&store), "runs": runs }),
+    ))
+}
+
+/// The query-side filters shared by `history` and `last`, plus the
+/// lowercased `--hash` argument for `matchedHash`.
+fn parse_filters(parsed: &args::Parsed) -> Result<(HistoryQuery, Option<String>), FacetError> {
     let hash = parsed
         .value("--hash")?
         .map(|value| value.trim().to_ascii_lowercase());
@@ -115,29 +145,46 @@ pub(crate) fn history(args: &[String]) -> Result<CommandOutput, FacetError> {
     if query.limit == 0 {
         return Err(FacetError::invalid_arguments("--limit must be at least 1"));
     }
+    Ok((query, hash))
+}
 
-    let Some(root) = root else {
-        return Ok(CommandOutput::new(
-            "No Lattice store found; run a request with facet first.\n",
-            json!({ "workspace": Value::Null, "runs": [] }),
-        ));
-    };
+/// `facet last [<path>] [filters]`: the newest matching run. Human mode
+/// prints the bare ULID, so `facet replay $(facet last --status 500)` is a
+/// one-liner; JSON is the `history --id` shape (`{ workspace, run }`).
+/// No match (or no store) is `run_not_found`, exit 4, so a shell
+/// substitution never yields an empty id.
+pub(crate) fn last(args: &[String]) -> Result<CommandOutput, FacetError> {
+    const LAST_VALUE_FLAGS: &[&str] = &[
+        "--request",
+        "--status",
+        "--actor",
+        "--since",
+        "--session",
+        "--environment",
+        "--tag",
+        "--hash",
+    ];
+    let parsed = args::parse(args, LAST_VALUE_FLAGS, &["--bodies"])?;
+    let path = single_optional_path(parsed.positionals(), "last")?;
+    let (mut query, hash) = parse_filters(&parsed)?;
+    query.limit = 1;
+    let (_, root) = locate_root(path);
+    let none = || FacetError::run_not_found("no run matches");
+    let root = root.ok_or_else(none)?;
     let store = open_store(&root, &ConfigOverrides::default())?;
-    let rows = store.history(&query).map_err(FacetError::lattice)?;
-
-    let mut lines = vec![HISTORY_HEADER.to_owned()];
-    let mut runs = Vec::with_capacity(rows.len());
-    for row in &rows {
-        lines.push(history_line(row));
-        let mut run = run_json(&store, row, include_bodies)?;
-        if let Some(hash) = &hash {
-            run["matchedHash"] = matched_hash(row, hash);
-        }
-        runs.push(run);
+    let row = store
+        .history(&query)
+        .map_err(FacetError::lattice)?
+        .into_iter()
+        .next()
+        .ok_or_else(none)?;
+    let mut run = run_json(&store, &row, parsed.switch("--bodies"))?;
+    if let Some(hash) = &hash {
+        run["matchedHash"] = matched_hash(&row, hash);
     }
     Ok(CommandOutput::new(
-        format!("{}\n", lines.join("\n")),
-        json!({ "workspace": workspace_json(&store), "runs": runs }),
+        format!("{}\n", row.id),
+        json!({ "workspace": workspace_json(&store), "run": run }),
     ))
 }
 

--- a/crates/facet/src/lib.rs
+++ b/crates/facet/src/lib.rs
@@ -30,6 +30,7 @@ mod error;
 mod expect;
 mod history;
 mod mcp;
+mod pin;
 mod presentation;
 mod replay;
 mod run;
@@ -197,6 +198,10 @@ pub const fn help() -> &'static str {
         "      [--expect <codes>] [--dry-run]  Assert the status (exit 1 on miss) or preview only\n",
         "  history [<path>]                    List recorded runs, newest first (metadata only)\n",
         "  history [<path>] --id <ulid>        Show one recorded run by id\n",
+        "  last [<path>] [filters]             Newest matching run; prints its ULID (same filters as history)\n",
+        "  pin <runId> --as <name> [<path>]    Name a run in the machine store\n",
+        "  pin get <name> [<path>]             Print a pinned run id (dangling reported in JSON)\n",
+        "  pin list [<path>] | pin delete <name>\n",
         "  history [<path>] --sql <query>      Run read-only SQL against the workspace store\n",
         "  session start                       Start a session; prints its ULID (use with FACET_SESSION)\n",
         "  session end [<id>|current]          End a session (default: $FACET_SESSION); idempotent\n",
@@ -281,8 +286,8 @@ where
     let owned = match args.first().map(String::as_str) {
         None => true,
         Some(
-            "history" | "mcp" | "session" | "replay" | "diff" | "env" | "doctor" | "blob" | "gc"
-            | "tui" | "-V" | "--version" | "-h" | "--help",
+            "history" | "last" | "pin" | "mcp" | "session" | "replay" | "diff" | "env" | "doctor"
+            | "blob" | "gc" | "tui" | "-V" | "--version" | "-h" | "--help",
         ) => true,
         Some("request") => args.get(1).map(String::as_str) == Some("run"),
         Some(_) => false,
@@ -326,6 +331,8 @@ where
     let result = match args[0].as_str() {
         "request" => run::run(&args[2..], stdin),
         "history" => history::history(&args[1..]),
+        "last" => history::last(&args[1..]),
+        "pin" => pin::pin(&args[1..]),
         "session" => session::session(&args[1..]),
         "replay" => replay::replay(&args[1..], stdin),
         "diff" => diff::diff(&args[1..]),

--- a/crates/facet/src/pin.rs
+++ b/crates/facet/src/pin.rs
@@ -1,0 +1,215 @@
+//! `facet pin`: name a run. The first real write to the machine store's
+//! `preferences` table, so an agent can say "replay the known-good auth"
+//! next week: `facet replay $(facet pin get auth-ok)`.
+//!
+//! Keys are `pin.<name>` in the **machine** store, so a pin survives `gc`
+//! of the workspace. It may then dangle; `pin get` says so (`dangling`).
+
+use lattice::{is_ulid, now_ms};
+use serde_json::{Value, json};
+
+use crate::{
+    CommandOutput, FacetError, args,
+    presentation::format_utc,
+    session::open_machine,
+    workspace::{ConfigOverrides, locate_root, open_store},
+};
+
+const KEY_PREFIX: &str = "pin.";
+
+pub(crate) fn pin(args: &[String]) -> Result<CommandOutput, FacetError> {
+    match args.first().map(String::as_str) {
+        Some("get") => get(&args[1..]),
+        Some("list") => list(&args[1..]),
+        Some("delete") => delete(&args[1..]),
+        Some(_) => set(args),
+        None => Err(FacetError::invalid_arguments(
+            "pin requires <runId> --as <name>, or a subcommand: get, list, delete",
+        )),
+    }
+}
+
+fn set(args: &[String]) -> Result<CommandOutput, FacetError> {
+    let parsed = args::parse(args, &["--as"], &[])?;
+    let (run_id, path) = match parsed.positionals() {
+        [run_id] => (run_id.as_str(), None),
+        [run_id, path] => (run_id.as_str(), Some(path.as_str())),
+        _ => {
+            return Err(FacetError::invalid_arguments(
+                "pin requires <runId> and an optional <path>",
+            ));
+        }
+    };
+    if !is_ulid(run_id) {
+        return Err(FacetError::invalid_arguments(format!(
+            "pin expects a run ULID (or get, list, delete), got {run_id:?}"
+        )));
+    }
+    let name = parsed
+        .value("--as")?
+        .ok_or_else(|| FacetError::invalid_arguments("--as <name> is required"))?;
+    validate_name(name)?;
+
+    // The run must exist where we can see it; the pin remembers the workspace.
+    let (_, root) = locate_root(path);
+    let root = root.ok_or_else(|| FacetError::run_not_found(run_id))?;
+    let store = open_store(&root, &ConfigOverrides::default())?;
+    let row = store
+        .run(run_id)
+        .map_err(FacetError::lattice)?
+        .ok_or_else(|| FacetError::run_not_found(run_id))?;
+    let machine = open_machine()?;
+    let pinned_at = now_ms();
+    let value = json!({
+        "runId": row.id,
+        "workspaceId": store.workspace_id(),
+        "pinnedAt": pinned_at,
+    });
+    machine
+        .set_preference(&key(name), &value.to_string())
+        .map_err(FacetError::lattice)?;
+    Ok(CommandOutput::new(
+        format!("pin {name} → {}\n", row.id),
+        json!({ "pin": pin_json(name, &value, Some(false)) }),
+    ))
+}
+
+fn get(args: &[String]) -> Result<CommandOutput, FacetError> {
+    let parsed = args::parse(args, &[], &[])?;
+    let (name, path) = match parsed.positionals() {
+        [name] => (name.as_str(), None),
+        [name, path] => (name.as_str(), Some(path.as_str())),
+        _ => {
+            return Err(FacetError::invalid_arguments(
+                "pin get requires <name> and an optional <path>",
+            ));
+        }
+    };
+    let machine = open_machine()?;
+    let value = machine
+        .preference(&key(name))
+        .map_err(FacetError::lattice)?
+        .ok_or_else(|| FacetError::pin_not_found(name))?;
+    let value = parse_value(&value)?;
+    let dangling = dangling(&value, path)?;
+    let run_id = value["runId"].as_str().unwrap_or("").to_owned();
+    Ok(CommandOutput::new(
+        format!("{run_id}\n"),
+        json!({ "pin": pin_json(name, &value, dangling) }),
+    ))
+}
+
+fn list(args: &[String]) -> Result<CommandOutput, FacetError> {
+    let parsed = args::parse(args, &[], &[])?;
+    let path = match parsed.positionals() {
+        [] => None,
+        [path] => Some(path.as_str()),
+        _ => {
+            return Err(FacetError::invalid_arguments(
+                "pin list accepts at most one <path>",
+            ));
+        }
+    };
+    let machine = open_machine()?;
+    let rows = machine
+        .preferences(KEY_PREFIX)
+        .map_err(FacetError::lattice)?;
+    let mut lines = vec!["NAME\tRUN\tWORKSPACE\tPINNED\tDANGLING".to_owned()];
+    let mut pins = Vec::with_capacity(rows.len());
+    for (full_key, raw) in &rows {
+        let name = &full_key[KEY_PREFIX.len()..];
+        let value = parse_value(raw)?;
+        let dangling = dangling(&value, path)?;
+        lines.push(format!(
+            "{name}\t{}\t{}\t{}\t{}",
+            value["runId"].as_str().unwrap_or("-"),
+            value["workspaceId"].as_str().unwrap_or("-"),
+            value["pinnedAt"]
+                .as_i64()
+                .map_or_else(|| "-".to_owned(), format_utc),
+            dangling.map_or("?", |flag| if flag { "yes" } else { "no" }),
+        ));
+        pins.push(pin_json(name, &value, dangling));
+    }
+    Ok(CommandOutput::new(
+        format!("{}\n", lines.join("\n")),
+        json!({ "pins": pins }),
+    ))
+}
+
+fn delete(args: &[String]) -> Result<CommandOutput, FacetError> {
+    let parsed = args::parse(args, &[], &[])?;
+    let [name] = parsed.positionals() else {
+        return Err(FacetError::invalid_arguments(
+            "pin delete requires exactly one <name>",
+        ));
+    };
+    let machine = open_machine()?;
+    let deleted = machine
+        .delete_preference(&key(name))
+        .map_err(FacetError::lattice)?;
+    Ok(CommandOutput::new(
+        if deleted {
+            format!("pin {name} deleted\n")
+        } else {
+            format!("pin {name} was not set\n")
+        },
+        json!({ "name": name, "deleted": deleted }),
+    ))
+}
+
+fn key(name: &str) -> String {
+    format!("{KEY_PREFIX}{name}")
+}
+
+fn validate_name(name: &str) -> Result<(), FacetError> {
+    let valid = !name.is_empty()
+        && name.len() <= 64
+        && name
+            .bytes()
+            .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'-' | b'_' | b'.'));
+    if valid {
+        Ok(())
+    } else {
+        Err(FacetError::invalid_arguments(format!(
+            "pin names are 1-64 characters of letters, digits, '-', '_' or '.', got {name:?}"
+        )))
+    }
+}
+
+fn parse_value(raw: &str) -> Result<Value, FacetError> {
+    serde_json::from_str(raw)
+        .map_err(|error| FacetError::lattice_corrupt(format!("malformed pin value: {error}")))
+}
+
+/// `Some(true)` when the pinned run is gone from the workspace store
+/// discovered from `path`, `Some(false)` when it is there, `None` when that
+/// workspace is not the pin's (cannot tell from here).
+fn dangling(value: &Value, path: Option<&str>) -> Result<Option<bool>, FacetError> {
+    let (Some(run_id), Some(workspace_id)) =
+        (value["runId"].as_str(), value["workspaceId"].as_str())
+    else {
+        return Ok(Some(true));
+    };
+    let (_, root) = locate_root(path);
+    let Some(root) = root else {
+        return Ok(None);
+    };
+    let store = open_store(&root, &ConfigOverrides::default())?;
+    if store.workspace_id() != workspace_id {
+        return Ok(None);
+    }
+    Ok(Some(
+        store.run(run_id).map_err(FacetError::lattice)?.is_none(),
+    ))
+}
+
+fn pin_json(name: &str, value: &Value, dangling: Option<bool>) -> Value {
+    json!({
+        "name": name,
+        "runId": value["runId"],
+        "workspaceId": value["workspaceId"],
+        "pinnedAt": value["pinnedAt"],
+        "dangling": dangling,
+    })
+}

--- a/crates/facet/src/session.rs
+++ b/crates/facet/src/session.rs
@@ -191,7 +191,7 @@ fn list(args: &[String]) -> Result<CommandOutput, FacetError> {
 
 /// Opens the machine store with the machine-level configuration only.
 /// Sessions are cross-workspace, so no workspace file applies.
-fn open_machine() -> Result<MachineStore, FacetError> {
+pub(crate) fn open_machine() -> Result<MachineStore, FacetError> {
     let mut config = LatticeConfig::default();
     if let Some(dir) = machine_config_dir() {
         config

--- a/crates/facet/tests/common/mod.rs
+++ b/crates/facet/tests/common/mod.rs
@@ -282,7 +282,7 @@ pub(crate) fn normalize(value: Value) -> Value {
                         "version" | "probeVersion" => json!("<version>"),
                         "id" | "runId" | "workspaceId" => json!("<ulid>"),
                         "sessionId" | "replayedFrom" if value.is_string() => json!("<ulid>"),
-                        "startedAt" | "durationMs" | "updatedAt" => json!("<int>"),
+                        "startedAt" | "durationMs" | "updatedAt" | "pinnedAt" => json!("<int>"),
                         "endedAt" if value.is_number() => json!("<int>"),
                         "requestHash" | "recordedHash" | "currentHash" => json!("<sha256>"),
                         "hash" if value.is_string() => json!("<sha256>"),

--- a/crates/facet/tests/facet_commands.rs
+++ b/crates/facet/tests/facet_commands.rs
@@ -1899,3 +1899,119 @@ fn git_head_auto_tag_rides_on_record_and_not_on_replay() {
     ]);
     assert_eq!(row["run"]["tags"], json!([]));
 }
+
+#[test]
+fn last_prints_the_newest_matching_run_or_exit_4() {
+    let sandbox = Sandbox::new();
+    let root = sandbox.root().to_str().unwrap().to_owned();
+    let (code, error) = sandbox.run_error_json(&["last", &root]);
+    assert_eq!(code, 4, "no store: nothing to substitute");
+    assert_eq!(error["error"]["category"], "run_not_found");
+
+    let first = record_one_run(&sandbox, &["--tag", "a"]);
+    let second = record_one_run(&sandbox, &["--tag", "b"]);
+    let second_id = second["lattice"]["runId"].as_str().unwrap();
+    let first_id = first["lattice"]["runId"].as_str().unwrap();
+
+    let output = sandbox.facet().args(["last", &root]).output().unwrap();
+    assert!(output.status.success());
+    assert_eq!(
+        String::from_utf8_lossy(&output.stdout).trim(),
+        second_id,
+        "bare ULID"
+    );
+    let last = sandbox.run_json(&["last", &root]);
+    assert_eq!(last["run"]["id"], second_id);
+    assert!(last.get("runs").is_none(), "history --id shape");
+    assert_golden("last.json", &normalize(last));
+    let by_tag = sandbox.run_json(&["last", &root, "--tag", "a"]);
+    assert_eq!(by_tag["run"]["id"], first_id);
+    let by_status = sandbox.run_json(&["last", &root, "--status", "200", "--request", "items/0"]);
+    assert_eq!(by_status["run"]["id"], second_id);
+    let (code, error) = sandbox.run_error_json(&["last", &root, "--status", "500"]);
+    assert_eq!(code, 4);
+    assert_eq!(error["error"]["category"], "run_not_found");
+    assert_golden("error_last_none.json", &normalize_error(error));
+    let (code, _) = sandbox.run_error_json(&["last", &root, "--session", "current"]);
+    assert_eq!(code, 5);
+    let (code, _) = sandbox.run_error_json(&["last", &root, "--limit", "2"]);
+    assert_eq!(code, 2, "last has no --limit");
+    let with_bodies = sandbox.run_json(&["last", &root, "--bodies"]);
+    assert_eq!(
+        with_bodies["run"]["response"]["body"]["content"],
+        r#"{"users":[]}"#
+    );
+}
+
+#[test]
+fn pins_name_runs_in_the_machine_store() {
+    let sandbox = Sandbox::new();
+    let root = sandbox.root().to_str().unwrap().to_owned();
+    let run = record_one_run(&sandbox, &[]);
+    let run_id = run["lattice"]["runId"].as_str().unwrap().to_owned();
+
+    let pinned = sandbox.run_json(&["pin", &run_id, "--as", "auth-ok", &root]);
+    assert_eq!(pinned["pin"]["name"], "auth-ok");
+    assert_eq!(pinned["pin"]["runId"], run_id);
+    assert_eq!(pinned["pin"]["workspaceId"], run["lattice"]["workspaceId"]);
+    assert_eq!(pinned["pin"]["dangling"], false);
+
+    // `pin get` prints the bare id so replay can substitute it.
+    let output = sandbox
+        .facet()
+        .args(["pin", "get", "auth-ok", &root])
+        .output()
+        .unwrap();
+    assert!(output.status.success());
+    assert_eq!(String::from_utf8_lossy(&output.stdout).trim(), run_id);
+    let got = sandbox.run_json(&["pin", "get", "auth-ok", &root]);
+    assert_eq!(got["pin"]["dangling"], false);
+    assert_golden("pin_get.json", &normalize(got));
+    let listed = sandbox.run_json(&["pin", "list", &root]);
+    assert_eq!(listed["pins"].as_array().unwrap().len(), 1);
+    assert_golden("pin_list.json", &normalize(listed));
+    // Without a workspace to check against, dangling is unknown.
+    let elsewhere = Sandbox::new();
+    let output = elsewhere
+        .facet()
+        .env("FACET_DATA_DIR", sandbox.root().join("machine"))
+        .args([
+            "pin",
+            "get",
+            "auth-ok",
+            elsewhere.root().to_str().unwrap(),
+            "--json",
+        ])
+        .output()
+        .unwrap();
+    let unknown: Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert!(unknown["pin"]["dangling"].is_null());
+
+    // Re-pin overwrites; bad names and unknown runs are refused.
+    let again = record_one_run(&sandbox, &[]);
+    let again_id = again["lattice"]["runId"].as_str().unwrap();
+    let repinned = sandbox.run_json(&["pin", again_id, "--as", "auth-ok", &root]);
+    assert_eq!(repinned["pin"]["runId"], again_id);
+    let (code, _) = sandbox.run_error_json(&["pin", again_id, "--as", "bad name", &root]);
+    assert_eq!(code, 2);
+    let (code, error) = sandbox.run_error_json(&["pin", UNKNOWN_ULID, "--as", "x", &root]);
+    assert_eq!(code, 4);
+    assert_eq!(error["error"]["category"], "run_not_found");
+    let (code, _) = sandbox.run_error_json(&["pin", "not-a-ulid", "--as", "x", &root]);
+    assert_eq!(code, 2);
+    let (code, error) = sandbox.run_error_json(&["pin", "get", "nope", &root]);
+    assert_eq!(code, 4);
+    assert_eq!(error["error"]["category"], "pin_not_found");
+    assert_golden("error_pin_not_found.json", &normalize_error(error));
+
+    // A pin survives the run: gc the run away and the pin dangles.
+    sandbox.backdate_run(again_id, lattice::now_ms() - 3 * 86_400_000);
+    sandbox.run_json(&["gc", &root, "--history-retention", "1d", "--yes"]);
+    let dangling = sandbox.run_json(&["pin", "get", "auth-ok", &root]);
+    assert_eq!(dangling["pin"]["dangling"], true);
+    let deleted = sandbox.run_json(&["pin", "delete", "auth-ok"]);
+    assert_eq!(deleted["deleted"], true);
+    let deleted = sandbox.run_json(&["pin", "delete", "auth-ok"]);
+    assert_eq!(deleted["deleted"], false);
+    assert_eq!(sandbox.run_json(&["pin", "list", &root])["pins"], json!([]));
+}

--- a/crates/facet/tests/golden/error_last_none.json
+++ b/crates/facet/tests/golden/error_last_none.json
@@ -1,0 +1,8 @@
+{
+  "error": {
+    "category": "run_not_found",
+    "exitCode": 4,
+    "message": "<message>"
+  },
+  "schemaVersion": 1
+}

--- a/crates/facet/tests/golden/error_pin_not_found.json
+++ b/crates/facet/tests/golden/error_pin_not_found.json
@@ -1,0 +1,8 @@
+{
+  "error": {
+    "category": "pin_not_found",
+    "exitCode": 4,
+    "message": "<message>"
+  },
+  "schemaVersion": 1
+}

--- a/crates/facet/tests/golden/last.json
+++ b/crates/facet/tests/golden/last.json
@@ -1,0 +1,62 @@
+{
+  "run": {
+    "actor": "human",
+    "durationMs": "<int>",
+    "environment": "local",
+    "error": null,
+    "id": "<ulid>",
+    "method": "POST",
+    "replayedFrom": null,
+    "request": {
+      "body": {
+        "hash": "<sha256>",
+        "retention": "blob",
+        "sizeBytes": 16
+      },
+      "headers": [
+        {
+          "disabled": false,
+          "name": "X-Probe",
+          "value": "phase-five"
+        }
+      ]
+    },
+    "requestHash": "<sha256>",
+    "requestPath": "items/0",
+    "response": {
+      "body": {
+        "hash": null,
+        "retention": "inline",
+        "sizeBytes": 12
+      },
+      "contentType": "application/json",
+      "headers": [
+        {
+          "name": "connection",
+          "value": "close"
+        },
+        {
+          "name": "content-length",
+          "value": "12"
+        },
+        {
+          "name": "content-type",
+          "value": "application/json"
+        }
+      ]
+    },
+    "sessionId": null,
+    "startedAt": "<int>",
+    "status": 200,
+    "tags": [
+      "b"
+    ],
+    "url": "<url>",
+    "varNames": []
+  },
+  "schemaVersion": 1,
+  "workspace": {
+    "id": "<ulid>",
+    "path": "<path>"
+  }
+}

--- a/crates/facet/tests/golden/pin_get.json
+++ b/crates/facet/tests/golden/pin_get.json
@@ -1,0 +1,10 @@
+{
+  "pin": {
+    "dangling": false,
+    "name": "auth-ok",
+    "pinnedAt": "<int>",
+    "runId": "<ulid>",
+    "workspaceId": "<ulid>"
+  },
+  "schemaVersion": 1
+}

--- a/crates/facet/tests/golden/pin_list.json
+++ b/crates/facet/tests/golden/pin_list.json
@@ -1,0 +1,12 @@
+{
+  "pins": [
+    {
+      "dangling": false,
+      "name": "auth-ok",
+      "pinnedAt": "<int>",
+      "runId": "<ulid>",
+      "workspaceId": "<ulid>"
+    }
+  ],
+  "schemaVersion": 1
+}

--- a/crates/lattice/src/machine.rs
+++ b/crates/lattice/src/machine.rs
@@ -287,6 +287,53 @@ impl MachineStore {
         Ok(out)
     }
 
+    // ----- Preferences (pins first; TUI-private state later) -------------
+
+    /// Sets one preference. `value` is JSON text; the caller owns its shape.
+    pub fn set_preference(&self, key: &str, value: &str) -> Result<(), LatticeError> {
+        self.conn.execute(
+            "INSERT INTO preferences (key, value) VALUES (?1, ?2) \
+             ON CONFLICT(key) DO UPDATE SET value = excluded.value",
+            params![key, value],
+        )?;
+        Ok(())
+    }
+
+    /// Reads one preference's JSON text, or `None`.
+    pub fn preference(&self, key: &str) -> Result<Option<String>, LatticeError> {
+        match self.conn.query_row(
+            "SELECT value FROM preferences WHERE key = ?1",
+            params![key],
+            |row| row.get::<_, String>(0),
+        ) {
+            Ok(value) => Ok(Some(value)),
+            Err(rusqlite::Error::QueryReturnedNoRows) => Ok(None),
+            Err(other) => Err(other.into()),
+        }
+    }
+
+    /// All `(key, value)` pairs whose key starts with `prefix`, sorted by key.
+    pub fn preferences(&self, prefix: &str) -> Result<Vec<(String, String)>, LatticeError> {
+        let mut statement = self.conn.prepare(
+            "SELECT key, value FROM preferences WHERE substr(key, 1, ?1) = ?2 ORDER BY key",
+        )?;
+        let rows = statement
+            .query_map(
+                params![i64::try_from(prefix.len()).unwrap_or(i64::MAX), prefix],
+                |row| Ok((row.get(0)?, row.get(1)?)),
+            )?
+            .collect::<Result<Vec<_>, _>>()?;
+        Ok(rows)
+    }
+
+    /// Deletes one preference; `false` when it was not set.
+    pub fn delete_preference(&self, key: &str) -> Result<bool, LatticeError> {
+        let removed = self
+            .conn
+            .execute("DELETE FROM preferences WHERE key = ?1", params![key])?;
+        Ok(removed > 0)
+    }
+
     // ----- Environments (Surface 3) --------------------------------------
 
     /// Sets one environment value for a workspace. When `secret` is true the

--- a/crates/lattice/tests/store.rs
+++ b/crates/lattice/tests/store.rs
@@ -992,3 +992,31 @@ fn machine_index_answers_which_workspace_holds_a_run() {
     assert_eq!(workspace_id, store.workspace_id());
     assert_eq!(path, store.root().to_string_lossy());
 }
+
+#[test]
+fn preferences_round_trip_by_prefix() {
+    let dir = tempfile::tempdir().unwrap();
+    let machine =
+        MachineStore::open_at(&dir.path().join("machine.db"), &LatticeConfig::default()).unwrap();
+    assert_eq!(machine.preference("pin.auth").unwrap(), None);
+    machine
+        .set_preference("pin.auth", r#"{"runId":"a"}"#)
+        .unwrap();
+    machine.set_preference("pin.b", r#"{"runId":"b"}"#).unwrap();
+    machine
+        .set_preference("tui.theme", r#""graphite""#)
+        .unwrap();
+    machine
+        .set_preference("pin.auth", r#"{"runId":"a2"}"#)
+        .unwrap();
+    assert_eq!(
+        machine.preference("pin.auth").unwrap().as_deref(),
+        Some(r#"{"runId":"a2"}"#)
+    );
+    let pins = machine.preferences("pin.").unwrap();
+    assert_eq!(pins.len(), 2);
+    assert_eq!(pins[0].0, "pin.auth");
+    assert!(machine.delete_preference("pin.b").unwrap());
+    assert!(!machine.delete_preference("pin.b").unwrap());
+    assert_eq!(machine.preferences("pin.").unwrap().len(), 1);
+}

--- a/docs/FACET.md
+++ b/docs/FACET.md
@@ -298,8 +298,10 @@ Graphite Honey is the TUI default. `:theme` (bare) toggles Porcelain Honey;
 `gg`/`G` jump, Enter hydrates the response pane from Lattice (titled
 `run <id> · replayed view`), `y` yanks the run id and `Y` the response
 body hash (OSC 52), `/` filters by selector, `s` toggles runs from
-`$FACET_SESSION` only, Esc closes. `:sql <query>` opens a read-only
-overlay. `?` lists the rest.
+`$FACET_SESSION` only, Esc closes. Under the header, a sparkline paints
+the last ≤24 statuses of the focused row's selector (oldest → newest,
+palette status buckets, stone for unrecorded) — paint, not a verb.
+`:sql <query>` opens a read-only overlay. `?` lists the rest.
 
 Roadmap (Probe's public list, folded): HTTP live; next WebSocket, GraphQL,
 gRPC streaming, user-defined theme files, git integration. Secret storage

--- a/docs/FACET.md
+++ b/docs/FACET.md
@@ -275,6 +275,11 @@ in the Lapis vault for the full runbook.
 facet request run <path> <selector> [<probe request run flags>] [--no-record] [--tag <tag>]... [--expect <codes>] [--dry-run] [--inline-body-max <size>] [--json]
 facet history [<path>] [--limit <n>] [--request <selector>] [--status <code>] [--actor <name>] [--since <unix-ms>] [--session <id>|current] [--environment <name>] [--tag <tag>]... [--hash <sha256>] [--bodies] [--json]
 facet history [<path>] --id <ulid> [--bodies] [--json]
+facet last [<path>] [--request <selector>] [--status <code>] [--actor <name>] [--since <unix-ms>] [--session <id>|current] [--environment <name>] [--tag <tag>]... [--hash <sha256>] [--bodies] [--json]
+facet pin <runId> --as <name> [<path>] [--json]
+facet pin get <name> [<path>] [--json]
+facet pin list [<path>] [--json]
+facet pin delete <name> [--json]
 facet history [<path>] --sql "<query>" [--json]
 facet session start [--actor <name>] [--meta <json>] [--json]
 facet session end [<id>|current] [--json]
@@ -437,6 +442,27 @@ Rows carry two lineage fields from migration 0003: `replayedFrom` (the run
 this one replayed, else `null`) and `varNames` (the `--var` names used at
 resolve time, never values; `[]` when none, `null` on rows recorded before
 0003, meaning unknown).
+
+### `last` and `pin`
+
+`facet last` is `history` with `--limit 1`: the same filters, the newest
+match. Human mode prints the bare ULID, so
+`facet replay $(facet last --status 500)` is a one-liner; `--json` is the
+`history --id` shape (`{ workspace, run }`). No match, or no store, is
+`run_not_found` (exit 4), so a shell substitution never yields an empty id.
+
+`facet pin <runId> --as <name>` names a run: the first real write to the
+machine store's `preferences` table, key `pin.<name>`, value
+`{ runId, workspaceId, pinnedAt }`. The run must exist in the workspace
+store discovered from `<path>` when pinned. Pins live in the **machine**
+store so they survive `gc` of the workspace; `pin get` prints the bare id
+(`facet replay $(facet pin get auth-ok)`) and its JSON reports
+`dangling: true` when the run is gone, `false` when it is there, `null` when
+the workspace under `<path>` is not the pin's. `pin list` returns
+`{ pins: [ … ] }`; `pin delete` reports `deleted`. Names are 1-64 characters
+of letters, digits, `-`, `_`, `.`. Unknown pin: `pin_not_found` (exit 4).
+`SELECT key, value FROM preferences WHERE key LIKE 'pin.%'` is the query
+against the machine store file.
 
 ### `history --sql`
 
@@ -702,8 +728,8 @@ Facet extends the upstream table; it never renumbers it.
 | 1 | Assertion failed (`expect_failed`, `replay_changed`; `diff` found differences) |
 | 9 | Lattice store failure (`lattice_error`, `lattice_not_found`) |
 
-Additional stable categories: `blob_not_found`, `run_not_found`, and
-`session_not_found` (exit 4, "not found"); `session_not_set` and
+Additional stable categories: `blob_not_found`, `run_not_found`,
+`session_not_found`, and `pin_not_found` (exit 4, "not found"); `session_not_set` and
 `secret_backend_unavailable` (exit 5, configuration); `invalid_sql` and
 `sql_read_only` (exit 2). Every JSON document carries `schemaVersion: 1`;
 fields are added compatibly and never removed or retyped within a version.


### PR DESCRIPTION
## Summary

Facet rest 3, the bells: `facet last`, `facet pin`, and the `:history` sparkline. Nothing in `probe-*`.

**`facet last [<path>] [filters] [--bodies] [--json]`** (fullstack)
- `history` with `--limit 1` and the same filters (`--request`, `--status`, `--actor`, `--since`, `--session <id>|current`, `--environment`, `--tag`, `--hash`); `history` and `last` share one filter parser.
- Human mode prints the bare ULID so `facet replay $(facet last --status 500)` is a one-liner. JSON is the `history --id` shape (`{ workspace, run }`).
- No match, or no store, is `run_not_found` (exit 4), so a shell substitution never yields an empty id. Agents stop `jq -r '.runs[0].id'`.

**`facet pin <runId> --as <name> | get | list | delete`** (fullstack)
- First real write to the machine store's `preferences` table: key `pin.<name>`, value `{ runId, workspaceId, pinnedAt }`. The run must exist in the workspace store under `<path>` when pinned (`run_not_found` otherwise). Names: 1–64 of `[A-Za-z0-9._-]`.
- Pins live in the **machine** store, so they survive `gc` of the workspace; `pin get` prints the bare id (`facet replay $(facet pin get auth-ok)`) and its JSON reports `dangling: true|false|null` (gone / present / cannot tell because `<path>` is another workspace). `pin list` → `{ pins }`; `pin delete` → `{ deleted }`; unknown pin → `pin_not_found` (exit 4).
- Lattice gains `set_preference` / `preference` / `preferences(prefix)` / `delete_preference` (JSON text values; the caller owns the shape).

**Sparkline on `:history`** (frontend, commit 8921df5): paint on the grid for the focused selector, not a new verb. See that commit's message; 56/56 `facet-tui` tests including render.

Docs: `docs/FACET.md` § `last` and `pin`, exit table categories.

## Test plan

On apiary (`~/src/facet`, cargo 1.95), head of this branch:

- [x] `cargo test -p lattice -p facet-record -p facet-cli -p facet-tui`: 153 passed, 0 failed. New: `last_prints_the_newest_matching_run_or_exit_4`, `pins_name_runs_in_the_machine_store` (pin, get, list, re-pin, bad name, unknown run, unknown pin, gc → dangling, delete), lattice `preferences_round_trip_by_prefix`, frontend's sparkline tests.
- [x] Goldens: `last`, `error_last_none`, `pin_get`, `pin_list`, `error_pin_not_found` (with `pinnedAt` normalized); no existing golden changed.
- [x] Release build + shell smoke: `facet last` → ULID; `last --status 500` → exit 4; `pin $(facet last) --as auth-ok` → `pin list` → `facet replay $(facet pin get auth-ok)` records with `replayedFrom`.
- [x] No new clippy warnings; `cargo fmt --check` clean on touched files (pre-existing `lattice/tests/{duckdb,turso}.rs` debt remains).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01E3MvVHmyGKQdu6CRignmME
