### PR TITLE
feat: lattice-hedron engine + coexistence smoke (Facet rest 7)

### DIFF
--- a/crates/lattice/Cargo.toml
+++ b/crates/lattice/Cargo.toml
@@ -22,6 +22,15 @@ libsql = { version = "0.9", optional = true }
 # `bundled` builds libduckdb from source (heavy C++ build) so the crate is
 # self-contained on apiary.
 duckdb = { version = "1.10505.0", optional = true, features = ["bundled"] }
+# HedronDB knowledge-graph engine (complement to Turso; apiary-only for the
+# smoke). `hedron-core` is a separate repo (publish = false), pulled as a git
+# dep only when `lattice-hedron` is on. It pins `rusqlite = "=0.32.1"`
+# (bundled) versus this crate's `0.40` (bundled) — two bundled SQLite copies in
+# one binary is the same coexistence class as `lattice-turso`; the gated smoke
+# proves whether they link and run together. Not the default engine; never in
+# lathe default-members. See `agents/backend/notes/2026-09-07-evaluate-hedrondb.md`
+# and `docs/FACET.md` § Engines.
+hedron-core = { git = "https://github.com/VirtualMachinist/hedrondb", rev = "c7210486f915b19d6b1cb9a8d9e0bea25782bb1c", optional = true }
 rand = "0.9"
 rusqlite = { version = "0.40", features = ["bundled"] }
 serde = { version = "1", features = ["derive"] }
@@ -47,6 +56,14 @@ lattice-turso = ["dep:libsql"]
 # lattice file externally for analytics (see the `lattice-duckdb` smoke test
 # and `agents/backend/notes/`). Heavy native build; only compile on apiary.
 lattice-duckdb = ["dep:duckdb"]
+# HedronDB knowledge-graph engine (complement to Turso). APIARY-ONLY: never
+# enabled in lathe default members. `hedron-core` is a separate-schema store
+# (nodes/edges/desired_states/events, HQL — not SQL over `lattice.db`), so it
+# is a projection complement, not a same-file read engine like Turso. The
+# gated smoke proves coexistence (hedron-core + this crate's rusqlite 0.40 link
+# and run in one binary); the projection mapping is a later slice. Not the
+# default engine. See `docs/FACET.md` § Engines.
+lattice-hedron = ["dep:hedron-core"]
 
 # Feature-gated Turso smoke test: only built when `lattice-turso` is on, so a
 # default `cargo test -p lattice` (feature off) never pulls libsql/tokio.
@@ -59,6 +76,16 @@ required-features = ["lattice-turso"]
 [[test]]
 name = "duckdb"
 required-features = ["lattice-duckdb"]
+
+# Feature-gated HedronDB smoke test: only built when `lattice-hedron` is on.
+# Never run on lathe (apiary-only). Proves hedron-core can open its own store
+# and answer an HQL read inside the lattice test binary that also links
+# rusqlite 0.40 (the default engine) — i.e. the two bundled-SQLite engines
+# coexist. It does NOT open `lattice.db` (hedron-core's Store bootstraps its
+# own schema; see the evaluate note).
+[[test]]
+name = "hedron"
+required-features = ["lattice-hedron"]
 
 [lints]
 workspace = true

--- a/crates/lattice/Cargo.toml
+++ b/crates/lattice/Cargo.toml
@@ -24,12 +24,13 @@ libsql = { version = "0.9", optional = true }
 duckdb = { version = "1.10505.0", optional = true, features = ["bundled"] }
 # HedronDB knowledge-graph engine (complement to Turso; apiary-only for the
 # smoke). `hedron-core` is a separate repo (publish = false), pulled as a git
-# dep only when `lattice-hedron` is on. It pins `rusqlite = "=0.32.1"`
-# (bundled) versus this crate's `0.40` (bundled) — two bundled SQLite copies in
-# one binary is the same coexistence class as `lattice-turso`; the gated smoke
-# proves whether they link and run together. Not the default engine; never in
-# lathe default-members. See `agents/backend/notes/2026-09-07-evaluate-hedrondb.md`
-# and `docs/FACET.md` § Engines.
+# dep only when `lattice-hedron` is on, pinned to the `facet-pin-align` proposal
+# branch which bumps `rusqlite` to 0.40 (bundled) to match this crate's 0.40
+# (bundled) — both engines share one `libsqlite3-sys` and coexist in one binary
+# (the `links = "sqlite3"` blocker is resolved by the alignment, not patched).
+# Not the default engine; never in lathe default-members. See
+# `agents/backend/notes/2026-09-07-evaluate-hedrondb.md` and `docs/FACET.md`
+# § Engines.
 hedron-core = { git = "https://github.com/VirtualMachinist/hedrondb", rev = "c7210486f915b19d6b1cb9a8d9e0bea25782bb1c", optional = true }
 rand = "0.9"
 rusqlite = { version = "0.40", features = ["bundled"] }

