### PR TITLE
feat(facet-tui): versioned theme files with built-in fallback (Facet rest 4)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2393,12 +2393,14 @@ dependencies = [
  "probe-core",
  "probe-http",
  "serde_json",
+ "tempfile",
 ]
 
 [[package]]
 name = "facet-tui"
 version = "0.5.7"
 dependencies = [
+ "base64 0.23.1",
  "crossterm 0.29.0",
  "facet-record",
  "lattice",
@@ -2407,7 +2409,9 @@ dependencies = [
  "probe-opencollection",
  "ratatui",
  "serde_json",
+ "tempfile",
  "tokio",
+ "toml 1.1.4+spec-1.1.0",
  "unicode-width",
 ]
 

--- a/crates/facet-tui/Cargo.toml
+++ b/crates/facet-tui/Cargo.toml
@@ -15,10 +15,12 @@ ratatui = { version = "0.30", default-features = false, features = ["crossterm"]
 crossterm = "0.29"
 serde_json = "1"
 base64 = "0.23.1"
+toml = "1"
 tokio = { version = "1.53.1", features = ["rt", "rt-multi-thread", "macros", "time"] }
 unicode-width = "0.2"
 
 [dev-dependencies]
 tokio = { version = "1.53.1", features = ["rt", "macros", "time"] }
+tempfile = "3"
 [lints]
 workspace = true

--- a/crates/facet-tui/src/app.rs
+++ b/crates/facet-tui/src/app.rs
@@ -20,6 +20,7 @@ use tokio::sync::mpsc;
 use tokio::sync::watch;
 
 use crate::theme::{Appearance, Depth, Theme};
+use crate::theme_file::{self, ThemeFile};
 use crate::tree::{Row, TreeView};
 
 /// Top-level TUI error type. Wraps I/O, OpenCollection, and HTTP failures
@@ -432,6 +433,9 @@ pub struct App {
     searching: bool,
     request_focus: RequestFocus,
     theme_state: Theme,
+    /// Name of the active theme file (`:theme <name>` / `--theme`), when
+    /// the palette came from disk instead of a built-in.
+    custom_theme: Option<String>,
     section: Section,
     mode: Mode,
     /// `:` command-line buffer (Command mode).
@@ -621,6 +625,7 @@ impl App {
             // Graphite Honey is the product default (2b-i). `--appearance`
             // and `:theme` are the switchers; COLORFGBG does not override.
             theme_state: Theme::new(Appearance::Dark).with_depth(Depth::from_env()),
+            custom_theme: None,
             section: Section::Path,
             mode: Mode::Normal,
             command: String::new(),
@@ -1205,19 +1210,19 @@ impl App {
             "theme" | "appearance" => match arg {
                 "" | "toggle" => {
                     self.theme_state = self.theme_state.toggle();
+                    self.custom_theme = None;
                 }
                 "graphite" | "dark" => {
                     self.theme_state =
                         Theme::new(Appearance::Dark).with_depth(self.theme_state.depth());
+                    self.custom_theme = None;
                 }
                 "porcelain" | "light" => {
                     self.theme_state =
                         Theme::new(Appearance::Light).with_depth(self.theme_state.depth());
+                    self.custom_theme = None;
                 }
-                _ => {
-                    self.status =
-                        RunStatus::Failed("usage: :theme [graphite|porcelain]".to_string());
-                }
+                other => self.apply_theme_file(other),
             },
             "env" | "environment" => {
                 if arg.is_empty() {
@@ -2227,6 +2232,33 @@ impl App {
     /// and `--appearance` overrides).
     pub fn apply_theme(&mut self, theme: Theme) {
         self.theme_state = theme;
+        self.custom_theme = None;
+    }
+
+    /// `:theme <name|path>` / `--theme`: load a theme file and paint with
+    /// it. On any error the built-in for the current appearance stays (or
+    /// is restored, reverting a previously applied file) and the footer
+    /// names the file and field — invalid files never take the chrome down.
+    pub fn apply_theme_file(&mut self, argument: &str) {
+        let result = theme_file::resolve_theme_path(argument).and_then(|path| ThemeFile::load(&path));
+        match result {
+            Ok(file) => {
+                let name = file.name().to_string();
+                self.theme_state = file.theme(self.theme_state.depth());
+                self.custom_theme = Some(name);
+            }
+            Err(error) => {
+                self.theme_state = Theme::new(self.theme_state.appearance())
+                    .with_depth(self.theme_state.depth());
+                self.custom_theme = None;
+                self.status = RunStatus::Failed(format!("theme: {error}"));
+            }
+        }
+    }
+
+    /// The active theme file's name, when one is applied.
+    pub fn custom_theme_name(&self) -> Option<&str> {
+        self.custom_theme.as_deref()
     }
 
     /// Response pane scroll offset.
@@ -2914,6 +2946,59 @@ mod tests {
         app.command = "theme porcelain".to_string();
         app.execute_command().await.unwrap();
         assert_eq!(app.theme().appearance(), Appearance::Light);
+        app.command = "theme graphite".to_string();
+        app.execute_command().await.unwrap();
+        assert_eq!(app.theme().appearance(), Appearance::Dark);
+    }
+
+    #[tokio::test]
+    async fn theme_file_command_applies_and_falls_back() {
+        let dir = tempfile::tempdir().unwrap();
+        let valid = dir.path().join("midnight-honey.toml");
+        std::fs::write(
+            &valid,
+            "version = 1\nname = \"midnight-honey\"\nextends = \"porcelain\"\n\
+             [colors]\naccent = \"#ff0000\"\n",
+        )
+        .unwrap();
+        let broken = dir.path().join("broken.toml");
+        std::fs::write(&broken, "version = 2\nextends = \"graphite\"\n").unwrap();
+
+        let mut app = App::load(Some(&fixture())).await;
+        app.command = format!("theme {}", valid.display());
+        app.execute_command().await.unwrap();
+        assert_eq!(app.custom_theme_name(), Some("midnight-honey"));
+        assert_eq!(app.theme().appearance(), Appearance::Light);
+        assert_eq!(
+            app.theme().palette().accent,
+            ratatui::style::Color::Rgb(255, 0, 0)
+        );
+
+        // Invalid → back to the built-in for the current appearance, with
+        // the file and field named in the footer.
+        app.command = format!("theme {}", broken.display());
+        app.execute_command().await.unwrap();
+        assert_eq!(app.custom_theme_name(), None);
+        assert_eq!(app.theme().appearance(), Appearance::Light);
+        assert_eq!(
+            app.theme().palette().accent,
+            crate::theme::Palette::porcelain_honey().accent
+        );
+        match app.status() {
+            RunStatus::Failed(message) => {
+                assert!(message.contains("broken.toml"), "{message}");
+                assert!(message.contains("version"), "{message}");
+            }
+            other => panic!("expected failure status, got {other:?}"),
+        }
+
+        // A missing file fails the same way and keeps the built-in.
+        app.command = format!("theme {}", dir.path().join("nope.toml").display());
+        app.execute_command().await.unwrap();
+        assert_eq!(app.custom_theme_name(), None);
+        assert!(matches!(app.status(), RunStatus::Failed(_)));
+
+        // Built-ins still win back the chrome afterwards.
         app.command = "theme graphite".to_string();
         app.execute_command().await.unwrap();
         assert_eq!(app.theme().appearance(), Appearance::Dark);

--- a/crates/facet-tui/src/lib.rs
+++ b/crates/facet-tui/src/lib.rs
@@ -7,6 +7,7 @@
 
 mod app;
 mod theme;
+pub mod theme_file;
 mod tree;
 pub mod ui;
 
@@ -15,3 +16,4 @@ pub use app::{
     ResponseView, RunResult, RunStatus, Section, TuiError,
 };
 pub use theme::{Appearance, Depth, Palette, PaletteToken, Role, Styles, Theme};
+pub use theme_file::{ThemeEntry, ThemeFile, ThemeFileError};

--- a/crates/facet-tui/src/main.rs
+++ b/crates/facet-tui/src/main.rs
@@ -42,6 +42,9 @@ fn main() -> ExitCode {
         if let Some(appearance) = cli.appearance {
             app.apply_theme(Theme::new(appearance).with_depth(Depth::from_env()));
         }
+        if let Some(theme) = &cli.theme {
+            app.apply_theme_file(theme);
+        }
         let result = app.run(&mut terminal).await;
         if let Err(error) = result {
             eprintln!("facet-tui: {error}");
@@ -59,11 +62,13 @@ fn main() -> ExitCode {
 
 struct Cli {
     appearance: Option<Appearance>,
+    theme: Option<String>,
     path: Option<PathBuf>,
 }
 
 fn parse_args(args: impl IntoIterator<Item = String>) -> Result<Cli, String> {
     let mut appearance = None;
+    let mut theme = None;
     let mut path = None;
     let mut iter = args.into_iter();
     while let Some(arg) = iter.next() {
@@ -82,11 +87,22 @@ fn parse_args(args: impl IntoIterator<Item = String>) -> Result<Cli, String> {
             );
             continue;
         }
+        if arg == "--theme" {
+            let value = iter
+                .next()
+                .ok_or_else(|| "--theme requires a theme name or path".to_string())?;
+            theme = Some(value);
+            continue;
+        }
         if let Some(value) = arg.strip_prefix("--appearance=") {
             appearance = Some(
                 Appearance::from_flag(value)
                     .ok_or_else(|| format!("unknown appearance '{value}'"))?,
             );
+            continue;
+        }
+        if let Some(value) = arg.strip_prefix("--theme=") {
+            theme = Some(value.to_string());
             continue;
         }
         if path.is_none() && !arg.starts_with('-') {
@@ -95,14 +111,19 @@ fn parse_args(args: impl IntoIterator<Item = String>) -> Result<Cli, String> {
         }
         return Err(format!("unexpected argument: {arg}"));
     }
-    Ok(Cli { appearance, path })
+    Ok(Cli {
+        appearance,
+        theme,
+        path,
+    })
 }
 
 fn print_help() {
     eprintln!(
-        "Usage: facet-tui [--appearance graphite|porcelain] [collection.yml]\n\
+        "Usage: facet-tui [--appearance graphite|porcelain] [--theme <name|path>] [collection.yml]\n\
          \n\
          Graphite Honey is the default. Porcelain Honey is the light appearance.\n\
+         --theme loads a theme file; invalid files fall back to the built-in.\n\
          Keys: j/k move · Enter send · i insert · : command · ? help · q quit"
     );
 }

--- a/crates/facet-tui/src/theme.rs
+++ b/crates/facet-tui/src/theme.rs
@@ -295,6 +295,17 @@ impl Theme {
         }
     }
 
+    /// A theme over a custom palette (a theme file's overrides merged into
+    /// a built-in base). The appearance stays the base's, so lower depths
+    /// resolve through the built-in role channels.
+    pub const fn from_palette(appearance: Appearance, palette: Palette) -> Self {
+        Self {
+            appearance,
+            palette,
+            depth: Depth::Truecolor,
+        }
+    }
+
     pub fn with_depth(mut self, depth: Depth) -> Self {
         self.depth = depth;
         self

--- a/crates/facet-tui/src/theme_file.rs
+++ b/crates/facet-tui/src/theme_file.rs
@@ -1,0 +1,586 @@
+//! Versioned, human-editable theme files (DESIGN.md § Future Plain-Text
+//! Themes), for `facet tui` only — the desktop's files stay upstream.
+//!
+//! A theme file is TOML at `<config dir>/themes/<name>.toml` (the config
+//! dir is `FACET_CONFIG_DIR` or the platform config dir for `facet`):
+//!
+//! ```toml
+//! version = 1
+//! name = "midnight-honey"
+//! extends = "graphite"          # built-in base: graphite | porcelain
+//!
+//! [colors]
+//! accent = "#e7821b"
+//! window_bg = "#1d1e22"
+//! ```
+//!
+//! Rules, per DESIGN.md: parsing and validation live here, outside every
+//! component; unsupported versions and invalid fields reject the **whole
+//! file**; missing tokens merge with the built-in base; a rejected file
+//! leaves a complete built-in theme in place; errors name the source file
+//! and the offending field. Unknown top-level keys are tolerated (the
+//! format grows additively inside a version); unknown `[colors]` tokens
+//! are rejected — a typo'd token silently doing nothing is the worse
+//! failure for a color file. Colors are `#rrggbb` only.
+
+use std::fmt;
+use std::path::{Path, PathBuf};
+
+use ratatui::style::Color;
+
+use crate::theme::{Appearance, Depth, Palette, Theme};
+
+/// The only schema version this binary reads.
+pub const THEME_FILE_VERSION: i64 = 1;
+
+/// A parsed, validated theme file: the built-in base it extends plus the
+/// merged palette (overrides applied, everything else from the base).
+#[derive(Clone, Debug)]
+pub struct ThemeFile {
+    name: String,
+    extends: Appearance,
+    palette: Palette,
+    /// Number of `[colors]` overrides the file set.
+    overrides: usize,
+}
+
+impl ThemeFile {
+    /// Reads and validates a theme file.
+    pub fn load(path: &Path) -> Result<Self, ThemeFileError> {
+        let text = std::fs::read_to_string(path).map_err(|error| ThemeFileError::Io {
+            path: path.to_path_buf(),
+            message: error.to_string(),
+        })?;
+        Self::parse(path, &text)
+    }
+
+    /// Parses and validates. `path` is used for error reporting and the
+    /// default name (file stem); the file is never read here.
+    pub fn parse(path: &Path, text: &str) -> Result<Self, ThemeFileError> {
+        let document: toml::Value =
+            toml::from_str(text).map_err(|error| ThemeFileError::Parse {
+                path: path.to_path_buf(),
+                message: error.to_string(),
+            })?;
+        let table = document.as_table().ok_or_else(|| ThemeFileError::Parse {
+            path: path.to_path_buf(),
+            message: "theme file must be a TOML table".to_string(),
+        })?;
+
+        let version = table.get("version").ok_or_else(|| ThemeFileError::MissingField {
+            path: path.to_path_buf(),
+            field: "version",
+        })?;
+        let version = version.as_integer().ok_or_else(|| ThemeFileError::InvalidField {
+            path: path.to_path_buf(),
+            field: "version".to_string(),
+            reason: "expected an integer".to_string(),
+        })?;
+        if version != THEME_FILE_VERSION {
+            return Err(ThemeFileError::UnsupportedVersion {
+                path: path.to_path_buf(),
+                found: version,
+            });
+        }
+
+        let extends_value = table.get("extends").ok_or_else(|| ThemeFileError::MissingField {
+            path: path.to_path_buf(),
+            field: "extends",
+        })?;
+        let extends_str = extends_value
+            .as_str()
+            .ok_or_else(|| ThemeFileError::InvalidField {
+                path: path.to_path_buf(),
+                field: "extends".to_string(),
+                reason: "expected \"graphite\" or \"porcelain\"".to_string(),
+            })?;
+        let extends = Appearance::from_flag(extends_str).ok_or_else(|| {
+            ThemeFileError::InvalidField {
+                path: path.to_path_buf(),
+                field: "extends".to_string(),
+                reason: format!("expected \"graphite\" or \"porcelain\", got {extends_str:?}"),
+            }
+        })?;
+
+        let name = match table.get("name") {
+            None => path
+                .file_stem()
+                .map(|stem| stem.to_string_lossy().into_owned())
+                .unwrap_or_else(|| "theme".to_string()),
+            Some(value) => {
+                let name = value.as_str().ok_or_else(|| ThemeFileError::InvalidField {
+                    path: path.to_path_buf(),
+                    field: "name".to_string(),
+                    reason: "expected a string".to_string(),
+                })?;
+                if name.is_empty() {
+                    return Err(ThemeFileError::InvalidField {
+                        path: path.to_path_buf(),
+                        field: "name".to_string(),
+                        reason: "must not be empty".to_string(),
+                    });
+                }
+                name.to_string()
+            }
+        };
+
+        let mut palette = Palette::for_appearance(extends);
+        let mut overrides = 0;
+        if let Some(colors) = table.get("colors") {
+            let colors = colors.as_table().ok_or_else(|| ThemeFileError::InvalidField {
+                path: path.to_path_buf(),
+                field: "colors".to_string(),
+                reason: "expected a table of token = \"#rrggbb\"".to_string(),
+            })?;
+            for (token, value) in colors {
+                let field = format!("colors.{token}");
+                let hex = value.as_str().ok_or_else(|| ThemeFileError::InvalidField {
+                    path: path.to_path_buf(),
+                    field: field.clone(),
+                    reason: "expected a \"#rrggbb\" string".to_string(),
+                })?;
+                let color = parse_hex(hex).ok_or_else(|| ThemeFileError::InvalidField {
+                    path: path.to_path_buf(),
+                    field: field.clone(),
+                    reason: format!("expected \"#rrggbb\", got {hex:?}"),
+                })?;
+                if !set_token(&mut palette, token, color) {
+                    return Err(ThemeFileError::UnknownField {
+                        path: path.to_path_buf(),
+                        field,
+                    });
+                }
+                overrides += 1;
+            }
+        }
+
+        Ok(Self {
+            name,
+            extends,
+            palette,
+            overrides,
+        })
+    }
+
+    /// Theme name (`name =` or the file stem).
+    pub fn name(&self) -> &str {
+        &self.name
+    }
+
+    /// The built-in base this theme extends.
+    pub fn extends(&self) -> Appearance {
+        self.extends
+    }
+
+    /// How many `[colors]` tokens the file set.
+    pub fn override_count(&self) -> usize {
+        self.overrides
+    }
+
+    /// The merged palette (overrides over the built-in base).
+    pub fn palette(&self) -> &Palette {
+        &self.palette
+    }
+
+    /// Builds the active theme at a color depth.
+    pub fn theme(&self, depth: Depth) -> Theme {
+        Theme::from_palette(self.extends, self.palette).with_depth(depth)
+    }
+}
+
+/// Why a theme file was rejected. Every variant names the file; field
+/// errors name the field (DESIGN.md: report source and field, never crash).
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum ThemeFileError {
+    /// Unreadable file.
+    Io { path: PathBuf, message: String },
+    /// Not TOML / not a table.
+    Parse { path: PathBuf, message: String },
+    /// `version` is absent.
+    MissingField { path: PathBuf, field: &'static str },
+    /// `version` is not 1.
+    UnsupportedVersion { path: PathBuf, found: i64 },
+    /// A field has the wrong type or an invalid value.
+    InvalidField {
+        path: PathBuf,
+        field: String,
+        reason: String,
+    },
+    /// A `[colors]` token this version does not know.
+    UnknownField { path: PathBuf, field: String },
+}
+
+impl ThemeFileError {
+    /// The source file.
+    pub fn path(&self) -> &Path {
+        match self {
+            Self::Io { path, .. }
+            | Self::Parse { path, .. }
+            | Self::MissingField { path, .. }
+            | Self::UnsupportedVersion { path, .. }
+            | Self::InvalidField { path, .. }
+            | Self::UnknownField { path, .. } => path,
+        }
+    }
+
+    /// The offending field, when the error has one.
+    pub fn field(&self) -> Option<&str> {
+        match self {
+            Self::MissingField { field, .. } => Some(field),
+            Self::InvalidField { field, .. } | Self::UnknownField { field, .. } => Some(field),
+            _ => None,
+        }
+    }
+}
+
+impl fmt::Display for ThemeFileError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Io { path, message } => {
+                write!(formatter, "{}: {message}", path.display())
+            }
+            Self::Parse { path, message } => {
+                write!(formatter, "{}: {message}", path.display())
+            }
+            Self::MissingField { path, field } => {
+                write!(formatter, "{}: missing required field `{field}`", path.display())
+            }
+            Self::UnsupportedVersion { path, found } => write!(
+                formatter,
+                "{}: unsupported theme version {found} (this facet reads version {THEME_FILE_VERSION})",
+                path.display()
+            ),
+            Self::InvalidField {
+                path,
+                field,
+                reason,
+            } => write!(formatter, "{}: {field}: {reason}", path.display()),
+            Self::UnknownField { path, field } => write!(
+                formatter,
+                "{}: unknown token `{field}` (see docs/FACET.md § Theme files)",
+                path.display()
+            ),
+        }
+    }
+}
+
+impl std::error::Error for ThemeFileError {}
+
+/// The themes directory: `<config dir>/themes`.
+pub fn themes_dir() -> Option<PathBuf> {
+    lattice::machine_config_dir().map(|dir| dir.join("themes"))
+}
+
+/// Resolves a `--theme` / `:theme` argument to a file path: an explicit
+/// path (contains a separator or ends in `.toml`) is used as-is; a bare
+/// name resolves to `<themes dir>/<name>.toml`.
+pub fn resolve_theme_path(argument: &str) -> Result<PathBuf, ThemeFileError> {
+    let looks_like_path =
+        argument.ends_with(".toml") || argument.contains('/') || argument.contains('\\');
+    if looks_like_path {
+        return Ok(PathBuf::from(argument));
+    }
+    let path = themes_dir()
+        .map(|dir| dir.join(format!("{argument}.toml")))
+        .ok_or_else(|| ThemeFileError::Io {
+            path: PathBuf::from(argument),
+            message: "no config directory for theme discovery".to_string(),
+        })?;
+    Ok(path)
+}
+
+/// One entry of `facet theme list`: a built-in or a file on disk.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ThemeEntry {
+    /// Theme name (`graphite` / `porcelain` for built-ins).
+    pub name: String,
+    /// `built-in` or `file`.
+    pub source: &'static str,
+    /// File path for file themes.
+    pub path: Option<PathBuf>,
+    /// Base appearance for file themes that parse.
+    pub extends: Option<Appearance>,
+    /// Validation error text for files that do not parse.
+    pub error: Option<String>,
+}
+
+/// Built-ins first, then every `*.toml` in the themes directory (sorted),
+/// validated but never fatal — invalid files list with their error.
+pub fn list_themes() -> Vec<ThemeEntry> {
+    let mut entries = vec![
+        ThemeEntry {
+            name: "graphite".to_string(),
+            source: "built-in",
+            path: None,
+            extends: Some(Appearance::Dark),
+            error: None,
+        },
+        ThemeEntry {
+            name: "porcelain".to_string(),
+            source: "built-in",
+            path: None,
+            extends: Some(Appearance::Light),
+            error: None,
+        },
+    ];
+    let Some(dir) = themes_dir() else {
+        return entries;
+    };
+    let Ok(read_dir) = std::fs::read_dir(&dir) else {
+        return entries;
+    };
+    let mut files: Vec<PathBuf> = read_dir
+        .filter_map(Result::ok)
+        .map(|entry| entry.path())
+        .filter(|path| path.extension().is_some_and(|ext| ext == "toml"))
+        .collect();
+    files.sort();
+    for path in files {
+        let entry = match ThemeFile::load(&path) {
+            Ok(theme) => ThemeEntry {
+                name: theme.name().to_string(),
+                source: "file",
+                path: Some(path),
+                extends: Some(theme.extends()),
+                error: None,
+            },
+            Err(error) => ThemeEntry {
+                name: path
+                    .file_stem()
+                    .map(|stem| stem.to_string_lossy().into_owned())
+                    .unwrap_or_else(|| "theme".to_string()),
+                source: "file",
+                path: Some(path),
+                extends: None,
+                error: Some(error.to_string()),
+            },
+        };
+        entries.push(entry);
+    }
+    entries
+}
+
+/// `#rrggbb` → RGB. The only accepted color literal.
+fn parse_hex(text: &str) -> Option<Color> {
+    let hex = text.strip_prefix('#')?;
+    if hex.len() != 6 || !hex.bytes().all(|byte| byte.is_ascii_hexdigit()) {
+        return None;
+    }
+    let channel = |index: usize| u8::from_str_radix(&hex[index..index + 2], 16).ok();
+    Some(Color::Rgb(channel(0)?, channel(2)?, channel(4)?))
+}
+
+/// Applies one `[colors]` token. Returns `false` for a token this schema
+/// version does not define. The token names are the public contract;
+/// docs/FACET.md § Theme files lists them in the same groups.
+fn set_token(palette: &mut Palette, token: &str, color: Color) -> bool {
+    match token {
+        // Surfaces (role fg/bg pairs).
+        "window_fg" => palette.window.fg = color,
+        "window_bg" => palette.window.bg = color,
+        "sidebar_fg" => palette.sidebar.fg = color,
+        "sidebar_bg" => palette.sidebar.bg = color,
+        "editor_fg" => palette.editor.fg = color,
+        "editor_bg" => palette.editor.bg = color,
+        "raised_fg" => palette.raised.fg = color,
+        "raised_bg" => palette.raised.bg = color,
+        "overlay_fg" => palette.overlay.fg = color,
+        "overlay_bg" => palette.overlay.bg = color,
+        // Text.
+        "text_primary" => palette.text_primary = color,
+        "text_secondary" => palette.text_secondary = color,
+        "text_muted" => palette.text_muted = color,
+        "text_placeholder" => palette.text_placeholder = color,
+        "text_inverse" => palette.text_inverse = color,
+        // Borders.
+        "border_subtle" => palette.border_subtle = color,
+        "border_standard" => palette.border_standard = color,
+        "border_strong" => palette.border_strong = color,
+        "border_focused" => palette.border_focused = color,
+        // Accent.
+        "accent" => palette.accent = color,
+        "accent_hover" => palette.accent_hover = color,
+        "accent_pressed" => palette.accent_pressed = color,
+        "accent_disabled" => palette.accent_disabled = color,
+        "accent_disabled_fg" => palette.accent_disabled_fg = color,
+        // Selection.
+        "selection_active_bg" => palette.selection_active_bg = color,
+        "selection_active_fg" => palette.selection_active_fg = color,
+        "selection_inactive_bg" => palette.selection_inactive_bg = color,
+        "selection_inactive_fg" => palette.selection_inactive_fg = color,
+        // Status.
+        "status_success" => palette.status_success = color,
+        "status_warning" => palette.status_warning = color,
+        "status_error" => palette.status_error = color,
+        "status_informational" => palette.status_informational = color,
+        // HTTP methods.
+        "method_get" => palette.method_get = color,
+        "method_post" => palette.method_post = color,
+        "method_put" => palette.method_put = color,
+        "method_patch" => palette.method_patch = color,
+        "method_delete" => palette.method_delete = color,
+        "method_other" => palette.method_other = color,
+        // Response status families.
+        "response_informational" => palette.response_informational = color,
+        "response_success" => palette.response_success = color,
+        "response_redirect" => palette.response_redirect = color,
+        "response_client_error" => palette.response_client_error = color,
+        "response_server_error" => palette.response_server_error = color,
+        // Syntax.
+        "syntax_property" => palette.syntax_property = color,
+        "syntax_string" => palette.syntax_string = color,
+        "syntax_number" => palette.syntax_number = color,
+        "syntax_boolean" => palette.syntax_boolean = color,
+        "syntax_null" => palette.syntax_null = color,
+        "syntax_punctuation" => palette.syntax_punctuation = color,
+        _ => return false,
+    }
+    true
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn path() -> &'static Path {
+        Path::new("midnight-honey.toml")
+    }
+
+    #[test]
+    fn valid_file_merges_overrides_with_the_base() {
+        let theme = ThemeFile::parse(
+            path(),
+            r##"
+version = 1
+name = "midnight-honey"
+extends = "graphite"
+
+[colors]
+accent = "#ff0000"
+window_bg = "#101012"
+"##,
+        )
+        .expect("valid theme");
+        assert_eq!(theme.name(), "midnight-honey");
+        assert_eq!(theme.extends(), Appearance::Dark);
+        assert_eq!(theme.override_count(), 2);
+        assert_eq!(theme.palette().accent, Color::Rgb(255, 0, 0));
+        assert_eq!(theme.palette().window.bg, Color::Rgb(16, 16, 18));
+        // Untouched tokens come from Graphite Honey.
+        assert_eq!(
+            theme.palette().text_primary,
+            Palette::graphite_honey().text_primary
+        );
+    }
+
+    #[test]
+    fn name_defaults_to_the_file_stem() {
+        let theme = ThemeFile::parse(path(), "version = 1\nextends = \"porcelain\"\n").unwrap();
+        assert_eq!(theme.name(), "midnight-honey");
+        assert_eq!(theme.extends(), Appearance::Light);
+        assert_eq!(theme.override_count(), 0);
+    }
+
+    #[test]
+    fn unsupported_version_rejects_the_file() {
+        let error = ThemeFile::parse(path(), "version = 2\nextends = \"graphite\"\n").unwrap_err();
+        assert_eq!(
+            error,
+            ThemeFileError::UnsupportedVersion {
+                path: path().to_path_buf(),
+                found: 2,
+            }
+        );
+    }
+
+    #[test]
+    fn missing_version_rejects_the_file() {
+        let error = ThemeFile::parse(path(), "extends = \"graphite\"\n").unwrap_err();
+        assert_eq!(
+            error,
+            ThemeFileError::MissingField {
+                path: path().to_path_buf(),
+                field: "version",
+            }
+        );
+    }
+
+    #[test]
+    fn bad_hex_names_the_field() {
+        let error = ThemeFile::parse(
+            path(),
+            "version = 1\nextends = \"graphite\"\n[colors]\naccent = \"red\"\n",
+        )
+        .unwrap_err();
+        assert_eq!(
+            error,
+            ThemeFileError::InvalidField {
+                path: path().to_path_buf(),
+                field: "colors.accent".to_string(),
+                reason: "expected \"#rrggbb\", got \"red\"".to_string(),
+            }
+        );
+    }
+
+    #[test]
+    fn unknown_color_token_rejects_the_file() {
+        let error = ThemeFile::parse(
+            path(),
+            "version = 1\nextends = \"graphite\"\n[colors]\naccnet = \"#ff0000\"\n",
+        )
+        .unwrap_err();
+        assert_eq!(
+            error,
+            ThemeFileError::UnknownField {
+                path: path().to_path_buf(),
+                field: "colors.accnet".to_string(),
+            }
+        );
+    }
+
+    #[test]
+    fn unknown_top_level_keys_are_tolerated() {
+        // Additive growth inside a version: a future optional key must not
+        // break this binary.
+        let theme = ThemeFile::parse(
+            path(),
+            "version = 1\nextends = \"graphite\"\nauthor = \"evan\"\n",
+        )
+        .unwrap();
+        assert_eq!(theme.extends(), Appearance::Dark);
+    }
+
+    #[test]
+    fn invalid_extends_rejects_the_file() {
+        let error =
+            ThemeFile::parse(path(), "version = 1\nextends = \"neon\"\n").unwrap_err();
+        assert!(matches!(
+            error,
+            ThemeFileError::InvalidField { field, .. } if field == "extends"
+        ));
+    }
+
+    #[test]
+    fn syntax_error_is_a_parse_error() {
+        let error = ThemeFile::parse(path(), "version = = 1\n").unwrap_err();
+        assert!(matches!(error, ThemeFileError::Parse { .. }));
+    }
+
+    #[test]
+    fn uppercase_hex_is_accepted() {
+        let theme = ThemeFile::parse(
+            path(),
+            "version = 1\nextends = \"graphite\"\n[colors]\naccent = \"#E7821B\"\n",
+        )
+        .unwrap();
+        assert_eq!(theme.palette().accent, Color::Rgb(0xe7, 0x82, 0x1b));
+    }
+
+    #[test]
+    fn theme_builds_at_any_depth() {
+        let file = ThemeFile::parse(path(), "version = 1\nextends = \"graphite\"\n").unwrap();
+        let theme = file.theme(Depth::Indexed);
+        assert_eq!(theme.appearance(), Appearance::Dark);
+        assert_eq!(theme.depth(), Depth::Indexed);
+    }
+}

--- a/crates/facet-tui/src/ui.rs
+++ b/crates/facet-tui/src/ui.rs
@@ -64,7 +64,10 @@ fn render_title(frame: &mut Frame, area: Rect, app: &App, styles: Styles) {
         Some(name) => format!(" facet · {name}{dirty} "),
         None => format!(" facet{dirty} "),
     };
-    let appearance = app.theme().appearance().label();
+    let appearance = app
+        .custom_theme_name()
+        .map(str::to_string)
+        .unwrap_or_else(|| app.theme().appearance().label().to_string());
     let line = Line::from(vec![
         Span::styled(title_text, styles.title),
         Span::raw(" "),
@@ -877,7 +880,10 @@ fn render_footer(frame: &mut Frame, area: Rect, app: &App, styles: Styles) {
     } else {
         "j/k · Enter send · i insert · : command · ? help · q quit".to_string()
     };
-    let appearance = app.theme().appearance().label().to_lowercase();
+    let appearance = app
+        .custom_theme_name()
+        .map(str::to_string)
+        .unwrap_or_else(|| app.theme().appearance().label().to_lowercase());
 
     let mut segments: Vec<(String, Style)> = vec![
         (CODENAME.to_string(), styles.muted),

--- a/crates/facet/src/error.rs
+++ b/crates/facet/src/error.rs
@@ -122,6 +122,16 @@ impl FacetError {
         }))
     }
 
+    /// `facet theme check` on a rejected theme file (exit 1, assertion
+    /// family): the TUI would fall back to a built-in; `check` reports it
+    /// instead, naming the file and field in `details`.
+    pub(crate) fn theme_invalid(error: &facet_tui::ThemeFileError) -> Self {
+        Self::new("theme_invalid", error.to_string(), ASSERTION_EXIT_CODE).with_details(json!({
+            "path": error.path().to_string_lossy(),
+            "field": error.field(),
+        }))
+    }
+
     /// `pin get <name>` with no such pin (exit 4).
     pub(crate) fn pin_not_found(name: &str) -> Self {
         Self::new(

--- a/crates/facet/src/lib.rs
+++ b/crates/facet/src/lib.rs
@@ -35,6 +35,7 @@ mod presentation;
 mod replay;
 mod run;
 mod session;
+mod theme;
 mod tui;
 mod workspace;
 
@@ -216,6 +217,8 @@ pub const fn help() -> &'static str {
         "  doctor [--probe]                   Preflight: machine/workspace stores, secret backend, FACET_* env\n",
         "  blob <hash> [<path>]                Fetch one stored body by SHA-256\n",
         "  gc [<path>] [--yes]                 Expire old runs and sweep orphaned blobs\n",
+        "  theme check <path>                  Validate a facet-tui theme file (exit 1 if invalid)\n",
+        "  theme list                          List built-in and discovered theme files\n",
         "  tui [<path>]                        Open the terminal UI\n",
         "  mcp                                 Serve the same commands as MCP tools over stdio\n",
         "\n",
@@ -287,7 +290,7 @@ where
         None => true,
         Some(
             "history" | "last" | "pin" | "mcp" | "session" | "replay" | "diff" | "env" | "doctor"
-            | "blob" | "gc" | "tui" | "-V" | "--version" | "-h" | "--help",
+            | "blob" | "gc" | "theme" | "tui" | "-V" | "--version" | "-h" | "--help",
         ) => true,
         Some("request") => args.get(1).map(String::as_str) == Some("run"),
         Some(_) => false,
@@ -340,6 +343,7 @@ where
         "doctor" => doctor::doctor(&args[1..]),
         "blob" => history::blob(&args[1..]),
         "gc" => history::gc(&args[1..]),
+        "theme" => theme::theme(&args[1..]),
         "tui" => Err(FacetError::invalid_arguments(
             "tui is interactive and must be started from the facet binary",
         )),

--- a/crates/facet/src/theme.rs
+++ b/crates/facet/src/theme.rs
@@ -1,0 +1,133 @@
+//! `facet theme`: validate and list `facet-tui` theme files without a
+//! terminal. Theme files are local presentation config (DESIGN.md), never
+//! collection data, so this command touches no workspace and no Lattice.
+//!
+//! `check` is the agent/CI surface: exit 0 when the file parses, exit 1
+//! (assertion family, `theme_invalid`) when the TUI would fall back to a
+//! built-in — with the file and field named in `details`.
+
+use std::path::Path;
+
+use facet_tui::theme_file::{self, ThemeFile};
+use facet_tui::Appearance;
+use serde_json::json;
+
+use crate::{CommandOutput, FacetError, args};
+
+pub(crate) fn theme(args: &[String]) -> Result<CommandOutput, FacetError> {
+    match args.first().map(String::as_str) {
+        Some("check") => check(&args[1..]),
+        Some("list") => list(&args[1..]),
+        _ => Err(FacetError::invalid_arguments(
+            "theme requires a subcommand: check <path>, list",
+        )),
+    }
+}
+
+fn check(args: &[String]) -> Result<CommandOutput, FacetError> {
+    let parsed = args::parse(args, &[], &[])?;
+    let [path] = parsed.positionals() else {
+        return Err(FacetError::invalid_arguments(
+            "theme check requires exactly one <path>",
+        ));
+    };
+    let path = Path::new(path.as_str());
+    match ThemeFile::load(path) {
+        Ok(theme) => Ok(CommandOutput::new(
+            format!(
+                "theme {} valid (extends {}, {} overrides)\n",
+                theme.name(),
+                appearance_flag(theme.extends()),
+                theme.override_count(),
+            ),
+            json!({ "theme": {
+                "path": path.to_string_lossy(),
+                "name": theme.name(),
+                "extends": appearance_flag(theme.extends()),
+                "overrides": theme.override_count(),
+                "valid": true,
+            } }),
+        )),
+        Err(error) => Err(FacetError::theme_invalid(&error)),
+    }
+}
+
+fn list(args: &[String]) -> Result<CommandOutput, FacetError> {
+    let parsed = args::parse(args, &[], &[])?;
+    if !parsed.positionals().is_empty() {
+        return Err(FacetError::invalid_arguments("theme list takes no arguments"));
+    }
+    let entries = theme_file::list_themes();
+    let mut lines = vec!["NAME\tSOURCE\tEXTENDS\tPATH".to_owned()];
+    let mut themes = Vec::with_capacity(entries.len());
+    for entry in &entries {
+        let extends = entry.extends.map(appearance_flag);
+        lines.push(format!(
+            "{}\t{}\t{}\t{}{}",
+            entry.name,
+            entry.source,
+            extends.unwrap_or("-"),
+            entry
+                .path
+                .as_ref()
+                .map(|path| path.display().to_string())
+                .unwrap_or_else(|| "-".to_owned()),
+            entry
+                .error
+                .as_ref()
+                .map(|error| format!(" (invalid: {error})"))
+                .unwrap_or_default(),
+        ));
+        themes.push(json!({
+            "name": entry.name,
+            "source": entry.source,
+            "extends": extends,
+            "path": entry.path.as_ref().map(|path| path.to_string_lossy()),
+            "valid": entry.error.is_none(),
+            "error": entry.error,
+        }));
+    }
+    Ok(CommandOutput::new(
+        format!("{}\n", lines.join("\n")),
+        json!({ "themes": themes }),
+    ))
+}
+
+fn appearance_flag(appearance: Appearance) -> &'static str {
+    match appearance {
+        Appearance::Dark => "graphite",
+        Appearance::Light => "porcelain",
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn check_rejects_a_bad_version_with_file_and_field() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("broken.toml");
+        std::fs::write(&path, "version = 2\nextends = \"graphite\"\n").unwrap();
+        let error = theme(&["check".to_owned(), path.display().to_string()]).unwrap_err();
+        assert_eq!(error.category, "theme_invalid");
+        assert_eq!(error.exit_code, 1);
+        assert!(error.message.contains("broken.toml"));
+        assert!(error.message.contains("version 2"));
+    }
+
+    #[test]
+    fn check_accepts_a_valid_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("ok.toml");
+        std::fs::write(
+            &path,
+            "version = 1\nextends = \"porcelain\"\n[colors]\naccent = \"#123456\"\n",
+        )
+        .unwrap();
+        let output = theme(&["check".to_owned(), path.display().to_string()]).unwrap();
+        assert_eq!(output.json["theme"]["valid"], true);
+        assert_eq!(output.json["theme"]["extends"], "porcelain");
+        assert_eq!(output.json["theme"]["overrides"], 1);
+    }
+}

--- a/crates/facet/src/tui.rs
+++ b/crates/facet/src/tui.rs
@@ -7,13 +7,16 @@ use std::{io, path::PathBuf};
 use facet_tui::{App, Appearance, Depth, Theme};
 use ratatui::{Terminal, backend::CrosstermBackend};
 
-const HELP: &str = "Usage: facet tui [--appearance graphite|porcelain] [<path>]\n\
+const HELP: &str = "Usage: facet tui [--appearance graphite|porcelain] [--theme <name|path>] [<path>]\n\
 \n\
 Graphite Honey is the default. Porcelain Honey is the light appearance.\n\
+--theme loads a theme file from <config dir>/themes/<name>.toml (or an explicit\n\
+path); an invalid file falls back to the built-in for the current appearance.\n\
 Keys: j/k move · Enter send · i insert · : command · ? help · q quit\n";
 
 struct Cli {
     appearance: Option<Appearance>,
+    theme: Option<String>,
     path: Option<PathBuf>,
 }
 
@@ -58,6 +61,11 @@ pub fn run_tui(args: &[String]) -> u8 {
         if let Some(appearance) = cli.appearance {
             app.apply_theme(Theme::new(appearance).with_depth(Depth::from_env()));
         }
+        if let Some(theme) = &cli.theme {
+            // Invalid files fall back to the built-in and name the field
+            // in the footer; the TUI never fails to start over a theme.
+            app.apply_theme_file(theme);
+        }
         match app.run(&mut terminal).await {
             Ok(()) => 0,
             Err(error) => {
@@ -75,6 +83,7 @@ pub fn run_tui(args: &[String]) -> u8 {
 
 fn parse_args(args: &[String]) -> Result<Cli, String> {
     let mut appearance = None;
+    let mut theme = None;
     let mut path = None;
     let mut iter = args.iter();
     while let Some(argument) = iter.next() {
@@ -86,9 +95,17 @@ fn parse_args(args: &[String]) -> Result<Cli, String> {
                     .ok_or_else(|| "--appearance requires graphite or porcelain".to_owned())?;
                 appearance = Some(parse_appearance(value)?);
             }
+            "--theme" => {
+                let value = iter
+                    .next()
+                    .ok_or_else(|| "--theme requires a theme name or path".to_owned())?;
+                theme = Some(value.clone());
+            }
             other => {
                 if let Some(value) = other.strip_prefix("--appearance=") {
                     appearance = Some(parse_appearance(value)?);
+                } else if let Some(value) = other.strip_prefix("--theme=") {
+                    theme = Some(value.to_owned());
                 } else if path.is_none() && !other.starts_with('-') {
                     path = Some(PathBuf::from(other));
                 } else {
@@ -97,7 +114,11 @@ fn parse_args(args: &[String]) -> Result<Cli, String> {
             }
         }
     }
-    Ok(Cli { appearance, path })
+    Ok(Cli {
+        appearance,
+        theme,
+        path,
+    })
 }
 
 fn parse_appearance(value: &str) -> Result<Appearance, String> {

--- a/crates/facet/tests/facet_commands.rs
+++ b/crates/facet/tests/facet_commands.rs
@@ -2015,3 +2015,80 @@ fn pins_name_runs_in_the_machine_store() {
     assert_eq!(deleted["deleted"], false);
     assert_eq!(sandbox.run_json(&["pin", "list", &root])["pins"], json!([]));
 }
+
+fn theme_fixture(name: &str) -> String {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../../tests/fixtures/themes")
+        .join(name)
+        .display()
+        .to_string()
+}
+
+#[test]
+fn theme_check_validates_a_theme_file() {
+    let sandbox = Sandbox::new();
+    let checked = sandbox.run_json(&["theme", "check", &theme_fixture("midnight-honey.toml")]);
+    assert_eq!(checked["theme"]["valid"], true);
+    assert_eq!(checked["theme"]["name"], "midnight-honey");
+    assert_eq!(checked["theme"]["extends"], "graphite");
+    assert_eq!(checked["theme"]["overrides"], 4);
+    assert_golden("theme_check_valid.json", &normalize(checked));
+}
+
+#[test]
+fn theme_check_rejects_an_invalid_file_with_file_and_field() {
+    let sandbox = Sandbox::new();
+    let (code, error) =
+        sandbox.run_error_json(&["theme", "check", &theme_fixture("broken-accent.toml")]);
+    assert_eq!(code, 1, "a rejected theme file is the assertion family");
+    assert_eq!(error["error"]["category"], "theme_invalid");
+    assert_eq!(error["error"]["details"]["field"], "colors.accent");
+    assert_golden("error_theme_invalid.json", &normalize_error(error));
+
+    // A missing file and a missing argument are their own categories.
+    let (code, error) = sandbox.run_error_json(&["theme", "check", "nope.toml"]);
+    assert_eq!(code, 1);
+    assert_eq!(error["error"]["category"], "theme_invalid");
+    let (code, _) = sandbox.run_error_json(&["theme", "check"]);
+    assert_eq!(code, 2);
+}
+
+#[test]
+fn theme_list_shows_built_ins_and_discovers_files() {
+    let sandbox = Sandbox::new();
+    // Sandbox config dir has no themes yet: built-ins only.
+    let list = sandbox.run_json(&["theme", "list"]);
+    let names: Vec<&str> = list["themes"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|theme| theme["name"].as_str().unwrap())
+        .collect();
+    assert_eq!(names, ["graphite", "porcelain"]);
+    assert_golden("theme_list.json", &normalize(list));
+
+    // A file in <config>/themes is discovered; a broken sibling lists
+    // with its error instead of failing the command.
+    let themes_dir = sandbox.root().join("config/themes");
+    fs::create_dir_all(&themes_dir).unwrap();
+    fs::write(
+        themes_dir.join("midnight-honey.toml"),
+        "version = 1\nextends = \"graphite\"\n[colors]\naccent = \"#e7821b\"\n",
+    )
+    .unwrap();
+    fs::write(themes_dir.join("oops.toml"), "version = 9\n").unwrap();
+    let list = sandbox.run_json(&["theme", "list"]);
+    let themes = list["themes"].as_array().unwrap();
+    assert_eq!(themes.len(), 4);
+    assert_eq!(themes[2]["name"], "midnight-honey");
+    assert_eq!(themes[2]["source"], "file");
+    assert_eq!(themes[2]["valid"], true);
+    assert_eq!(themes[3]["name"], "oops");
+    assert_eq!(themes[3]["valid"], false);
+    assert!(
+        themes[3]["error"]
+            .as_str()
+            .unwrap()
+            .contains("unsupported theme version 9")
+    );
+}

--- a/crates/facet/tests/golden/error_theme_invalid.json
+++ b/crates/facet/tests/golden/error_theme_invalid.json
@@ -1,0 +1,12 @@
+{
+  "error": {
+    "category": "theme_invalid",
+    "details": {
+      "field": "colors.accent",
+      "path": "<path>"
+    },
+    "exitCode": 1,
+    "message": "<message>"
+  },
+  "schemaVersion": 1
+}

--- a/crates/facet/tests/golden/theme_check_valid.json
+++ b/crates/facet/tests/golden/theme_check_valid.json
@@ -1,0 +1,10 @@
+{
+  "schemaVersion": 1,
+  "theme": {
+    "extends": "graphite",
+    "name": "midnight-honey",
+    "overrides": 4,
+    "path": "<path>",
+    "valid": true
+  }
+}

--- a/crates/facet/tests/golden/theme_list.json
+++ b/crates/facet/tests/golden/theme_list.json
@@ -1,0 +1,21 @@
+{
+  "schemaVersion": 1,
+  "themes": [
+    {
+      "error": null,
+      "extends": "graphite",
+      "name": "graphite",
+      "path": null,
+      "source": "built-in",
+      "valid": true
+    },
+    {
+      "error": null,
+      "extends": "porcelain",
+      "name": "porcelain",
+      "path": null,
+      "source": "built-in",
+      "valid": true
+    }
+  ]
+}

--- a/docs/FACET.md
+++ b/docs/FACET.md
@@ -293,12 +293,17 @@ facet env delete [<path>] --environment <name> --name <key> [--json]
 facet blob <hash> [<path>] [--output <file>] [--json]
 facet gc [<path>] [--history-retention <r>] [--yes] [--json]
 facet doctor [--probe] [--json]
-facet tui [<path>] [--appearance graphite|porcelain]
+facet theme check <path> [--json]
+facet theme list [--json]
+facet tui [<path>] [--appearance graphite|porcelain] [--theme <name|path>]
 facet mcp
 ```
 
 Graphite Honey is the TUI default. `:theme` (bare) toggles Porcelain Honey;
-`:theme graphite|porcelain` sets one. `:history` opens the run grid
+`:theme graphite|porcelain` sets one. `:theme <name|path>` loads a theme
+file (see [Theme files](#theme-files)); an invalid file falls back to the
+built-in for the current appearance and names the field in the footer.
+`:history` opens the run grid
 (`STARTED STATUS MS METHOD REQUEST ACTOR ID`): `j`/`k` or arrows move,
 `gg`/`G` jump, Enter hydrates the response pane from Lattice (titled
 `run <id> · replayed view`), `y` yanks the run id and `Y` the response
@@ -308,8 +313,9 @@ the last ≤24 statuses of the focused row's selector (oldest → newest,
 palette status buckets, stone for unrecorded) — paint, not a verb.
 `:sql <query>` opens a read-only overlay. `?` lists the rest.
 
-Roadmap (Probe's public list, folded): HTTP live; next WebSocket, GraphQL,
-gRPC streaming, user-defined theme files, git integration. Secret storage
+Roadmap (Probe's public list, folded): HTTP live; user-defined theme files
+live (`facet-tui`, see [Theme files](#theme-files)); next WebSocket, GraphQL,
+gRPC streaming, git integration. Secret storage
 is already in the Facet machine store. See [IMPLEMENTATION_PLAN.md](../IMPLEMENTATION_PLAN.md).
 
 `<path>` for `history`, `blob`, and `gc` is any file or directory inside the
@@ -672,6 +678,54 @@ orphans. Nothing is deleted without `--yes`.
   "retention": "unlimited", "runsExpired": 0,
   "orphans": [ { "hash": "…", "sizeBytes": 3 } ], "registryOrphans": 0, "bytesReclaimable": 3 }
 ```
+
+### Theme files
+
+`facet tui` reads versioned, human-editable theme files (TOML) from
+`<config dir>/themes/<name>.toml` — the config dir is `FACET_CONFIG_DIR`
+or the platform config dir (`~/.config/facet` on Linux). Theme files are
+local presentation configuration: never collection data, never in Lattice.
+
+```toml
+version = 1                   # required; this facet reads version 1 only
+name = "midnight-honey"       # optional; defaults to the file stem
+extends = "graphite"          # required built-in base: graphite | porcelain
+
+[colors]
+accent = "#e7821b"            # any subset of tokens; "#rrggbb" only
+window_bg = "#101012"
+```
+
+Rules (DESIGN.md § Future Plain-Text Themes): missing tokens merge with the
+built-in base; unknown top-level keys are tolerated so the format can grow
+additively inside a version; an unsupported `version`, an unknown
+`[colors]` token, or an invalid value rejects the **whole file** — the TUI
+keeps (or restores) the complete built-in for the current appearance and
+names the file and field in the footer, and `facet theme check` exits 1
+(`theme_invalid`) with `details.{path, field}`. Built-ins are always
+available as `graphite` / `porcelain`. At 256-color and 16-color depths a
+custom theme resolves through the built-in role channels, so method and
+status families stay distinct.
+
+Apply one with `facet tui --theme <name|path>` or `:theme <name|path>` in
+the TUI (a bare name resolves in the themes directory; anything with a
+path separator or a `.toml` suffix is read as a path). `facet theme check
+<path>` validates without a terminal; `facet theme list` shows built-ins
+plus every discovered file, invalid ones listed with their error.
+
+The `[colors]` tokens, grouped as in `Palette`:
+
+| Group | Tokens |
+| --- | --- |
+| Surfaces | `window_fg` `window_bg` `sidebar_fg` `sidebar_bg` `editor_fg` `editor_bg` `raised_fg` `raised_bg` `overlay_fg` `overlay_bg` |
+| Text | `text_primary` `text_secondary` `text_muted` `text_placeholder` `text_inverse` |
+| Borders | `border_subtle` `border_standard` `border_strong` `border_focused` |
+| Accent | `accent` `accent_hover` `accent_pressed` `accent_disabled` `accent_disabled_fg` |
+| Selection | `selection_active_bg` `selection_active_fg` `selection_inactive_bg` `selection_inactive_fg` |
+| Status | `status_success` `status_warning` `status_error` `status_informational` |
+| HTTP methods | `method_get` `method_post` `method_put` `method_patch` `method_delete` `method_other` |
+| Response status | `response_informational` `response_success` `response_redirect` `response_client_error` `response_server_error` |
+| Syntax | `syntax_property` `syntax_string` `syntax_number` `syntax_boolean` `syntax_null` `syntax_punctuation` |
 
 ### `mcp`
 

--- a/tests/fixtures/themes/broken-accent.toml
+++ b/tests/fixtures/themes/broken-accent.toml
@@ -1,0 +1,8 @@
+# Fixture: invalid color literal — the TUI falls back to Graphite Honey
+# and `facet theme check` exits 1 naming colors.accent.
+version = 1
+name = "broken-accent"
+extends = "graphite"
+
+[colors]
+accent = "red"

--- a/tests/fixtures/themes/midnight-honey.toml
+++ b/tests/fixtures/themes/midnight-honey.toml
@@ -1,0 +1,10 @@
+# Fixture: a valid v1 theme file extending Graphite Honey.
+version = 1
+name = "midnight-honey"
+extends = "graphite"
+
+[colors]
+accent = "#e7821b"
+window_bg = "#101012"
+text_primary = "#e9e6e0"
+method_get = "#7fd1b9"


### PR DESCRIPTION
## Facet rest 4 — theme files

Versioned, human-editable theme files for `facet-tui` (DESIGN.md § Future Plain-Text Themes). Built-ins stay; no B/C.

**Format** — TOML v1 at `<config dir>/themes/<name>.toml` (`FACET_CONFIG_DIR` or platform config):

```toml
version = 1
name = "midnight-honey"      # optional; defaults to file stem
extends = "graphite"          # required base: graphite | porcelain

[colors]
accent = "#e7821b"            # any subset of the full Palette tokens; #rrggbb only
```

**Semantics** (per DESIGN.md):
- Missing tokens merge with the built-in base; unknown top-level keys tolerated (additive in-version growth).
- Unsupported `version`, unknown `[colors]` token, or invalid value rejects the **whole file**.
- Invalid → complete built-in for the current appearance, file + field named: TUI footer for `:theme <name|path>` / `--theme`; exit 1 `theme_invalid` with `details.{path,field}` for `facet theme check`.
- Lower depths resolve custom palettes through the built-in role channels, keeping method/status families distinct.

**Surface:**
- `:theme <name|path>` and `facet tui --theme <name|path>`; bare name resolves in the themes dir. `:theme` toggle and `graphite`/`porcelain` unchanged. Title/footer show the custom theme name.
- `facet theme check <path>` — validate without a terminal (agent/CI surface).
- `facet theme list` — built-ins + discovered files; invalid files list with their error, never fatal.

**Tests:** 11 new in `theme_file.rs` (parse/validate/fallback matrix), TUI command test (apply → invalid fallback → missing file → built-in), facet-cli unit tests, goldens `theme_check_valid` / `error_theme_invalid` / `theme_list` with fixtures under `tests/fixtures/themes/`. `cargo test` (default members) + clippy clean on apiary; smoke of `check`/`list`/`tui --help` verified.

Docs: FACET.md § Theme files with the full token list.

Made with [Cursor](https://cursor.com)