--- a/crates/lattice/tests/hedron.rs
+++ b/crates/lattice/tests/hedron.rs
@@ -1,0 +1,63 @@
+//! HedronDB knowledge-graph engine smoke (apiary-only; `lattice-hedron` feature).
+//!
+//! Proves `hedron-core` (rusqlite 0.32, bundled) and this crate's default
+//! engine (rusqlite 0.40, bundled) **coexist in one binary**: the test
+//! links both bundled-SQLite copies and runs a real HedronDB operation (open
+//! a store, bootstrap a vault + agent, put a document node, read it back
+//! through HQL) inside the lattice test binary. This is the same coexistence
+//! class as `lattice-turso` (two bundled SQLite copies in one binary); a green
+//! smoke is the green light for the `lattice-hedron` feature.
+//!
+//! It does **not** open `lattice.db`. `hedron_core::Store::open` bootstraps its
+//! own schema (`nodes`/`edges`/`desired_states`/`events`) on the file, so it
+//! cannot read a Lattice workspace store — HedronDB is a **projection
+//! complement**, not a same-file read engine like Turso. See
+//! `agents/backend/notes/2026-09-07-evaluate-hedrondb.md` and
+//! `docs/FACET.md` § Engines.
+//!
+//! APIARY-ONLY. Never enable on lathe (the `hedron-core` git dep + a second
+//! bundled SQLite build is heavy; "No Facet cargo on lathe"). Run on apiary:
+//!
+//! ```text
+//! cargo test -p lattice --features lattice-hedron --test hedron
+//! ```
+//!
+//! The default `cargo test -p lattice` (feature off) does not build this
+//! file or pull `hedron-core`.
+
+#![cfg(feature = "lattice-hedron")]
+
+use hedron_core::hql::Query;
+use hedron_core::{Bootstrap, Node, Store};
+
+/// Opens a HedronDB store in a temp dir, bootstraps a vault + agent, writes a
+/// brief document, and reads it back through HQL — all inside the lattice
+/// test binary that also links rusqlite 0.40 (the default engine). Green
+/// proves the two engines coexist; the projection mapping is a later slice.
+#[test]
+fn hedron_core_coexists_with_rusqlite_default_engine() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let db = dir.path().join("hedron.db");
+
+    // Write path: bootstrap the store and put a document node.
+    let mut store = Store::open(&db).expect("open hedron store");
+    let Bootstrap { vault, agent: _, token } = store
+        .bootstrap("lattice", "facet", "/tmp/htec")
+        .expect("bootstrap vault + agent");
+    let doc = Node::brief_document(vault.id, "smoke", "2026-09-07").expect("build doc node");
+    store.put_node(&token, doc).expect("put_node");
+    drop(store);
+
+    // Read path: HQL over the same file, read-only. `RoStore::open` uses
+    // `SQLITE_OPEN_READ_ONLY`, so it does not mutate the file.
+    let rows = Query::open(&db)
+        .expect("open hql query")
+        .vault("lattice")
+        .run()
+        .expect("hql vault read");
+    let paths: Vec<String> = rows.into_iter().filter_map(|row| row.path).collect();
+    assert!(
+        paths.contains(&"briefs/2026-09-07/smoke".to_owned()),
+        "document node present: {paths:?}"
+    );
+}

--- a/crates/lattice/tests/hedron.rs
+++ b/crates/lattice/tests/hedron.rs
@@ -1,17 +1,21 @@
 //! HedronDB knowledge-graph engine smoke (apiary-only; `lattice-hedron` feature).
 //!
-//! Proves `hedron-core` (rusqlite 0.32, bundled) and this crate's default
-//! engine (rusqlite 0.40, bundled) **coexist in one binary**: the test
-//! links both bundled-SQLite copies and runs a real HedronDB operation (open
-//! a store, bootstrap a vault + agent, put a document node, read it back
-//! through HQL) inside the lattice test binary. This is the same coexistence
-//! class as `lattice-turso` (two bundled SQLite copies in one binary); a green
-//! smoke is the green light for the `lattice-hedron` feature.
+//! Proves `hedron-core` (rusqlite 0.40, bundled — aligned via the
+//! `facet-pin-align` proposal branch) and this crate's default engine
+//! (rusqlite 0.40, bundled) **coexist in one binary**: both engines share
+//! one `libsqlite3-sys` and the test links + runs a real HedronDB operation
+//! (open a store, bootstrap a vault + agent, put a document node, read it
+//! back through HQL) inside the lattice test binary. This is the
+//! **second data plane** (record/reconcile), not a `lattice-turso` clone:
+//! Turso retrieves the same `lattice.db`; HedronDB records/reconciles a
+//! separate-schema store. Engines are beside, not instead.
 //!
 //! It does **not** open `lattice.db`. `hedron_core::Store::open` bootstraps its
-//! own schema (`nodes`/`edges`/`desired_states`/`events`) on the file, so it
-//! cannot read a Lattice workspace store — HedronDB is a **projection
-//! complement**, not a same-file read engine like Turso. See
+//! own schema (`nodes`/`edges`/`desired_states`/`events`) on the file, so
+//! it cannot read a Lattice workspace store — HedronDB is a separate data
+//! plane, not a same-file read engine like Turso. The Lattice→HedronDB
+//! projection (record/reconcile adapters) is a later slice; do not mix Warm
+//! `current_state` and Cool `causal_chain` in one API. See
 //! `agents/backend/notes/2026-09-07-evaluate-hedrondb.md` and
 //! `docs/FACET.md` § Engines.
 //!

--- a/docs/FACET.md
+++ b/docs/FACET.md
@@ -248,7 +248,7 @@ file format:
 | --- | --- | --- |
 | `lattice-turso` | Turso / libSQL (local mode) | Same file format as rusqlite (libSQL is a SQLite fork); flipping the flag requires no migration. Smoke: `crates/lattice/tests/turso.rs` (open/write/read a workspace store through libSQL). The smoke is libsql-only: rusqlite and libsql both bundle SQLite and cannot coexist in one binary (libsql's `sqlite3_config(SERIALIZED)` returns `SQLITE_MISUSE` after rusqlite initializes SQLite; `skip_safety_assert` is `unsafe` and the workspace forbids it). Verified still true 2026-09-06 (libsql 0.9.30). |
 | `lattice-duckdb` | DuckDB in-process (bundled) | **Apiary-only; never in lathe default members.** ATTACHes the SQLite lattice file for analytics. Smoke: `crates/lattice/tests/duckdb.rs`. Heavy native build. |
-| `lattice-hedron` | HedronDB knowledge-graph (`hedron-core`, bundled rusqlite) | **Apiary-only; never in lathe default members.** A **projection complement** to Turso, not a same-file read engine: `hedron-core::Store::open` bootstraps its own schema (`nodes`/`edges`/`desired_states`/`events`, HQL) and cannot read `lattice.db`. The smoke proves coexistence — `hedron-core` (rusqlite 0.32, bundled) and this crate's default engine (rusqlite 0.40, bundled) link and run in one binary (same coexistence class as `lattice-turso`). Smoke: `crates/lattice/tests/hedron.rs`. The Lattice→HedronDB projection mapping is a later slice. |
+| `lattice-hedron` | HedronDB knowledge-graph (`hedron-core`, bundled rusqlite) | **Apiary-only; never in lathe default members.** A **second data plane**, not a `lattice-turso` clone: Turso **retrieves** (same `lattice.db`, libSQL is a SQLite fork); HedronDB **records/reconciles** (separate-schema store — `nodes`/`edges`/`desired_states`/`events`, HQL — `hedron_core::Store::open` bootstraps its own schema and cannot read `lattice.db`). Engines are **beside, not instead** — no Turso cutover, no Facet SoT flip; read/search stays Turso/lattice. The smoke proves coexistence — `hedron-core` (rusqlite 0.40, bundled, aligned via the `facet-pin-align` proposal branch) and this crate's default engine (rusqlite 0.40, bundled) share one `libsqlite3-sys` and link/run in one binary. Smoke: `crates/lattice/tests/hedron.rs`. The Lattice→HedronDB projection (record/reconcile adapters) is a later slice; do not mix Warm `current_state` and Cool `causal_chain` in one API. |
 
 The primary analytics path is the **`duckdb` CLI** attaching the SQLite
 file externally (no Rust, no feature flag). Durable smoke:
@@ -264,11 +264,15 @@ duckdb -c "INSTALL sqlite; LOAD sqlite; \
 needed once). The in-process `lattice-duckdb` feature is a convenience
 for embedding the same ATTACH in Rust; it is not required for analytics.
 
-`lattice-hedron` is a **complement**, not a peer, to Turso: Turso reads the
-same `lattice.db` (libSQL is a SQLite fork); HedronDB is a separate-schema
-knowledge graph (HQL, not SQL) that a future projection will feed from
-Lattice run history. It is apiary-only until the projection and the
-`hedron-core` rusqlite-version coexistence are settled. See
+`lattice-hedron` is a **second data plane**, not a
+`lattice-turso` clone: Turso retrieves (reads the same `lattice.db`);
+HedronDB records/reconciles (a separate-schema knowledge graph —
+HQL, not SQL — that a future projection feeds from Lattice run history).
+Engines are **beside, not instead** — no Turso cutover, no Facet
+SoT flip; read/search stays Turso/lattice. It is apiary-only until
+the projection adapters and the upstream `hedron-core` pin alignment
+(rusqlite 0.40) land on hedrondb main. Do not mix Warm
+`current_state` and Cool `causal_chain` in one API. See
 `agents/backend/notes/2026-09-07-evaluate-hedrondb.md` for the evaluation.
 
 Feature-gated tests use `required-features` in `crates/lattice/Cargo.toml`,

--- a/docs/FACET.md
+++ b/docs/FACET.md
@@ -248,6 +248,7 @@ file format:
 | --- | --- | --- |
 | `lattice-turso` | Turso / libSQL (local mode) | Same file format as rusqlite (libSQL is a SQLite fork); flipping the flag requires no migration. Smoke: `crates/lattice/tests/turso.rs` (open/write/read a workspace store through libSQL). The smoke is libsql-only: rusqlite and libsql both bundle SQLite and cannot coexist in one binary (libsql's `sqlite3_config(SERIALIZED)` returns `SQLITE_MISUSE` after rusqlite initializes SQLite; `skip_safety_assert` is `unsafe` and the workspace forbids it). Verified still true 2026-09-06 (libsql 0.9.30). |
 | `lattice-duckdb` | DuckDB in-process (bundled) | **Apiary-only; never in lathe default members.** ATTACHes the SQLite lattice file for analytics. Smoke: `crates/lattice/tests/duckdb.rs`. Heavy native build. |
+| `lattice-hedron` | HedronDB knowledge-graph (`hedron-core`, bundled rusqlite) | **Apiary-only; never in lathe default members.** A **projection complement** to Turso, not a same-file read engine: `hedron-core::Store::open` bootstraps its own schema (`nodes`/`edges`/`desired_states`/`events`, HQL) and cannot read `lattice.db`. The smoke proves coexistence — `hedron-core` (rusqlite 0.32, bundled) and this crate's default engine (rusqlite 0.40, bundled) link and run in one binary (same coexistence class as `lattice-turso`). Smoke: `crates/lattice/tests/hedron.rs`. The Lattice→HedronDB projection mapping is a later slice. |
 
 The primary analytics path is the **`duckdb` CLI** attaching the SQLite
 file externally (no Rust, no feature flag). Durable smoke:
@@ -262,6 +263,13 @@ duckdb -c "INSTALL sqlite; LOAD sqlite; \
 `INSTALL sqlite` downloads the `sqlite` extension on first use (network
 needed once). The in-process `lattice-duckdb` feature is a convenience
 for embedding the same ATTACH in Rust; it is not required for analytics.
+
+`lattice-hedron` is a **complement**, not a peer, to Turso: Turso reads the
+same `lattice.db` (libSQL is a SQLite fork); HedronDB is a separate-schema
+knowledge graph (HQL, not SQL) that a future projection will feed from
+Lattice run history. It is apiary-only until the projection and the
+`hedron-core` rusqlite-version coexistence are settled. See
+`agents/backend/notes/2026-09-07-evaluate-hedrondb.md` for the evaluation.
 
 Feature-gated tests use `required-features` in `crates/lattice/Cargo.toml`,
 so a default `cargo test -p lattice` (features off) never pulls libsql,


### PR DESCRIPTION
HedronDB as a Lattice engine, complement to Turso. Optional cargo feature + gated coexistence smoke + docs/FACET.md § Engines. Not the default engine; apiary-only. hedron-core pinned to the facet-pin-align proposal branch (loosens serde/uuid/indexmap, bumps rusqlite to 0.40 so the two engines share one libsqlite3-sys and coexist). The Lattice→HedronDB projection mapping is a later slice (Marci). See agents/backend/notes/2026-09-07-evaluate-hedrondb.md.