### PR TITLE
Integrate scoped cluster authentication and Rust Turso storage

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -21,7 +21,7 @@ dependencies = [
  "accesskit",
  "accesskit_consumer 0.36.0",
  "atspi-common",
- "phf 0.13.1",
+ "phf",
  "serde",
  "zvariant",
 ]
@@ -119,12 +119,32 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "aead"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d122413f284cf2d62fb1b7db97e02edb8cda96d769b16e443a4f6195e35662b0"
+dependencies = [
+ "crypto-common 0.1.7",
+ "generic-array",
+]
+
+[[package]]
+name = "aead"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1973cfbc1a2daf9cf550e74e1f088c28e7f7d8c1e1418fb6c9dc5184b7e84c99"
 dependencies = [
  "crypto-common 0.2.2",
  "inout 0.2.2",
+]
+
+[[package]]
+name = "aegis"
+version = "0.9.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "58541132f980da31e9aa99f7bdee69bc84bf1e168b9b91ef2dbe8abb7b4ce5dd"
+dependencies = [
+ "cc",
+ "softaes",
 ]
 
 [[package]]
@@ -151,6 +171,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "aes-gcm"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "831010a0f742e1209b3bcea8fab6a8e149051ba6099432c8cb2cc117dec3ead1"
+dependencies = [
+ "aead 0.5.2",
+ "aes 0.8.4",
+ "cipher 0.4.4",
+ "ctr",
+ "ghash",
+ "subtle",
+]
+
+[[package]]
 name = "ahash"
 version = "0.8.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -161,7 +195,7 @@ dependencies = [
  "getrandom 0.3.4",
  "once_cell",
  "version_check",
- "zerocopy 0.8.56",
+ "zerocopy",
 ]
 
 [[package]]
@@ -198,6 +232,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
+name = "allocator-api2"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c880a97d28a3681c0267bd29cff89621202715b065127cd445fa0f0fe0aa2880"
+
+[[package]]
 name = "android_system_properties"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -219,6 +259,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
 
 [[package]]
+name = "antithesis_sdk"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8ed6751597568a284314fd9e2db420665898600109dedc7d8d9b588f00ae9c4"
+dependencies = [
+ "libc",
+ "libloading",
+ "linkme",
+ "once_cell",
+ "rand 0.8.7",
+ "rustc_version_runtime",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "anyhow"
 version = "1.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -232,7 +288,7 @@ checksum = "2b350bfd03649e07aa05c0a81b3e15934374e585c98204a57e20b9d49f49bb9a"
 dependencies = [
  "keyring-core",
  "log",
- "security-framework 3.7.0",
+ "security-framework",
 ]
 
 [[package]]
@@ -263,10 +319,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "arc-swap"
+version = "1.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c049c0be4daef0b145cb3555416b3b8ef5b7888a38aea1a3a155801fe7b0810b"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
 name = "arg_enum_proc_macro"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ae92a5119aa49cdbcf6b9f893fe4e1d98b04ccbf82ee0584ad948a44a734dea"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "aristo"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fcdeefa800110050103e2459a2f8dbdbd560ad046e30f1f87e24ce19c2cb8bde"
+dependencies = [
+ "aristo-macros",
+]
+
+[[package]]
+name = "aristo-macros"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d64a66d21a80182b35b1741997a6d2456911f54b7eb1918aa4e2382fc205268d"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -491,6 +576,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "assoc"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfdc70193dadb9d7287fa4b633f15f90c876915b31f6af17da307fc59c9859a8"
+
+[[package]]
 name = "async-broadcast"
 version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -639,28 +730,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "async-stream"
-version = "0.3.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b5a71a6f37880a80d1d7f19efd781e4b5de42c88f0722cc13bcb6cc2cfe8476"
-dependencies = [
- "async-stream-impl",
- "futures-core",
- "pin-project-lite",
-]
-
-[[package]]
-name = "async-stream-impl"
-version = "0.3.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7c24de15d275a1ecfd47a380fb4d5ec9bfe0933f309ed5e705b775596a3574d"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.119",
-]
-
-[[package]]
 name = "async-task"
 version = "4.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -764,7 +833,7 @@ dependencies = [
  "log",
  "num-rational",
  "num-traits",
- "pastey",
+ "pastey 0.1.1",
  "rayon",
  "thiserror 2.0.20",
  "v_frame",
@@ -818,51 +887,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "axum"
-version = "0.6.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b829e4e32b91e643de6eafe82b1d90675f5874230191a4ffbc1b336dec4d6bf"
-dependencies = [
- "async-trait",
- "axum-core",
- "bitflags 1.3.2",
- "bytes",
- "futures-util",
- "http 0.2.12",
- "http-body 0.4.6",
- "hyper 0.14.32",
- "itoa",
- "matchit",
- "memchr",
- "mime",
- "percent-encoding",
- "pin-project-lite",
- "rustversion",
- "serde",
- "sync_wrapper 0.1.2",
- "tower 0.4.13",
- "tower-layer",
- "tower-service",
-]
-
-[[package]]
-name = "axum-core"
-version = "0.3.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "759fa577a247914fd3f7f76d62972792636412fbfd634cd452f6a385a74d2d2c"
-dependencies = [
- "async-trait",
- "bytes",
- "futures-util",
- "http 0.2.12",
- "http-body 0.4.6",
- "mime",
- "rustversion",
- "tower-layer",
- "tower-service",
-]
-
-[[package]]
 name = "backtrace"
 version = "0.3.76"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -879,12 +903,6 @@ dependencies = [
 
 [[package]]
 name = "base64"
-version = "0.21.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
-
-[[package]]
-name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
@@ -894,6 +912,19 @@ name = "base64"
 version = "0.23.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac07cdecf99051d9a5238b80f35af32cdeba5b336e55d957b318b50137e18da5"
+
+[[package]]
+name = "bigdecimal"
+version = "0.4.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d6867f1565b3aad85681f1015055b087fcfd840d6aeee6eee7f2da317603695"
+dependencies = [
+ "autocfg",
+ "libm",
+ "num-bigint",
+ "num-integer",
+ "num-traits",
+]
 
 [[package]]
 name = "bincode"
@@ -906,17 +937,17 @@ dependencies = [
 
 [[package]]
 name = "bindgen"
-version = "0.66.1"
+version = "0.69.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2b84e06fc203107bfbad243f4aba2af864eb7db3b1cf46ea0a023b0b433d2a7"
+checksum = "271383c67ccabffb7381723dea0672a673f292304fcb45c01cc648c7a8d58088"
 dependencies = [
  "bitflags 2.13.1",
  "cexpr",
  "clang-sys",
+ "itertools 0.12.1",
  "lazy_static",
  "lazycell",
  "log",
- "peeking_take_while",
  "prettyplease",
  "proc-macro2",
  "quote",
@@ -1005,6 +1036,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "bitvec"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddcec3d12c579d40898fe0a9a358a803c23e9c52ca3c425707f81c9436211837"
+dependencies = [
+ "funty",
+ "radium",
+ "tap",
+ "wyz",
+]
+
+[[package]]
+name = "blake3"
+version = "1.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3888aaa89e4b2a40fca9848e400f6a658a5a3978de7be858e209cafa8be9a4a0"
+dependencies = [
+ "arrayref",
+ "arrayvec",
+ "cc",
+ "cfg-if",
+ "constant_time_eq",
+]
+
+[[package]]
 name = "block"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1088,6 +1144,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "branches"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7436b21fd6195415058eb41c9090e156b556bc7e0377bb57c5c026a421521525"
+dependencies = [
+ "rustc_version",
+]
+
+[[package]]
 name = "built"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1142,9 +1207,6 @@ name = "bytes"
 version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc652a48c352aef3ea3aed32080501cf3ef6ed5da78602a020c991775b0aff04"
-dependencies = [
- "serde",
-]
 
 [[package]]
 name = "bzip2"
@@ -1220,7 +1282,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eadd868a2ce9ca38de7eeafdcec9c7065ef89b42b32f0839278d55f35c54d1ff"
 dependencies = [
  "heck 0.4.1",
- "indexmap 2.14.0",
+ "indexmap",
  "log",
  "proc-macro2",
  "quote",
@@ -1265,6 +1327,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f079e83a288787bcd14a6aea84cee5c87a67c5a3e660c30f557a3d24761b3527"
 
 [[package]]
+name = "cfg_block"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18758054972164c3264f7c8386f5fc6da6114cb46b619fd365d4e3b2dc3ae487"
+
+[[package]]
 name = "cgl"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1291,7 +1359,7 @@ version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b89e1c441e926b9c82a8d023f6e1b7ae0adcfaa7d621814e4d60789bac751cb"
 dependencies = [
- "aead",
+ "aead 0.6.1",
  "chacha20",
  "cipher 0.5.2",
  "poly1305",
@@ -1479,7 +1547,7 @@ checksum = "af491d569909a7e4dee0ad7db7f5341fef5c614d5b8ec8cf765732aba3cff681"
 dependencies = [
  "serde",
  "termcolor",
- "unicode-width",
+ "unicode-width 0.2.2",
 ]
 
 [[package]]
@@ -1488,7 +1556,7 @@ version = "0.1.0"
 source = "git+https://github.com/zed-industries/zed#cc053a4a6fa2fd0e8793201ed9099466af1be0b1"
 dependencies = [
  "gpui_util",
- "indexmap 2.14.0",
+ "indexmap",
  "rustc-hash 2.1.3",
 ]
 
@@ -1516,7 +1584,7 @@ checksum = "4a65ebfec4fb190b6f90e944a817d60499ee0744e582530e2c9900a22e591d9a"
 dependencies = [
  "crossterm 0.28.1",
  "unicode-segmentation",
- "unicode-width",
+ "unicode-width 0.2.2",
 ]
 
 [[package]]
@@ -1595,6 +1663,12 @@ dependencies = [
  "once_cell",
  "tiny-keccak",
 ]
+
+[[package]]
+name = "constant_time_eq"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c74b8349d32d297c9134b8c88677813a227df8f779daa29bfc29c183fe3dca6"
 
 [[package]]
 name = "convert_case"
@@ -1798,6 +1872,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "crc32c"
+version = "0.6.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a47af21622d091a8f0fb295b88bc886ac74efcc613efc19f5d0b21de5c89e47"
+dependencies = [
+ "rustc_version",
+]
+
+[[package]]
 name = "crc32fast"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1837,6 +1920,15 @@ checksum = "9b1bcc0dc7dfae599d84ad0b1a55f80cde8af3725da8313b528da95ef783e338"
 dependencies = [
  "cast",
  "itertools 0.13.0",
+]
+
+[[package]]
+name = "crossbeam-channel"
+version = "0.5.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "98b0cc327b5bc766e7fda9c9260cc0fa81b43a8e240440422dff70788e3f9ef1"
+dependencies = [
+ "crossbeam-utils",
 ]
 
 [[package]]
@@ -1926,6 +2018,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
 dependencies = [
  "generic-array",
+ "rand_core 0.6.4",
  "typenum",
 ]
 
@@ -1948,6 +2041,15 @@ checksum = "914a755b7c2d4af2bdcff7ce1739e2db9a1b81a9b07123d8015786ae03c0980d"
 dependencies = [
  "link-section",
  "linktime-proc-macro",
+]
+
+[[package]]
+name = "ctr"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0369ee1ad671834580515889b80f2ea915f23b8be8d0daa4bbaf2ac5c7590835"
+dependencies = [
+ "cipher 0.4.4",
 ]
 
 [[package]]
@@ -2164,7 +2266,7 @@ dependencies = [
  "arrow",
  "cast",
  "comfy-table",
- "fallible-iterator 0.3.0",
+ "fallible-iterator",
  "fallible-streaming-iterator",
  "hashlink 0.10.0",
  "libduckdb-sys",
@@ -2261,6 +2363,26 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.119",
+]
+
+[[package]]
+name = "env_filter"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "900d271a03799a1ee8d1ca9b19893b48ca674a9284fefcfb85f05e74ed314217"
+dependencies = [
+ "log",
+ "regex",
+]
+
+[[package]]
+name = "env_logger"
+version = "0.11.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de671bd27a75a797dc9ae289ba1e77276e75e2026408aab65185384e2d5cd3f6"
+dependencies = [
+ "env_filter",
+ "log",
 ]
 
 [[package]]
@@ -2412,14 +2534,8 @@ dependencies = [
  "tempfile",
  "tokio",
  "toml 1.1.4+spec-1.1.0",
- "unicode-width",
+ "unicode-width 0.2.2",
 ]
-
-[[package]]
-name = "fallible-iterator"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4443176a9f2c162692bd3d352d745ef9413eec5782a80d8fd6f8a1ac692a07f7"
 
 [[package]]
 name = "fallible-iterator"
@@ -2442,6 +2558,17 @@ dependencies = [
  "bit-set 0.8.0",
  "regex-automata",
  "regex-syntax",
+]
+
+[[package]]
+name = "fastbloom"
+version = "0.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e7f34442dbe69c60fe8eaf58a8cafff81a1f278816d8ab4db255b3bef4ac3c4"
+dependencies = [
+ "getrandom 0.3.4",
+ "libm",
+ "siphasher",
 ]
 
 [[package]]
@@ -2683,6 +2810,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "funty"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
+
+[[package]]
 name = "futures"
 version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2797,6 +2930,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "genawaiter"
+version = "0.99.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c86bd0361bcbde39b13475e6e36cb24c329964aa2611be285289d1e4b751c1a0"
+dependencies = [
+ "genawaiter-macro",
+]
+
+[[package]]
+name = "genawaiter-macro"
+version = "0.99.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b32dfe1fdfc0bbde1f22a5da25355514b5e450c33a6af6770884c8750aedfbc"
+
+[[package]]
+name = "generator"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3b854b0e584ead1a33f18b2fcad7cf7be18b3875c78816b753639aa501513ae"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "libc",
+ "log",
+ "rustversion",
+ "windows-link 0.1.3",
+ "windows-result 0.3.4",
+]
+
+[[package]]
 name = "generic-array"
 version = "0.14.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2855,6 +3018,16 @@ dependencies = [
  "r-efi 6.0.0",
  "rand_core 0.10.1",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "ghash"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0d8a4362ccb29cb0b265253fb0a2728f592895ee6854fd9bc13f2ffda266ff1"
+dependencies = [
+ "opaque-debug",
+ "polyval",
 ]
 
 [[package]]
@@ -3294,25 +3467,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b40ca9252762c466af32d0b1002e91e4e1bc5398f77455e55474deb466355ff5"
 
 [[package]]
-name = "h2"
-version = "0.3.27"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0beca50380b1fc32983fc1cb4587bfa4bb9e78fc259aad4a0032d2080309222d"
-dependencies = [
- "bytes",
- "fnv",
- "futures-core",
- "futures-sink",
- "futures-util",
- "http 0.2.12",
- "indexmap 2.14.0",
- "slab",
- "tokio",
- "tokio-util",
- "tracing",
-]
-
-[[package]]
 name = "half"
 version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3321,7 +3475,7 @@ dependencies = [
  "cfg-if",
  "crunchy",
  "num-traits",
- "zerocopy 0.8.56",
+ "zerocopy",
 ]
 
 [[package]]
@@ -3348,19 +3502,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.12.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
-
-[[package]]
-name = "hashbrown"
 version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
-dependencies = [
- "ahash",
- "allocator-api2",
-]
 
 [[package]]
 name = "hashbrown"
@@ -3377,7 +3521,7 @@ version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
 dependencies = [
- "allocator-api2",
+ "allocator-api2 0.2.21",
  "equivalent",
  "foldhash 0.2.0",
 ]
@@ -3388,18 +3532,9 @@ version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 dependencies = [
- "allocator-api2",
+ "allocator-api2 0.2.21",
  "equivalent",
  "foldhash 0.2.0",
-]
-
-[[package]]
-name = "hashlink"
-version = "0.8.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8094feaf31ff591f651a2664fb9cfd92bba7a60ce3197265e9482ebe753c8f7"
-dependencies = [
- "hashbrown 0.14.5",
 ]
 
 [[package]]
@@ -3441,6 +3576,19 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "hedron-core"
+version = "0.1.0"
+source = "git+https://github.com/VirtualMachinist/hedrondb?rev=c7210486f915b19d6b1cb9a8d9e0bea25782bb1c#c7210486f915b19d6b1cb9a8d9e0bea25782bb1c"
+dependencies = [
+ "blake3",
+ "indexmap",
+ "rusqlite",
+ "serde",
+ "serde_yaml",
+ "uuid",
+]
 
 [[package]]
 name = "hermit-abi"
@@ -3507,17 +3655,6 @@ dependencies = [
 
 [[package]]
 name = "http"
-version = "0.2.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "601cbb57e577e2f5ef5be8e7b83f0f63994f25aa94d673e54a92d5c516d101f1"
-dependencies = [
- "bytes",
- "fnv",
- "itoa",
-]
-
-[[package]]
-name = "http"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "918d3568bebf352712bc2ef3d46a8bcf1a75b373be6539de198e9105cbbf9ce0"
@@ -3528,23 +3665,12 @@ dependencies = [
 
 [[package]]
 name = "http-body"
-version = "0.4.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ceab25649e9960c0311ea418d17bee82c0dcec1bd053b5f9a66e265a693bed2"
-dependencies = [
- "bytes",
- "http 0.2.12",
- "pin-project-lite",
-]
-
-[[package]]
-name = "http-body"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ca2a8f2913ee65f60facd6a5905613afaa448497a0230cc41ce022d93290bc2c"
 dependencies = [
  "bytes",
- "http 1.5.0",
+ "http",
 ]
 
 [[package]]
@@ -3555,16 +3681,10 @@ checksum = "23169fe34a5fbcdd3f3862e78fb9b6fccd5f02a6dc6f732547005d45631ce71c"
 dependencies = [
  "bytes",
  "futures-core",
- "http 1.5.0",
- "http-body 1.1.0",
+ "http",
+ "http-body",
  "pin-project-lite",
 ]
-
-[[package]]
-name = "http-range-header"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "add0ab9360ddbd88cfeb3bd9574a1d85cfdfa14db10b3e21d3700dbc4328758f"
 
 [[package]]
 name = "http_client"
@@ -3576,8 +3696,8 @@ dependencies = [
  "bytes",
  "derive_more",
  "futures",
- "http 1.5.0",
- "http-body 1.1.0",
+ "http",
+ "http-body",
  "log",
  "parking_lot",
  "serde",
@@ -3593,42 +3713,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
 
 [[package]]
-name = "httpdate"
-version = "1.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
-
-[[package]]
 name = "hybrid-array"
 version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "707114b52a152fa7bdb290cd7cd5912d9467273b6d74e21b8d81aca1f8533f6b"
 dependencies = [
  "typenum",
-]
-
-[[package]]
-name = "hyper"
-version = "0.14.32"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41dfc780fdec9373c01bae43289ea34c972e40ee3c9f6b3c8801a35f35586ce7"
-dependencies = [
- "bytes",
- "futures-channel",
- "futures-core",
- "futures-util",
- "h2",
- "http 0.2.12",
- "http-body 0.4.6",
- "httparse",
- "httpdate",
- "itoa",
- "pin-project-lite",
- "socket2 0.5.10",
- "tokio",
- "tower-service",
- "tracing",
- "want",
 ]
 
 [[package]]
@@ -3641,8 +3731,8 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-core",
- "http 1.5.0",
- "http-body 1.1.0",
+ "http",
+ "http-body",
  "httparse",
  "itoa",
  "pin-project-lite",
@@ -3653,47 +3743,17 @@ dependencies = [
 
 [[package]]
 name = "hyper-rustls"
-version = "0.25.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "399c78f9338483cb7e630c8474b07268983c6bd5acee012e4211f9f7bb21b070"
-dependencies = [
- "futures-util",
- "http 0.2.12",
- "hyper 0.14.32",
- "log",
- "rustls 0.22.4",
- "rustls-native-certs 0.7.3",
- "rustls-pki-types",
- "tokio",
- "tokio-rustls 0.25.0",
- "webpki-roots 0.26.11",
-]
-
-[[package]]
-name = "hyper-rustls"
 version = "0.27.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f"
 dependencies = [
- "http 1.5.0",
- "hyper 1.11.0",
+ "http",
+ "hyper",
  "hyper-util",
- "rustls 0.23.43",
+ "rustls",
  "tokio",
- "tokio-rustls 0.26.4",
+ "tokio-rustls",
  "tower-service",
-]
-
-[[package]]
-name = "hyper-timeout"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbb958482e8c7be4bc3cf272a766a2b0bf1a6755e7a6ae777f017a31d11b13b1"
-dependencies = [
- "hyper 0.14.32",
- "pin-project-lite",
- "tokio",
- "tokio-io-timeout",
 ]
 
 [[package]]
@@ -3706,14 +3766,14 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-util",
- "http 1.5.0",
- "http-body 1.1.0",
- "hyper 1.11.0",
+ "http",
+ "http-body",
+ "hyper",
  "ipnet",
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.5",
+ "socket2",
  "tokio",
  "tower-service",
  "tracing",
@@ -3769,6 +3829,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "icu_collator"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59eea194d189ca897bcb960fd2130f9e7d53998460d4d32e85a60b10d5507cf4"
+dependencies = [
+ "icu_collator_data",
+ "icu_collections",
+ "icu_locale_core",
+ "icu_locale_fallback",
+ "icu_normalizer",
+ "icu_properties",
+ "icu_provider",
+ "smallvec",
+ "utf16_iter",
+ "utf8_iter",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_collator_data"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7d7e54efdddeb1208c08dd5d32b53a879ac00d2d3d051b2255fd26821d16368"
+
+[[package]]
 name = "icu_collections"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3783,6 +3868,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "icu_locale"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "250ec6d4ac288584d1d0ba29dbfad7737635b7b0e822441f4026a523e3fdb147"
+dependencies = [
+ "icu_collections",
+ "icu_locale_core",
+ "icu_locale_data",
+ "icu_locale_fallback",
+ "icu_provider",
+ "tinystr",
+ "zerovec",
+]
+
+[[package]]
 name = "icu_locale_core"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3790,10 +3890,37 @@ checksum = "d56e28588da92eee5c3201a6eff33fabdd49b62269c8938d4ff050ce4d900deb"
 dependencies = [
  "displaydoc",
  "litemap",
+ "serde",
  "tinystr",
  "writeable",
  "zerovec",
 ]
+
+[[package]]
+name = "icu_locale_data"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d37d91460e362a5cf58907cd7ce871411775ee6294e49a5cc8e6cec16dfa75ea"
+
+[[package]]
+name = "icu_locale_fallback"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "251af8e57c9400e3eb58242fe5b8b1152b2a64fdf4cf632f923c38ccee6f2fa9"
+dependencies = [
+ "icu_locale_core",
+ "icu_locale_fallback_data",
+ "icu_provider",
+ "potential_utf",
+ "tinystr",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_locale_fallback_data"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "decf2a22ec8fa68f1a0c1129a3f8583f8f8bc24e8b9ccbe98ead99f62a4dc3a8"
 
 [[package]]
 name = "icu_normalizer"
@@ -3806,6 +3933,9 @@ dependencies = [
  "icu_properties",
  "icu_provider",
  "smallvec",
+ "utf16_iter",
+ "utf8_iter",
+ "write16",
  "zerovec",
 ]
 
@@ -3844,6 +3974,8 @@ checksum = "92a7ed671a6aad807a8651a2e1782a6598fda9ce5185dd8158549e95a91c6428"
 dependencies = [
  "displaydoc",
  "icu_locale_core",
+ "serde",
+ "stable_deref_trait",
  "writeable",
  "yoke",
  "zerofrom",
@@ -3922,16 +4054,6 @@ name = "imgref"
 version = "1.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "89194689a993ab15268672e99e7b0e19da2da3268ac682e8f02d29d4d1434cd7"
-
-[[package]]
-name = "indexmap"
-version = "1.9.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
-dependencies = [
- "autocfg",
- "hashbrown 0.12.3",
-]
 
 [[package]]
 name = "indexmap"
@@ -4031,6 +4153,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "intrusive-collections"
+version = "0.9.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "189d0897e4cbe8c75efedf3502c18c887b05046e59d28404d4d8e46cbc4d1e86"
+dependencies = [
+ "memoffset",
+]
+
+[[package]]
 name = "inventory"
 version = "0.3.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4049,6 +4180,17 @@ dependencies = [
  "core-foundation 0.10.1",
  "core-foundation-sys",
  "leaky-cow",
+]
+
+[[package]]
+name = "io-uring"
+version = "0.7.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed3bd0ecfbb87805f538bb7b32e5239ca0763890c623e349860ecba69469f2bb"
+dependencies = [
+ "bitflags 2.13.1",
+ "cfg-if",
+ "libc",
 ]
 
 [[package]]
@@ -4277,10 +4419,11 @@ dependencies = [
  "chacha20poly1305",
  "directories",
  "duckdb",
+ "futures",
+ "hedron-core",
  "hkdf 0.13.0",
  "hmac 0.13.0",
  "keyring",
- "libsql",
  "rand 0.9.5",
  "rusqlite",
  "serde",
@@ -4288,6 +4431,8 @@ dependencies = [
  "tempfile",
  "tokio",
  "toml 1.1.4+spec-1.1.0",
+ "turso",
+ "turso_parser",
 ]
 
 [[package]]
@@ -4445,142 +4590,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "libsql"
-version = "0.9.30"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30fe980ac5693ed1f3db490559fb578885e913a018df64af8a1a46e1959a78df"
-dependencies = [
- "anyhow",
- "async-stream",
- "async-trait",
- "base64 0.21.7",
- "bincode",
- "bitflags 2.13.1",
- "bytes",
- "chrono",
- "crc32fast",
- "fallible-iterator 0.3.0",
- "futures",
- "http 0.2.12",
- "hyper 0.14.32",
- "hyper-rustls 0.25.0",
- "libsql-hrana",
- "libsql-sqlite3-parser",
- "libsql-sys",
- "libsql_replication",
- "parking_lot",
- "serde",
- "serde_json",
- "thiserror 1.0.69",
- "tokio",
- "tokio-stream",
- "tokio-util",
- "tonic",
- "tonic-web",
- "tower 0.4.13",
- "tower-http 0.4.4",
- "tracing",
- "uuid",
- "zerocopy 0.7.35",
-]
-
-[[package]]
-name = "libsql-ffi"
-version = "0.9.30"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0be1da6f123ceb2cd23f469883415cab9ee963286a85d61e22afb8b12e15e681"
-dependencies = [
- "bindgen 0.66.1",
- "cc",
- "cmake",
- "glob",
-]
-
-[[package]]
-name = "libsql-hrana"
-version = "0.9.30"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3358538b52cfcf9af4fe7aeb57d6843aafed2e8af80807bd636fd1448e94ea7"
-dependencies = [
- "base64 0.21.7",
- "bytes",
- "prost",
- "serde",
-]
-
-[[package]]
-name = "libsql-rusqlite"
-version = "0.9.30"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b646f94fc1d266e481c38a2d44d6d9d1be3ad04b56b90457acfb310dc450030e"
-dependencies = [
- "bitflags 2.13.1",
- "fallible-iterator 0.2.0",
- "fallible-streaming-iterator",
- "hashlink 0.8.4",
- "libsql-ffi",
- "smallvec",
-]
-
-[[package]]
-name = "libsql-sqlite3-parser"
-version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15a90128c708356af8f7d767c9ac2946692c9112b4f74f07b99a01a60680e413"
-dependencies = [
- "bitflags 2.13.1",
- "cc",
- "fallible-iterator 0.3.0",
- "indexmap 2.14.0",
- "log",
- "memchr",
- "phf 0.11.3",
- "phf_codegen",
- "phf_shared 0.11.3",
- "uncased",
-]
-
-[[package]]
-name = "libsql-sys"
-version = "0.9.30"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90725458cc4461bc82f8f7983e80b002ea4f64b5184e1462f252d0dd74b122f5"
-dependencies = [
- "bytes",
- "libsql-ffi",
- "libsql-rusqlite",
- "once_cell",
- "tracing",
- "zerocopy 0.7.35",
-]
-
-[[package]]
-name = "libsql_replication"
-version = "0.9.30"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3bba5c9b3a26aca06d70f6a3646ba341cf574a548355353fe135af524b1b77cc"
-dependencies = [
- "aes 0.8.4",
- "async-stream",
- "async-trait",
- "bytes",
- "cbc 0.1.2",
- "libsql-rusqlite",
- "libsql-sys",
- "parking_lot",
- "prost",
- "serde",
- "thiserror 1.0.69",
- "tokio",
- "tokio-stream",
- "tokio-util",
- "tonic",
- "tracing",
- "uuid",
- "zerocopy 0.7.35",
-]
-
-[[package]]
 name = "libsqlite3-sys"
 version = "0.38.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4611,6 +4620,26 @@ name = "link-section"
 version = "0.19.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39c29a617ce3df32c08497bdc1ab6e2376e0b17948ac166a2fbe5977c5954cd9"
+
+[[package]]
+name = "linkme"
+version = "0.3.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3045e122bd98aef8ec3ad58ce84f0791f64e70163d1a02710af4aa11a4d54cc5"
+dependencies = [
+ "linkme-impl",
+]
+
+[[package]]
+name = "linkme-impl"
+version = "0.3.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77060ebe535362c3da75682cd17b0431017b6e7c5661e714fc69a7ad017d1301"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.3",
+]
 
 [[package]]
 name = "linktime-proc-macro"
@@ -4659,6 +4688,19 @@ checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
 dependencies = [
  "serde_core",
  "value-bag",
+]
+
+[[package]]
+name = "loom"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "419e0dc8046cb947daa77eb95ae174acfbddb7673b4151f56d1eed8e93fbfaca"
+dependencies = [
+ "cfg-if",
+ "generator",
+ "scoped-tls",
+ "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]
@@ -4783,10 +4825,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "matchit"
-version = "0.7.3"
+name = "matchers"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e7465ac9959cc2b1404e8e2367b43684a6d13790fe23056cc8c6c5a6b7bcb94"
+checksum = "d1525a2a28c7f4fa0fc98bb91ae755d1e2d1505079e05539e35bc876b5d65ae9"
+dependencies = [
+ "regex-automata",
+]
 
 [[package]]
 name = "maybe-rayon"
@@ -4863,6 +4908,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "miette"
+version = "7.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f98efec8807c63c752b5bd61f862c165c115b0a35685bdcfd9238c7aeb592b7"
+dependencies = [
+ "cfg-if",
+ "miette-derive",
+ "unicode-width 0.1.14",
+]
+
+[[package]]
+name = "miette-derive"
+version = "7.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db5b29714e950dbb20d5e6f74f9dcec4edbcc1067bb7f8ed198c097b8c1a818b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
 name = "mime"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4931,7 +4998,7 @@ dependencies = [
  "half",
  "hashbrown 0.16.1",
  "hexf-parse",
- "indexmap 2.14.0",
+ "indexmap",
  "libm",
  "log",
  "num-traits",
@@ -5586,6 +5653,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
 
 [[package]]
+name = "opaque-debug"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
+
+[[package]]
 name = "open"
 version = "5.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5594,12 +5667,6 @@ dependencies = [
  "is-wsl",
  "libc",
 ]
-
-[[package]]
-name = "openssl-probe"
-version = "0.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
 
 [[package]]
 name = "openssl-probe"
@@ -5630,6 +5697,21 @@ checksum = "9aa2b01e1d916879f73a53d01d1d6cee68adbb31d6d9177a8cfce093cced1d50"
 dependencies = [
  "futures-core",
  "pin-project-lite",
+]
+
+[[package]]
+name = "owo-colors"
+version = "3.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1b04fb49957986fdce4d6ee7a65027d55d4b6d2265e5848bbb507b58ccfdb6f"
+
+[[package]]
+name = "pack1"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3b7bb0ecf2e447b1f20ee94ee79ef6eed1e9d4b3c36ce1903b9dea3bf205523"
+dependencies = [
+ "bytemuck",
 ]
 
 [[package]]
@@ -5707,6 +5789,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "35fb2e5f958ec131621fdd531e9fc186ed768cbe395337403ae56c17a74c68ec"
 
 [[package]]
+name = "pastey"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ee67f1008b1ba2321834326597b8e186293b049a023cdef258527550b9935b4"
+
+[[package]]
 name = "pathfinder_geometry"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5736,12 +5824,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "peeking_take_while"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19b17cddbe7ec3f8bc800887bab5e717348c95ea2ca0b1bf0837fb964dc67099"
-
-[[package]]
 name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5759,42 +5841,13 @@ dependencies = [
 
 [[package]]
 name = "phf"
-version = "0.11.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fd6780a80ae0c52cc120a26a1a42c1ae51b247a253e4e06113d23d2c2edd078"
-dependencies = [
- "phf_shared 0.11.3",
-]
-
-[[package]]
-name = "phf"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c1562dc717473dbaa4c1f85a36410e03c047b2e7df7f45ee938fbef64ae7fadf"
 dependencies = [
  "phf_macros",
- "phf_shared 0.13.1",
+ "phf_shared",
  "serde",
-]
-
-[[package]]
-name = "phf_codegen"
-version = "0.11.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aef8048c789fa5e851558d709946d6d79a8ff88c0440c587967f8e94bfb1216a"
-dependencies = [
- "phf_generator 0.11.3",
- "phf_shared 0.11.3",
-]
-
-[[package]]
-name = "phf_generator"
-version = "0.11.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c80231409c20246a13fddb31776fb942c38553c51e871f8cbd687a4cfb5843d"
-dependencies = [
- "phf_shared 0.11.3",
- "rand 0.8.7",
 ]
 
 [[package]]
@@ -5804,7 +5857,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "135ace3a761e564ec88c03a77317a7c6b80bb7f7135ef2544dbe054243b89737"
 dependencies = [
  "fastrand",
- "phf_shared 0.13.1",
+ "phf_shared",
 ]
 
 [[package]]
@@ -5813,21 +5866,11 @@ version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "812f032b54b1e759ccd5f8b6677695d5268c588701effba24601f6932f8269ef"
 dependencies = [
- "phf_generator 0.13.1",
- "phf_shared 0.13.1",
+ "phf_generator",
+ "phf_shared",
  "proc-macro2",
  "quote",
  "syn 2.0.119",
-]
-
-[[package]]
-name = "phf_shared"
-version = "0.11.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67eabc2ef2a60eb7faa00097bd1ffdb5bd28e62bf39990626a582201b7a754e5"
-dependencies = [
- "siphasher",
- "uncased",
 ]
 
 [[package]]
@@ -5975,7 +6018,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e2d0073b297041425c7c3df6eb4792d598a15323fe63346852b092eca02904c"
 dependencies = [
  "cpufeatures 0.3.0",
- "universal-hash",
+ "universal-hash 0.6.1",
 ]
 
 [[package]]
@@ -5985,6 +6028,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "50596ddc09eb5ad5f75cacd40209568e66df71baf86e1499a0e99c4cff12a5a6"
 dependencies = [
  "arrayvec",
+]
+
+[[package]]
+name = "polyval"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d1fe60d06143b2430aa532c94cfe9e29783047f06c0d7fd359a9a51b729fa25"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.2.17",
+ "opaque-debug",
+ "universal-hash 0.5.1",
 ]
 
 [[package]]
@@ -6025,6 +6080,8 @@ version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d83eb9bc6d8e5cf568e7a1101d60ee05e81ed50ea106026f3d18deeb046d7661"
 dependencies = [
+ "serde_core",
+ "writeable",
  "zerovec",
 ]
 
@@ -6040,7 +6097,7 @@ version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
 dependencies = [
- "zerocopy 0.8.56",
+ "zerocopy",
 ]
 
 [[package]]
@@ -6235,9 +6292,9 @@ dependencies = [
 
 [[package]]
 name = "prost"
-version = "0.12.6"
+version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "deb1435c188b76130da55f17a466d252ff7b1418b2ad3e037d127b94e3411f29"
+checksum = "528ac67416ff8646872a3c02cad9cc4ee5dc9f9540c9b10771855c95cb2e5ae1"
 dependencies = [
  "bytes",
  "prost-derive",
@@ -6245,9 +6302,9 @@ dependencies = [
 
 [[package]]
 name = "prost-derive"
-version = "0.12.6"
+version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81bddcdb20abf9501610992b6759a4c888aef7d1a7247ef75e2404275ac24af1"
+checksum = "b570b25f7617e43d59005d0990ccb79e950a423952cea19671b7a876da390adf"
 dependencies = [
  "anyhow",
  "itertools 0.12.1",
@@ -6346,8 +6403,8 @@ dependencies = [
  "quinn-proto",
  "quinn-udp",
  "rustc-hash 2.1.3",
- "rustls 0.23.43",
- "socket2 0.6.5",
+ "rustls",
+ "socket2",
  "thiserror 2.0.20",
  "tokio",
  "tracing",
@@ -6365,10 +6422,10 @@ dependencies = [
  "getrandom 0.4.3",
  "lru-slab",
  "rand 0.10.2",
- "rand_pcg",
+ "rand_pcg 0.10.2",
  "ring",
  "rustc-hash 2.1.3",
- "rustls 0.23.43",
+ "rustls",
  "rustls-pki-types",
  "slab",
  "thiserror 2.0.20",
@@ -6386,7 +6443,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.6.5",
+ "socket2",
  "tracing",
  "windows-sys 0.61.2",
 ]
@@ -6411,6 +6468,12 @@ name = "r-efi"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
+name = "radium"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
 
 [[package]]
 name = "rand"
@@ -6490,6 +6553,15 @@ checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
 
 [[package]]
 name = "rand_pcg"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59cad018caf63deb318e5a4586d99a24424a364f40f1e5778c29aca23f4fc73e"
+dependencies = [
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand_pcg"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "caa0f4137e1c0a72f4c651489402276c8e8e1cf081f3b0ba156d2cbeef09e86a"
@@ -6517,6 +6589,15 @@ name = "rangemap"
 version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a611d15b50743feb4c76b7d03edcb0e64f399c26961e4efe6975bc398be6aa3d"
+
+[[package]]
+name = "rapidhash"
+version = "4.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5da7e78a036ce858e8d55b7e7dc8ba3a88b78350fd2155d3591bbd966b58589e"
+dependencies = [
+ "rustversion",
+]
 
 [[package]]
 name = "ratatui"
@@ -6549,7 +6630,7 @@ dependencies = [
  "thiserror 2.0.20",
  "unicode-segmentation",
  "unicode-truncate",
- "unicode-width",
+ "unicode-width 0.2.2",
 ]
 
 [[package]]
@@ -6581,7 +6662,7 @@ dependencies = [
  "strum 0.28.0",
  "time",
  "unicode-segmentation",
- "unicode-width",
+ "unicode-width 0.2.2",
 ]
 
 [[package]]
@@ -6802,11 +6883,11 @@ dependencies = [
  "bytes",
  "futures-core",
  "futures-util",
- "http 1.5.0",
- "http-body 1.1.0",
+ "http",
+ "http-body",
  "http-body-util",
- "hyper 1.11.0",
- "hyper-rustls 0.27.9",
+ "hyper",
+ "hyper-rustls",
  "hyper-util",
  "js-sys",
  "log",
@@ -6814,17 +6895,17 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "quinn",
- "rustls 0.23.43",
+ "rustls",
  "rustls-pki-types",
  "rustls-platform-verifier",
  "serde",
  "serde_urlencoded",
- "sync_wrapper 1.0.2",
+ "sync_wrapper",
  "tokio",
- "tokio-rustls 0.26.4",
+ "tokio-rustls",
  "tokio-util",
- "tower 0.5.3",
- "tower-http 0.6.11",
+ "tower",
+ "tower-http",
  "tower-service",
  "url",
  "wasm-bindgen",
@@ -6874,6 +6955,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "roaring"
+version = "0.11.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18bd8a37d17a58532776dcdf6041ce64929adca78e8489d5cacbafe99229d3e1"
+dependencies = [
+ "bytemuck",
+ "byteorder",
+]
+
+[[package]]
 name = "ropey"
 version = "2.0.0-beta.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6914,7 +7005,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23f2a97da3e3873c73cb2a2e71b35c40ff95e0b1eefa8d72d8499a6928c3b5b3"
 dependencies = [
  "bitflags 2.13.1",
- "fallible-iterator 0.3.0",
+ "fallible-iterator",
  "fallible-streaming-iterator",
  "hashlink 0.12.1",
  "libsqlite3-sys",
@@ -6950,6 +7041,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustc_version_runtime"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2dd18cd2bae1820af0b6ad5e54f4a51d0f3fcc53b05f845675074efcc7af071d"
+dependencies = [
+ "rustc_version",
+ "semver",
+]
+
+[[package]]
 name = "rustix"
 version = "0.38.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6977,20 +7078,6 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.22.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf4ef73721ac7bcd79b2b315da7779d8fc09718c6b3d2d1b2d94850eb8c18432"
-dependencies = [
- "log",
- "ring",
- "rustls-pki-types",
- "rustls-webpki 0.102.8",
- "subtle",
- "zeroize",
-]
-
-[[package]]
-name = "rustls"
 version = "0.23.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0283386ce02abc0151e1761d08802dfe86c173b0b494af5cbc086574e453da06"
@@ -7000,22 +7087,9 @@ dependencies = [
  "once_cell",
  "ring",
  "rustls-pki-types",
- "rustls-webpki 0.103.14",
+ "rustls-webpki",
  "subtle",
  "zeroize",
-]
-
-[[package]]
-name = "rustls-native-certs"
-version = "0.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5bfb394eeed242e909609f56089eecfe5fda225042e8b171791b9c95f5931e5"
-dependencies = [
- "openssl-probe 0.1.6",
- "rustls-pemfile",
- "rustls-pki-types",
- "schannel",
- "security-framework 2.11.1",
 ]
 
 [[package]]
@@ -7024,19 +7098,10 @@ version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dab5152771c58876a2146916e53e35057e1a4dfa2b9df0f0305b07f611fdea4d"
 dependencies = [
- "openssl-probe 0.2.1",
+ "openssl-probe",
  "rustls-pki-types",
  "schannel",
- "security-framework 3.7.0",
-]
-
-[[package]]
-name = "rustls-pemfile"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dce314e5fee3f39953d46bb63bb8a46d40c2f8fb7cc5a3b6cab2bde9721d6e50"
-dependencies = [
- "rustls-pki-types",
+ "security-framework",
 ]
 
 [[package]]
@@ -7060,11 +7125,11 @@ dependencies = [
  "jni",
  "log",
  "once_cell",
- "rustls 0.23.43",
- "rustls-native-certs 0.8.4",
+ "rustls",
+ "rustls-native-certs",
  "rustls-platform-verifier-android",
- "rustls-webpki 0.103.14",
- "security-framework 3.7.0",
+ "rustls-webpki",
+ "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
  "windows-sys 0.61.2",
@@ -7075,17 +7140,6 @@ name = "rustls-platform-verifier-android"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
-
-[[package]]
-name = "rustls-webpki"
-version = "0.102.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64ca1bc8749bd4cf37b5ce386cc146580777b4e8572c7b97baf22c83f444bee9"
-dependencies = [
- "ring",
- "rustls-pki-types",
- "untrusted",
-]
 
 [[package]]
 name = "rustls-webpki"
@@ -7181,7 +7235,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "687274d293b6cdc6e73e0fee520bf2049650090d7164f87672d212a3c530cf4a"
 dependencies = [
  "dyn-clone",
- "indexmap 2.14.0",
+ "indexmap",
  "ref-cast",
  "schemars_derive",
  "serde",
@@ -7258,19 +7312,6 @@ dependencies = [
  "serde",
  "sha2 0.11.0",
  "zbus",
-]
-
-[[package]]
-name = "security-framework"
-version = "2.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
-dependencies = [
- "bitflags 2.13.1",
- "core-foundation 0.9.4",
- "core-foundation-sys",
- "libc",
- "security-framework-sys",
 ]
 
 [[package]]
@@ -7378,7 +7419,7 @@ version = "1.0.151"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c841b55ecdae098c80dcae9cf767f6f8a0c2cdb3416bbef72181df4d0fe73f14"
 dependencies = [
- "indexmap 2.14.0",
+ "indexmap",
  "itoa",
  "memchr",
  "serde",
@@ -7428,12 +7469,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_yaml"
+version = "0.9.34+deprecated"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
+dependencies = [
+ "indexmap",
+ "itoa",
+ "ryu",
+ "serde",
+ "unsafe-libyaml",
+]
+
+[[package]]
 name = "serde_yaml_ng"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b4db627b98b36d4203a7b458cf3573730f2bb591b28871d916dfa9efabfd41f"
 dependencies = [
- "indexmap 2.14.0",
+ "indexmap",
  "itoa",
  "ryu",
  "serde",
@@ -7488,6 +7542,26 @@ name = "shlex"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
+
+[[package]]
+name = "shuttle"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ab17edba38d63047f46780cf7360acf7467fec2c048928689a5c1dd1c2b4e31"
+dependencies = [
+ "assoc",
+ "bitvec",
+ "cfg-if",
+ "generator",
+ "hex",
+ "owo-colors",
+ "rand 0.8.7",
+ "rand_core 0.6.4",
+ "rand_pcg 0.3.1",
+ "scoped-tls",
+ "smallvec",
+ "tracing",
+]
 
 [[package]]
 name = "signal-hook"
@@ -7558,6 +7632,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a9c6883ca9c3c7c90e888de77b7a5c849c779d25d74a1269b0218b14e8b136c"
 dependencies = [
  "log",
+]
+
+[[package]]
+name = "simsimd"
+version = "6.5.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4fb3bc3cdce07a7d7d4caa4c54f8aa967f6be41690482b54b24100a2253fa70"
+dependencies = [
+ "cc",
 ]
 
 [[package]]
@@ -7636,16 +7719,6 @@ dependencies = [
 
 [[package]]
 name = "socket2"
-version = "0.5.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e22376abed350d73dd1cd119b57ffccad95b4e585a7cda43e286245ce23c0678"
-dependencies = [
- "libc",
- "windows-sys 0.52.0",
-]
-
-[[package]]
-name = "socket2"
 version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3d1e2c7f27f8d4cb10542a02c49005dbd6e93095799d6f3be745fae9f8fedd4"
@@ -7653,6 +7726,12 @@ dependencies = [
  "libc",
  "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "softaes"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "45e14297decde697ddf377c25752aead0927d5cfc89c2684d2af96901a4ceeea"
 
 [[package]]
 name = "spin"
@@ -7762,6 +7841,15 @@ checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "strum"
+version = "0.26.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fec0f0aef304996cf250b31b5a10dee7980c85da9d759361292b8bca5a18f06"
+dependencies = [
+ "strum_macros 0.26.4",
+]
+
+[[package]]
+name = "strum"
 version = "0.27.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "af23d6f6c1a224baef9d3f61e287d2761385a5b88fdab4eb4c6f11aeb54c4bcf"
@@ -7776,6 +7864,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9628de9b8791db39ceda2b119bbe13134770b56c138ec1d3af810d045c04f9bd"
 dependencies = [
  "strum_macros 0.28.0",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c6bee85a5a24955dc440386795aa378cd9cf82acd5f764469152d2270e581be"
+dependencies = [
+ "heck 0.5.0",
+ "proc-macro2",
+ "quote",
+ "rustversion",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -7834,7 +7935,7 @@ checksum = "f4324db9ac500c609d659b752edf9c8abbf2233f8afd61a503fd6f88ed625032"
 dependencies = [
  "sval",
  "sval_ref",
- "zerocopy 0.8.56",
+ "zerocopy",
 ]
 
 [[package]]
@@ -7927,6 +8028,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "symlink"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7973cce6668464ea31f176d85b13c7ab3bba2cb3b77a2ed26abd7801688010a"
+
+[[package]]
 name = "syn"
 version = "2.0.119"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7947,12 +8054,6 @@ dependencies = [
  "quote",
  "unicode-ident",
 ]
-
-[[package]]
-name = "sync_wrapper"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2047c6ded9c721764247e62cd3b03c09ffc529b2ba5b10ec482ae507a4a70160"
 
 [[package]]
 name = "sync_wrapper"
@@ -8038,6 +8139,12 @@ dependencies = [
  "libc",
  "objc",
 ]
+
+[[package]]
+name = "tap"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "tar"
@@ -8159,6 +8266,7 @@ dependencies = [
  "powerfmt",
  "serde_core",
  "time-core",
+ "time-macros",
 ]
 
 [[package]]
@@ -8166,6 +8274,16 @@ name = "time-core"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e1c906769ad99c88eaa54e728060edef082f8e358ff32030cb7c7d315e81109"
+
+[[package]]
+name = "time-macros"
+version = "0.2.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e689342a48d2ea927c87ea50cabf8594854bf940e9310208848d680d668ed85"
+dependencies = [
+ "num-conv",
+ "time-core",
+]
 
 [[package]]
 name = "tiny-keccak"
@@ -8209,6 +8327,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b1e27c91459209c2986af3dcf603a5a74a4368754ce37414f59acc971167f643"
 dependencies = [
  "displaydoc",
+ "serde_core",
  "zerovec",
 ]
 
@@ -8246,22 +8365,11 @@ dependencies = [
  "bytes",
  "libc",
  "mio",
- "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
- "socket2 0.6.5",
+ "socket2",
  "tokio-macros",
  "windows-sys 0.61.2",
-]
-
-[[package]]
-name = "tokio-io-timeout"
-version = "1.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bd86198d9ee903fedd2f9a2e72014287c0d9167e4ae43b5853007205dda1b76"
-dependencies = [
- "pin-project-lite",
- "tokio",
 ]
 
 [[package]]
@@ -8277,33 +8385,11 @@ dependencies = [
 
 [[package]]
 name = "tokio-rustls"
-version = "0.25.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "775e0c0f0adb3a2f22a00c4745d728b479985fc15ee7ca6a2608388c5569860f"
-dependencies = [
- "rustls 0.22.4",
- "rustls-pki-types",
- "tokio",
-]
-
-[[package]]
-name = "tokio-rustls"
 version = "0.26.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
 dependencies = [
- "rustls 0.23.43",
- "tokio",
-]
-
-[[package]]
-name = "tokio-stream"
-version = "0.1.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3d06f0b082ba57c26b79407372e57cf2a1e28124f78e9479fe80322cf53420b"
-dependencies = [
- "futures-core",
- "pin-project-lite",
+ "rustls",
  "tokio",
 ]
 
@@ -8316,7 +8402,6 @@ dependencies = [
  "bytes",
  "futures-core",
  "futures-sink",
- "libc",
  "pin-project-lite",
  "tokio",
 ]
@@ -8339,7 +8424,7 @@ version = "1.1.4+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3aace63f4bbcdfc2c965b059de67119c89c4017a70d633be6c104910f67056f5"
 dependencies = [
- "indexmap 2.14.0",
+ "indexmap",
  "serde_core",
  "serde_spanned 1.1.1",
  "toml_datetime 1.1.1+spec-1.1.0",
@@ -8372,7 +8457,7 @@ version = "0.22.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
 dependencies = [
- "indexmap 2.14.0",
+ "indexmap",
  "serde",
  "serde_spanned 0.6.9",
  "toml_datetime 0.6.11",
@@ -8386,7 +8471,7 @@ version = "0.25.13+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6975367e4d2ef766d86af01ffad14b622fecc8d4357a998fbc4deb6e9bacaf9b"
 dependencies = [
- "indexmap 2.14.0",
+ "indexmap",
  "toml_datetime 1.1.1+spec-1.1.0",
  "toml_parser",
  "winnow 1.0.4",
@@ -8414,73 +8499,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d56353a2a665ad0f41a421187180aab746c8c325620617ad883a99a1cbe66d2"
 
 [[package]]
-name = "tonic"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76c4eb7a4e9ef9d4763600161f12f5070b92a578e1b634db88a6887844c91a13"
-dependencies = [
- "async-stream",
- "async-trait",
- "axum",
- "base64 0.21.7",
- "bytes",
- "h2",
- "http 0.2.12",
- "http-body 0.4.6",
- "hyper 0.14.32",
- "hyper-timeout",
- "percent-encoding",
- "pin-project",
- "prost",
- "tokio",
- "tokio-stream",
- "tower 0.4.13",
- "tower-layer",
- "tower-service",
- "tracing",
-]
-
-[[package]]
-name = "tonic-web"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc3b0e1cedbf19fdfb78ef3d672cb9928e0a91a9cb4629cc0c916e8cff8aaaa1"
-dependencies = [
- "base64 0.21.7",
- "bytes",
- "http 0.2.12",
- "http-body 0.4.6",
- "hyper 0.14.32",
- "pin-project",
- "tokio-stream",
- "tonic",
- "tower-http 0.4.4",
- "tower-layer",
- "tower-service",
- "tracing",
-]
-
-[[package]]
-name = "tower"
-version = "0.4.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8fa9be0de6cf49e536ce1851f987bd21a43b771b09473c3549a6c853db37c1c"
-dependencies = [
- "futures-core",
- "futures-util",
- "indexmap 1.9.3",
- "pin-project",
- "pin-project-lite",
- "rand 0.8.7",
- "slab",
- "tokio",
- "tokio-util",
- "tower-layer",
- "tower-service",
- "tracing",
-]
-
-[[package]]
 name = "tower"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8489,30 +8507,10 @@ dependencies = [
  "futures-core",
  "futures-util",
  "pin-project-lite",
- "sync_wrapper 1.0.2",
+ "sync_wrapper",
  "tokio",
  "tower-layer",
  "tower-service",
-]
-
-[[package]]
-name = "tower-http"
-version = "0.4.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61c5bb1d698276a2443e5ecfabc1008bf15a36c12e6a7176e7bf089ea9131140"
-dependencies = [
- "bitflags 2.13.1",
- "bytes",
- "futures-core",
- "futures-util",
- "http 0.2.12",
- "http-body 0.4.6",
- "http-range-header",
- "pin-project-lite",
- "tower 0.4.13",
- "tower-layer",
- "tower-service",
- "tracing",
 ]
 
 [[package]]
@@ -8524,10 +8522,10 @@ dependencies = [
  "bitflags 2.13.1",
  "bytes",
  "futures-util",
- "http 1.5.0",
- "http-body 1.1.0",
+ "http",
+ "http-body",
  "pin-project-lite",
- "tower 0.5.3",
+ "tower",
  "tower-layer",
  "tower-service",
  "url",
@@ -8555,6 +8553,19 @@ dependencies = [
  "pin-project-lite",
  "tracing-attributes",
  "tracing-core",
+]
+
+[[package]]
+name = "tracing-appender"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "050686193eb999b4bb3bc2acfa891a13da00f79734704c4b8b4ef1a10b368a3c"
+dependencies = [
+ "crossbeam-channel",
+ "symlink",
+ "thiserror 2.0.20",
+ "time",
+ "tracing-subscriber",
 ]
 
 [[package]]
@@ -8595,10 +8606,14 @@ version = "0.3.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb7f578e5945fb242538965c2d0b04418d38ec25c79d160cd279bf0731c8d319"
 dependencies = [
+ "matchers",
  "nu-ansi-term",
+ "once_cell",
+ "regex-automata",
  "sharded-slab",
  "smallvec",
  "thread_local",
+ "tracing",
  "tracing-core",
  "tracing-log",
 ]
@@ -8616,6 +8631,200 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2df906b07856748fa3f6e0ad0cbaa047052d4a7dd609e231c4f72cee8c36f31"
 dependencies = [
  "core_maths",
+]
+
+[[package]]
+name = "turso"
+version = "0.8.0-pre.8"
+source = "git+https://github.com/tursodatabase/turso?rev=87c7a8516511c3ad2745c25b1079ea5c90112692#87c7a8516511c3ad2745c25b1079ea5c90112692"
+dependencies = [
+ "thiserror 2.0.20",
+ "tracing",
+ "tracing-subscriber",
+ "turso_core",
+ "turso_sdk_kit",
+ "turso_sync_sdk_kit",
+]
+
+[[package]]
+name = "turso_core"
+version = "0.8.0-pre.8"
+source = "git+https://github.com/tursodatabase/turso?rev=87c7a8516511c3ad2745c25b1079ea5c90112692#87c7a8516511c3ad2745c25b1079ea5c90112692"
+dependencies = [
+ "aegis",
+ "aes 0.8.4",
+ "aes-gcm",
+ "allocator-api2 0.4.0",
+ "antithesis_sdk",
+ "arc-swap",
+ "aristo",
+ "bigdecimal",
+ "bitflags 2.13.1",
+ "branches",
+ "bumpalo",
+ "bytemuck",
+ "cfg_aliases",
+ "cfg_block",
+ "chrono",
+ "crc32c",
+ "crossbeam-epoch",
+ "crossbeam-utils",
+ "either",
+ "fallible-iterator",
+ "fastbloom",
+ "getrandom 0.2.17",
+ "getrandom 0.3.4",
+ "hex",
+ "icu_collator",
+ "icu_locale",
+ "intrusive-collections",
+ "io-uring",
+ "libc",
+ "libloading",
+ "libm",
+ "loom",
+ "miette",
+ "num-bigint",
+ "num-traits",
+ "pack1",
+ "parking_lot",
+ "pastey 0.2.3",
+ "polling",
+ "rand 0.9.5",
+ "rapidhash",
+ "regex",
+ "regex-syntax",
+ "roaring",
+ "rustc-hash 2.1.3",
+ "rustix 1.1.4",
+ "ryu",
+ "serde_json",
+ "shuttle",
+ "simdutf8",
+ "simsimd",
+ "smallvec",
+ "strum 0.26.3",
+ "strum_macros 0.26.4",
+ "tempfile",
+ "thiserror 2.0.20",
+ "tracing",
+ "tracing-subscriber",
+ "turso_ext",
+ "turso_macros",
+ "turso_parser",
+ "twox-hash",
+ "uncased",
+ "uuid",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "turso_ext"
+version = "0.8.0-pre.8"
+source = "git+https://github.com/tursodatabase/turso?rev=87c7a8516511c3ad2745c25b1079ea5c90112692#87c7a8516511c3ad2745c25b1079ea5c90112692"
+dependencies = [
+ "chrono",
+ "getrandom 0.4.3",
+ "turso_macros",
+]
+
+[[package]]
+name = "turso_macros"
+version = "0.8.0-pre.8"
+source = "git+https://github.com/tursodatabase/turso?rev=87c7a8516511c3ad2745c25b1079ea5c90112692#87c7a8516511c3ad2745c25b1079ea5c90112692"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "turso_parser"
+version = "0.8.0-pre.8"
+source = "git+https://github.com/tursodatabase/turso?rev=87c7a8516511c3ad2745c25b1079ea5c90112692#87c7a8516511c3ad2745c25b1079ea5c90112692"
+dependencies = [
+ "bitflags 2.13.1",
+ "memchr",
+ "miette",
+ "strum 0.26.3",
+ "strum_macros 0.26.4",
+ "thiserror 2.0.20",
+ "turso_macros",
+]
+
+[[package]]
+name = "turso_sdk_kit"
+version = "0.8.0-pre.8"
+source = "git+https://github.com/tursodatabase/turso?rev=87c7a8516511c3ad2745c25b1079ea5c90112692#87c7a8516511c3ad2745c25b1079ea5c90112692"
+dependencies = [
+ "bindgen 0.69.5",
+ "env_logger",
+ "parking_lot",
+ "tracing",
+ "tracing-appender",
+ "tracing-subscriber",
+ "turso_core",
+ "turso_ext",
+ "turso_sdk_kit_macros",
+]
+
+[[package]]
+name = "turso_sdk_kit_macros"
+version = "0.8.0-pre.8"
+source = "git+https://github.com/tursodatabase/turso?rev=87c7a8516511c3ad2745c25b1079ea5c90112692#87c7a8516511c3ad2745c25b1079ea5c90112692"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "turso_sync_engine"
+version = "0.8.0-pre.8"
+source = "git+https://github.com/tursodatabase/turso?rev=87c7a8516511c3ad2745c25b1079ea5c90112692#87c7a8516511c3ad2745c25b1079ea5c90112692"
+dependencies = [
+ "base64 0.22.1",
+ "bytes",
+ "crc32c",
+ "genawaiter",
+ "http",
+ "libc",
+ "prost",
+ "roaring",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.20",
+ "tracing",
+ "turso_core",
+ "turso_parser",
+ "uuid",
+]
+
+[[package]]
+name = "turso_sync_sdk_kit"
+version = "0.8.0-pre.8"
+source = "git+https://github.com/tursodatabase/turso?rev=87c7a8516511c3ad2745c25b1079ea5c90112692#87c7a8516511c3ad2745c25b1079ea5c90112692"
+dependencies = [
+ "bindgen 0.69.5",
+ "env_logger",
+ "genawaiter",
+ "parking_lot",
+ "tracing",
+ "tracing-appender",
+ "tracing-subscriber",
+ "turso_core",
+ "turso_sdk_kit",
+ "turso_sdk_kit_macros",
+ "turso_sync_engine",
+]
+
+[[package]]
+name = "twox-hash"
+version = "2.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5283634e518fe9e82c7b20520bb4bc209009fd16c82077c802f8111ecbb0117a"
+dependencies = [
+ "rand 0.9.5",
 ]
 
 [[package]]
@@ -8718,7 +8927,7 @@ checksum = "16b380a1238663e5f8a691f9039c73e1cdae598a30e9855f541d29b08b53e9a5"
 dependencies = [
  "itertools 0.14.0",
  "unicode-segmentation",
- "unicode-width",
+ "unicode-width 0.2.2",
 ]
 
 [[package]]
@@ -8726,6 +8935,12 @@ name = "unicode-vo"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b1d386ff53b415b7fe27b50bb44679e2cc4660272694b7b6f3326d8480823a94"
+
+[[package]]
+name = "unicode-width"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
 
 [[package]]
 name = "unicode-width"
@@ -8738,6 +8953,16 @@ name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
+name = "universal-hash"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc1de2c688dc15305988b563c3854064043356019f97a4b46276fe734c4f07ea"
+dependencies = [
+ "crypto-common 0.1.7",
+ "subtle",
+]
 
 [[package]]
 name = "universal-hash"
@@ -8770,11 +8995,11 @@ dependencies = [
  "base64 0.23.1",
  "log",
  "percent-encoding",
- "rustls 0.23.43",
+ "rustls",
  "rustls-pki-types",
  "ureq-proto",
  "utf8-zero",
- "webpki-roots 1.0.9",
+ "webpki-roots",
 ]
 
 [[package]]
@@ -8784,7 +9009,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fabc3e92916c89c95b20eef7b06b00b066bc217ef9ea3a4ac9bf1a7e35261e10"
 dependencies = [
  "base64 0.23.1",
- "http 1.5.0",
+ "http",
  "httparse",
  "log",
 ]
@@ -8827,6 +9052,12 @@ dependencies = [
  "unicode-vo",
  "xmlwriter",
 ]
+
+[[package]]
+name = "utf16_iter"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8232dd3cdaed5356e0f716d285e4b40b932ac434100fe9b7e0e8e935b9e6246"
 
 [[package]]
 name = "utf8-zero"
@@ -9205,15 +9436,6 @@ dependencies = [
 
 [[package]]
 name = "webpki-roots"
-version = "0.26.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "521bc38abb08001b01866da9f51eb7c5d647a19260e00054a8c7fd5f9e57f7a9"
-dependencies = [
- "webpki-roots 1.0.9",
-]
-
-[[package]]
-name = "webpki-roots"
 version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7dcd9d09a39985f5344844e66b0c530a33843579125f23e21e9f0f220850f22a"
@@ -9271,7 +9493,7 @@ dependencies = [
  "cfg_aliases",
  "document-features",
  "hashbrown 0.16.1",
- "indexmap 2.14.0",
+ "indexmap",
  "log",
  "naga",
  "once_cell",
@@ -9989,10 +10211,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "beffa227304dbaea3ad6a06ac674f9bc83a3dec3b7f63eeb442de37e7cb6bb01"
 
 [[package]]
+name = "write16"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1890f4022759daae28ed4fe62859b1236caebfc61ede2f63ed4e695f3f6d936"
+
+[[package]]
 name = "writeable"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3ad82d2a33cdc9674dc7465672f271e096168fcdbe0f799d9e6db8c5892679dc"
+
+[[package]]
+name = "wyz"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05f360fc0b24296329c78fda852a1e9ae82de9cf7b27dae4b7f62f118f77b9ed"
+dependencies = [
+ "tap",
+]
 
 [[package]]
 name = "x11"
@@ -10349,32 +10586,11 @@ checksum = "6df3dc4292935e51816d896edcd52aa30bc297907c26167fec31e2b0c6a32524"
 
 [[package]]
 name = "zerocopy"
-version = "0.7.35"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b9b4fd18abc82b8136838da5d50bae7bdea537c574d8dc1a34ed098d6c166f0"
-dependencies = [
- "byteorder",
- "zerocopy-derive 0.7.35",
-]
-
-[[package]]
-name = "zerocopy"
 version = "0.8.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "556764e583adb45a9f8d413c2a147fa7e8d821e48e12b14fd560b607998b75eb"
 dependencies = [
- "zerocopy-derive 0.8.56",
-]
-
-[[package]]
-name = "zerocopy-derive"
-version = "0.7.35"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.119",
+ "zerocopy-derive",
 ]
 
 [[package]]
@@ -10438,6 +10654,7 @@ dependencies = [
  "displaydoc",
  "yoke",
  "zerofrom",
+ "zerovec",
 ]
 
 [[package]]
@@ -10446,6 +10663,7 @@ version = "0.11.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94b5c6b5976d66c1d703c4fd17d3f5e43c8cedaacf604961b171adc7130896d8"
 dependencies = [
+ "serde",
  "yoke",
  "zerofrom",
  "zerovec-derive",
@@ -10471,7 +10689,7 @@ dependencies = [
  "arbitrary",
  "crc32fast",
  "flate2",
- "indexmap 2.14.0",
+ "indexmap",
  "memchr",
  "zopfli",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -576,6 +576,45 @@ dependencies = [
 ]
 
 [[package]]
+name = "asn1-rs"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7f43a50ac4fdca5df8e885c21b835997f0a1cdee65494a6847694a98652d9d8"
+dependencies = [
+ "asn1-rs-derive",
+ "asn1-rs-impl",
+ "displaydoc",
+ "nom 7.1.3",
+ "num-traits",
+ "rusticata-macros",
+ "thiserror 2.0.20",
+ "time",
+]
+
+[[package]]
+name = "asn1-rs-derive"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3109e49b1e4909e9db6515a30c633684d68cdeaa252f215214cb4fa1a5bfee2c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+ "synstructure",
+]
+
+[[package]]
+name = "asn1-rs-impl"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b18050c2cd6fe86c3a76584ef5e0baf286d038cda203eb6223df2cc413565f7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
 name = "assoc"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -870,6 +909,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ce2b2dcc879c3bae0d371e77c99f2238400ef24ec001394befa67b6e543add9e"
 dependencies = [
  "aws-lc-sys",
+ "untrusted 0.7.1",
  "zeroize",
 ]
 
@@ -1007,6 +1047,9 @@ name = "bit-vec"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b71798fca2c1fe1086445a7258a4bc81e6e49dcd24c8d0dd9a1e57395b603f51"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "bit_field"
@@ -2096,10 +2139,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "data-encoding"
+version = "2.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4583a4551df46e2792f82ceeac45e850d2e2d5debba0b91f102385cda5b11f06"
+
+[[package]]
 name = "data-url"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be1e0bca6c3637f992fc1cc7cbc52a78c1ef6db076dbf1059c4323d6a2048376"
+
+[[package]]
+name = "der-parser"
+version = "10.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07da5016415d5a3c4dd39b11ed26f915f52fc4e0dc197d87908bc916e51bc1a6"
+dependencies = [
+ "asn1-rs",
+ "displaydoc",
+ "nom 7.1.3",
+ "num-bigint",
+ "num-traits",
+ "rusticata-macros",
+]
 
 [[package]]
 name = "deranged"
@@ -2511,10 +2574,14 @@ dependencies = [
 name = "facet-record"
 version = "0.5.7"
 dependencies = [
+ "base64 0.23.1",
  "lattice",
  "probe-core",
  "probe-http",
+ "rcgen",
+ "serde",
  "serde_json",
+ "serde_yaml_ng",
  "tempfile",
 ]
 
@@ -2955,8 +3022,8 @@ dependencies = [
  "libc",
  "log",
  "rustversion",
- "windows-link 0.1.3",
- "windows-result 0.3.4",
+ "windows-link 0.2.1",
+ "windows-result 0.4.1",
 ]
 
 [[package]]
@@ -5606,6 +5673,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "oid-registry"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12f40cff3dde1b6087cc5d5f5d4d65712f34016a03ed60e9c08dcc392736b5b7"
+dependencies = [
+ "asn1-rs",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5821,6 +5897,16 @@ checksum = "f8ed6a7761f76e3b9f92dfb0a60a6a6477c61024b775147ff0973a02653abaf2"
 dependencies = [
  "digest 0.10.7",
  "hmac 0.12.1",
+]
+
+[[package]]
+name = "pem"
+version = "4.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d354a98a3d1251555de99e8fdd8afda05573c31b82f59063a7b0a29b5527f120"
+dependencies = [
+ "base64 0.23.1",
+ "serde_core",
 ]
 
 [[package]]
@@ -6166,8 +6252,11 @@ name = "probe-http"
 version = "0.5.7"
 dependencies = [
  "probe-core",
+ "rcgen",
  "reqwest",
+ "rustls",
  "tokio",
+ "tokio-rustls",
 ]
 
 [[package]]
@@ -6307,7 +6396,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b570b25f7617e43d59005d0990ccb79e950a423952cea19671b7a876da390adf"
 dependencies = [
  "anyhow",
- "itertools 0.12.1",
+ "itertools 0.14.0",
  "proc-macro2",
  "quote",
  "syn 2.0.119",
@@ -6763,6 +6852,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "rcgen"
+version = "0.14.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8774e05a7d0de114588e6a28fe7e71694b82614ed569d86d8b389dfbc98b8ad8"
+dependencies = [
+ "aws-lc-rs",
+ "pem",
+ "rustls-pki-types",
+ "time",
+ "x509-parser",
+ "yasna",
+]
+
+[[package]]
 name = "read-fonts"
 version = "0.37.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6950,7 +7053,7 @@ dependencies = [
  "cfg-if",
  "getrandom 0.2.17",
  "libc",
- "untrusted",
+ "untrusted 0.9.0",
  "windows-sys 0.52.0",
 ]
 
@@ -7048,6 +7151,15 @@ checksum = "2dd18cd2bae1820af0b6ad5e54f4a51d0f3fcc53b05f845675074efcc7af071d"
 dependencies = [
  "rustc_version",
  "semver",
+]
+
+[[package]]
+name = "rusticata-macros"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "faf0c4a6ece9950b9abdb62b1cfcf2a68b3b67a10ba445b3bb85be2a293d0632"
+dependencies = [
+ "nom 7.1.3",
 ]
 
 [[package]]
@@ -7150,7 +7262,7 @@ dependencies = [
  "aws-lc-rs",
  "ring",
  "rustls-pki-types",
- "untrusted",
+ "untrusted 0.9.0",
 ]
 
 [[package]]
@@ -8385,9 +8497,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-rustls"
-version = "0.26.4"
+version = "0.26.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
+checksum = "b0c85f2c3ef0b1cd58b36682f4b17aaa995f0e5db534d85692b4903abce21f67"
 dependencies = [
  "rustls",
  "tokio",
@@ -8824,7 +8936,7 @@ version = "2.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5283634e518fe9e82c7b20520bb4bc209009fd16c82077c802f8111ecbb0117a"
 dependencies = [
- "rand 0.9.5",
+ "rand 0.10.2",
 ]
 
 [[package]]
@@ -8979,6 +9091,12 @@ name = "unsafe-libyaml"
 version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
+
+[[package]]
+name = "untrusted"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
 
 [[package]]
 name = "untrusted"
@@ -10272,6 +10390,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ea6fc2961e4ef194dcbfe56bb845534d0dc8098940c7e5c012a258bfec6701bd"
 
 [[package]]
+name = "x509-parser"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d43b0f71ce057da06bc0851b23ee24f3f86190b07203dd8f567d0b706a185202"
+dependencies = [
+ "asn1-rs",
+ "aws-lc-rs",
+ "data-encoding",
+ "der-parser",
+ "lazy_static",
+ "nom 7.1.3",
+ "oid-registry",
+ "rusticata-macros",
+ "thiserror 2.0.20",
+ "time",
+]
+
+[[package]]
 name = "xattr"
 version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10350,6 +10486,16 @@ name = "y4m"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a5a4b21e1a62b67a2970e6831bc091d7b87e119e7f9791aef9702e3bef04448"
+
+[[package]]
+name = "yasna"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5f6765e852b9b4dc8e2a76843e4d64d1cea8e79bcde0b6901aea8e7c7f08282"
+dependencies = [
+ "bit-vec 0.9.1",
+ "time",
+]
 
 [[package]]
 name = "yazi"

--- a/crates/facet-record/Cargo.toml
+++ b/crates/facet-record/Cargo.toml
@@ -7,6 +7,9 @@ rust-version.workspace = true
 description = "Facet: shared run-recording path into Lattice for the CLI and TUI"
 
 [dependencies]
+base64 = "0.23.1"
+serde = { version = "1", features = ["derive"] }
+serde_yaml_ng = "0.10"
 lattice = { path = "../lattice" }
 probe-core = { path = "../core" }
 probe-http = { path = "../http" }
@@ -17,3 +20,4 @@ workspace = true
 
 [dev-dependencies]
 tempfile = "3"
+rcgen = { version = "0.14.10", default-features = false, features = ["aws_lc_rs", "pem"] }

--- a/crates/facet-record/src/lib.rs
+++ b/crates/facet-record/src/lib.rs
@@ -94,6 +94,8 @@ pub fn session_from_env() -> Option<String> {
 }
 
 /// What happened to the Lattice write for this run.
+// Keep the existing owned RunRow API; boxing this variant would break callers.
+#[allow(clippy::large_enum_variant)]
 pub enum Recording {
     /// The run row landed in the workspace store.
     Recorded {

--- a/crates/facet-record/src/lib.rs
+++ b/crates/facet-record/src/lib.rs
@@ -8,6 +8,7 @@
 
 mod diff;
 mod hydrate;
+mod transport;
 
 use std::path::Path;
 
@@ -16,6 +17,7 @@ pub use diff::{
     diff_response_bodies, unified_diff,
 };
 pub use hydrate::{HydrateError, Hydration, overlay_secrets};
+pub use transport::{http_engine_from_env, http_engine_from_kubeconfig};
 
 use lattice::{
     BodyInput, LatticeConfig, LatticeError, MachineStore, NewRun, Retention, RunRow,

--- a/crates/facet-record/src/transport.rs
+++ b/crates/facet-record/src/transport.rs
@@ -1,0 +1,181 @@
+//! Explicit project kubeconfig loading for Facet's shared HTTP transport.
+//! No ambient KUBECONFIG discovery, credential plugins, insecure TLS, or mutation
+//! of canonical YAML. Diagnostics never include credential values or YAML text.
+
+use std::{
+    collections::BTreeMap,
+    fs::File,
+    io::Read,
+    path::{Path, PathBuf},
+};
+
+use base64::{Engine as _, prelude::BASE64_STANDARD};
+use probe_http::{ClusterTls, HttpEngine, HttpError};
+use serde::Deserialize;
+use serde_json::Value;
+
+const MAX_FILE_BYTES: u64 = 4 * 1024 * 1024;
+
+/// Builds the shared transport from an explicitly selected project kubeconfig.
+/// Without `FACET_KUBECONFIG`, ordinary Facet HTTP behavior is unchanged.
+/// `FACET_KUBE_CONTEXT` optionally selects a context within that one file.
+pub fn http_engine_from_env() -> Result<HttpEngine, HttpError> {
+    let Some(path) = std::env::var_os("FACET_KUBECONFIG") else {
+        return HttpEngine::new();
+    };
+    if path.is_empty() {
+        return Err(config("FACET_KUBECONFIG is empty"));
+    }
+    let context = match std::env::var("FACET_KUBE_CONTEXT") {
+        Ok(value) if !value.is_empty() => Some(value),
+        Ok(_) => return Err(config("FACET_KUBE_CONTEXT is empty")),
+        Err(std::env::VarError::NotPresent) => None,
+        Err(_) => return Err(config("FACET_KUBE_CONTEXT is not valid UTF-8")),
+    };
+    http_engine_from_kubeconfig(Path::new(&path), context.as_deref())
+}
+
+/// Loads a single kubeconfig and creates a verified client-certificate engine.
+/// This synchronous filesystem work belongs off the UI event thread.
+pub fn http_engine_from_kubeconfig(
+    path: &Path,
+    selected: Option<&str>,
+) -> Result<HttpEngine, HttpError> {
+    let source = read_bounded(path)?;
+    let kube: Kubeconfig =
+        serde_yaml_ng::from_slice(&source).map_err(|_| config("invalid kubeconfig document"))?;
+    if kube.api_version != "v1" || kube.kind != "Config" {
+        return Err(config("kubeconfig requires apiVersion v1 and kind Config"));
+    }
+    let context_name = selected.unwrap_or(&kube.current_context);
+    let context = unique(&kube.contexts, context_name, |entry| &entry.name)?;
+    let cluster = &unique(&kube.clusters, &context.context.cluster, |entry| {
+        &entry.name
+    })?
+    .cluster;
+    let user = &unique(&kube.users, &context.context.user, |entry| &entry.name)?.user;
+    if cluster.insecure_skip_tls_verify || !cluster.extra.is_empty() || !user.extra.is_empty() {
+        return Err(config(
+            "unsupported kubeconfig transport/authentication: use verified CA and client certificate/key; exec, auth-provider, bearer tokens, proxies, TLS-name overrides and impersonation are not supported by this profile",
+        ));
+    }
+    let base = path.parent().unwrap_or_else(|| Path::new("."));
+    let ca = material(base, &cluster.ca_data, &cluster.ca_file)?;
+    let cert = material(base, &user.cert_data, &user.cert_file)?;
+    let key = material(base, &user.key_data, &user.key_file)?;
+    let mut identity = cert;
+    identity.push(b'\n');
+    identity.extend_from_slice(&key);
+    HttpEngine::with_cluster_tls(ClusterTls::from_pem(&cluster.server, &ca, &identity)?)
+}
+
+fn unique<'a, T>(
+    entries: &'a [T],
+    selected: &str,
+    name: impl Fn(&T) -> &str,
+) -> Result<&'a T, HttpError> {
+    if selected.is_empty() {
+        return Err(config(
+            "kubeconfig context, cluster and user names must be nonempty",
+        ));
+    }
+    let mut matches = entries.iter().filter(|entry| name(entry) == selected);
+    let found = matches
+        .next()
+        .ok_or_else(|| config("selected kubeconfig context, cluster or user is missing"))?;
+    if matches.next().is_some() {
+        return Err(config("selected kubeconfig name is duplicated"));
+    }
+    Ok(found)
+}
+
+fn material(
+    base: &Path,
+    data: &Option<String>,
+    file: &Option<PathBuf>,
+) -> Result<Vec<u8>, HttpError> {
+    match (data, file) {
+        (Some(data), None) => BASE64_STANDARD
+            .decode(data)
+            .map_err(|_| config("invalid base64 credential data in kubeconfig")),
+        (None, Some(file)) => read_bounded(&base.join(file)),
+        _ => Err(config(
+            "kubeconfig requires exactly one data or file source for each CA, client certificate and private key",
+        )),
+    }
+}
+
+fn read_bounded(path: &Path) -> Result<Vec<u8>, HttpError> {
+    let file = File::open(path)
+        .map_err(|_| config("cannot open kubeconfig or referenced credential file"))?;
+    let mut bytes = Vec::new();
+    file.take(MAX_FILE_BYTES + 1)
+        .read_to_end(&mut bytes)
+        .map_err(|_| config("cannot read kubeconfig or referenced credential file"))?;
+    if bytes.len() as u64 > MAX_FILE_BYTES {
+        return Err(config("kubeconfig or credential file exceeds 4 MiB"));
+    }
+    Ok(bytes)
+}
+
+fn config(message: &str) -> HttpError {
+    HttpError::ClientConfiguration(message.to_owned())
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "kebab-case")]
+struct Kubeconfig {
+    #[serde(rename = "apiVersion")]
+    api_version: String,
+    kind: String,
+    #[serde(default)]
+    current_context: String,
+    clusters: Vec<NamedCluster>,
+    users: Vec<NamedUser>,
+    contexts: Vec<NamedContext>,
+}
+#[derive(Deserialize)]
+struct NamedCluster {
+    name: String,
+    cluster: Cluster,
+}
+#[derive(Deserialize)]
+struct NamedUser {
+    name: String,
+    user: User,
+}
+#[derive(Deserialize)]
+struct NamedContext {
+    name: String,
+    context: Context,
+}
+#[derive(Deserialize)]
+struct Context {
+    cluster: String,
+    user: String,
+}
+#[derive(Deserialize)]
+struct Cluster {
+    server: String,
+    #[serde(default, rename = "certificate-authority-data")]
+    ca_data: Option<String>,
+    #[serde(default, rename = "certificate-authority")]
+    ca_file: Option<PathBuf>,
+    #[serde(default, rename = "insecure-skip-tls-verify")]
+    insecure_skip_tls_verify: bool,
+    #[serde(flatten)]
+    extra: BTreeMap<String, Value>,
+}
+#[derive(Deserialize)]
+struct User {
+    #[serde(default, rename = "client-certificate-data")]
+    cert_data: Option<String>,
+    #[serde(default, rename = "client-certificate")]
+    cert_file: Option<PathBuf>,
+    #[serde(default, rename = "client-key-data")]
+    key_data: Option<String>,
+    #[serde(default, rename = "client-key")]
+    key_file: Option<PathBuf>,
+    #[serde(flatten)]
+    extra: BTreeMap<String, Value>,
+}

--- a/crates/facet-record/tests/cluster_config.rs
+++ b/crates/facet-record/tests/cluster_config.rs
@@ -1,0 +1,120 @@
+use base64::{Engine as _, prelude::BASE64_STANDARD};
+use facet_record::http_engine_from_kubeconfig;
+use serde_json::{Value, json};
+
+#[path = "../../../tests/support/cluster_pki.rs"]
+#[allow(dead_code)]
+mod cluster_pki;
+use cluster_pki::Pki;
+
+fn kube(pki: &Pki) -> Value {
+    json!({"apiVersion":"v1", "kind":"Config", "current-context":"m1",
+        "clusters":[{"name":"cluster", "cluster":{"server":"https://127.0.0.1:6443", "certificate-authority-data":BASE64_STANDARD.encode(&pki.ca)}}],
+        "users":[{"name":"facet", "user":{"client-certificate-data":BASE64_STANDARD.encode(&pki.client_cert), "client-key-data":BASE64_STANDARD.encode(&pki.client_key)}}],
+        "contexts":[{"name":"m1", "context":{"cluster":"cluster", "user":"facet", "namespace":"api-smoke"}}]})
+}
+fn load(
+    doc: &Value,
+    selected: Option<&str>,
+) -> Result<probe_http::HttpEngine, probe_http::HttpError> {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("config");
+    std::fs::write(&path, serde_json::to_vec(doc).unwrap()).unwrap();
+    http_engine_from_kubeconfig(&path, selected)
+}
+
+#[test]
+fn loads_embedded_and_relative_file_credentials_with_explicit_context() {
+    let pki = Pki::new(&["127.0.0.1"]);
+    let doc = kube(&pki);
+    assert!(load(&doc, None).is_ok());
+    let mut explicit = doc.clone();
+    explicit["current-context"] = json!("absent");
+    assert!(load(&explicit, Some("m1")).is_ok());
+    assert!(load(&explicit, None).is_err());
+    let dir = tempfile::tempdir().unwrap();
+    std::fs::write(dir.path().join("ca.pem"), &pki.ca).unwrap();
+    std::fs::write(dir.path().join("client.pem"), &pki.client_cert).unwrap();
+    std::fs::write(dir.path().join("key.pem"), &pki.client_key).unwrap();
+    let mut files = doc;
+    files["clusters"][0]["cluster"] =
+        json!({"server":"https://127.0.0.1:6443", "certificate-authority":"ca.pem"});
+    files["users"][0]["user"] = json!({"client-certificate":"client.pem", "client-key":"key.pem"});
+    let path = dir.path().join("config.yaml");
+    std::fs::write(&path, serde_yaml_ng::to_string(&files).unwrap()).unwrap();
+    assert!(http_engine_from_kubeconfig(&path, None).is_ok());
+}
+
+#[test]
+fn rejects_ambiguous_insecure_and_executable_credentials_without_leaking_material() {
+    let pki = Pki::new(&["127.0.0.1"]);
+    let original = kube(&pki);
+    let mut cases = Vec::new();
+    for server in [
+        "http://127.0.0.1:6443",
+        "https://user:secret@127.0.0.1",
+        "https://127.0.0.1/prefix",
+        "https://127.0.0.1?token=secret",
+    ] {
+        let mut doc = original.clone();
+        doc["clusters"][0]["cluster"]["server"] = json!(server);
+        cases.push(doc);
+    }
+    for key in [
+        "exec",
+        "auth-provider",
+        "token",
+        "tokenFile",
+        "username",
+        "password",
+        "as",
+    ] {
+        let mut doc = original.clone();
+        doc["users"][0]["user"][key] = json!("credential-canary-do-not-print");
+        cases.push(doc);
+    }
+    for key in ["tls-server-name", "proxy-url"] {
+        let mut doc = original.clone();
+        doc["clusters"][0]["cluster"][key] = json!("credential-canary-do-not-print");
+        cases.push(doc);
+    }
+    let mut doc = original.clone();
+    doc["clusters"][0]["cluster"]["insecure-skip-tls-verify"] = json!(true);
+    cases.push(doc);
+    let mut doc = original.clone();
+    doc["users"][0]["user"]["client-key"] = json!("extra.pem");
+    cases.push(doc);
+    let mut doc = original.clone();
+    doc["users"][0]["user"]["client-key-data"] =
+        json!("invalid-base64 credential-canary-do-not-print");
+    cases.push(doc);
+    let mut doc = original.clone();
+    let entry = doc["contexts"][0].clone();
+    doc["contexts"].as_array_mut().unwrap().push(entry);
+    cases.push(doc);
+    let mut doc = original.clone();
+    doc["contexts"][0]["context"]["user"] = json!("missing");
+    cases.push(doc);
+    for doc in cases {
+        let error = load(&doc, None).unwrap_err();
+        assert!(error.is_configuration());
+        assert!(!format!("{error:?}").contains("credential-canary-do-not-print"));
+        assert!(!error.to_string().contains(&pki.client_key));
+    }
+}
+
+#[test]
+fn malformed_or_oversized_input_has_safe_diagnostics() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("config");
+    std::fs::write(&path, "client-key: [credential-canary-do-not-print").unwrap();
+    let error = http_engine_from_kubeconfig(&path, None).unwrap_err();
+    assert!(!error.to_string().contains("credential-canary-do-not-print"));
+    std::fs::write(&path, vec![b'x'; 4 * 1024 * 1024 + 1]).unwrap();
+    assert!(
+        http_engine_from_kubeconfig(&path, None)
+            .unwrap_err()
+            .to_string()
+            .contains("exceeds 4 MiB")
+    );
+}

--- a/crates/facet-tui/src/app.rs
+++ b/crates/facet-tui/src/app.rs
@@ -1505,10 +1505,16 @@ impl App {
                 self.env_overlay = None;
             }
             KeyCode::Char('j') | KeyCode::Down => {
-                self.env_overlay.as_mut().expect("overlay").move_selection(1);
+                self.env_overlay
+                    .as_mut()
+                    .expect("overlay")
+                    .move_selection(1);
             }
             KeyCode::Char('k') | KeyCode::Up => {
-                self.env_overlay.as_mut().expect("overlay").move_selection(-1);
+                self.env_overlay
+                    .as_mut()
+                    .expect("overlay")
+                    .move_selection(-1);
             }
             KeyCode::Char('d') if modifiers == KeyModifiers::CONTROL => {
                 let rows = half_page_rows(&self.viewports.env);
@@ -2768,7 +2774,8 @@ impl App {
     /// is restored, reverting a previously applied file) and the footer
     /// names the file and field — invalid files never take the chrome down.
     pub fn apply_theme_file(&mut self, argument: &str) {
-        let result = theme_file::resolve_theme_path(argument).and_then(|path| ThemeFile::load(&path));
+        let result =
+            theme_file::resolve_theme_path(argument).and_then(|path| ThemeFile::load(&path));
         match result {
             Ok(file) => {
                 let name = file.name().to_string();
@@ -2776,8 +2783,8 @@ impl App {
                 self.custom_theme = Some(name);
             }
             Err(error) => {
-                self.theme_state = Theme::new(self.theme_state.appearance())
-                    .with_depth(self.theme_state.depth());
+                self.theme_state =
+                    Theme::new(self.theme_state.appearance()).with_depth(self.theme_state.depth());
                 self.custom_theme = None;
                 self.status = RunStatus::Failed(format!("theme: {error}"));
             }
@@ -3588,10 +3595,7 @@ mod tests {
         assert_eq!(overlay.rows[0].key, "token");
         assert!(!overlay.rows[0].secret);
         // The notice carries metadata only — never the value.
-        assert_eq!(
-            overlay.notice.as_deref(),
-            Some("local/token set (plain)")
-        );
+        assert_eq!(overlay.notice.as_deref(), Some("local/token set (plain)"));
 
         // `d` then anything-but-y keeps the row; `d` then `y` deletes.
         app.handle_key(KeyCode::Char('d'), KeyModifiers::NONE)

--- a/crates/facet-tui/src/app.rs
+++ b/crates/facet-tui/src/app.rs
@@ -16,7 +16,7 @@ use lattice::{
 use probe_core::{
     FolderKey, Header, HttpRequest, QueryParameter, RequestKey, RequestUpdate, resolve_request,
 };
-use probe_http::{ExecutionOptions, HttpEngine, HttpResponse};
+use probe_http::{ExecutionOptions, HttpResponse};
 use probe_opencollection::{LoadedWorkspace, SaveError, load_workspace};
 use ratatui::Terminal;
 use ratatui::backend::Backend;
@@ -2525,25 +2525,24 @@ impl App {
         tokio::spawn(async move {
             let started_at = lattice::now_ms();
             let clock = Instant::now();
-            let engine = match HttpEngine::new() {
-                Ok(engine) => engine,
-                Err(error) => {
-                    let _ = sender.send((RunResult::Err(error.to_string()), None)).await;
-                    return;
+            let engine = facet_record::http_engine_from_env();
+            let outcome = match engine {
+                Ok(engine) => {
+                    engine
+                        .execute_cancellable(&request, &options, async move {
+                            loop {
+                                if *cancel_signal.borrow() {
+                                    return;
+                                }
+                                if cancel_signal.changed().await.is_err() {
+                                    return;
+                                }
+                            }
+                        })
+                        .await
                 }
+                Err(error) => Err(error),
             };
-            let outcome = engine
-                .execute_cancellable(&request, &options, async move {
-                    loop {
-                        if *cancel_signal.borrow() {
-                            return;
-                        }
-                        if cancel_signal.changed().await.is_err() {
-                            return;
-                        }
-                    }
-                })
-                .await;
             let elapsed_ms = i64::try_from(clock.elapsed().as_millis()).unwrap_or(i64::MAX);
             // Same recording path as `facet request run`, so TUI and CLI
             // rows are identical. Store I/O is brief and off the UI loop.

--- a/crates/facet-tui/src/theme.rs
+++ b/crates/facet-tui/src/theme.rs
@@ -454,6 +454,7 @@ pub fn ansi(appearance: Appearance, kind: Role16) -> Color {
 pub enum Role256 {
     Window,
     Sidebar,
+    #[allow(dead_code)] // Retained palette role; current resolver shares Window.
     Editor,
     Raised,
     Overlay,
@@ -464,6 +465,7 @@ pub enum Role256 {
     Accent,
     AccentInverse,
     MethodGet,
+    #[allow(dead_code)] // Retained palette role; current resolver shares Accent.
     MethodPost,
     MethodPut,
     MethodPatch,
@@ -483,6 +485,7 @@ pub enum Role16 {
     Accent,
     AccentInverse,
     MethodGet,
+    #[allow(dead_code)] // Retained palette role; current resolver shares Accent.
     MethodPost,
     MethodPut,
     MethodPatch,

--- a/crates/facet-tui/src/theme_file.rs
+++ b/crates/facet-tui/src/theme_file.rs
@@ -67,15 +67,19 @@ impl ThemeFile {
             message: "theme file must be a TOML table".to_string(),
         })?;
 
-        let version = table.get("version").ok_or_else(|| ThemeFileError::MissingField {
-            path: path.to_path_buf(),
-            field: "version",
-        })?;
-        let version = version.as_integer().ok_or_else(|| ThemeFileError::InvalidField {
-            path: path.to_path_buf(),
-            field: "version".to_string(),
-            reason: "expected an integer".to_string(),
-        })?;
+        let version = table
+            .get("version")
+            .ok_or_else(|| ThemeFileError::MissingField {
+                path: path.to_path_buf(),
+                field: "version",
+            })?;
+        let version = version
+            .as_integer()
+            .ok_or_else(|| ThemeFileError::InvalidField {
+                path: path.to_path_buf(),
+                field: "version".to_string(),
+                reason: "expected an integer".to_string(),
+            })?;
         if version != THEME_FILE_VERSION {
             return Err(ThemeFileError::UnsupportedVersion {
                 path: path.to_path_buf(),
@@ -83,10 +87,12 @@ impl ThemeFile {
             });
         }
 
-        let extends_value = table.get("extends").ok_or_else(|| ThemeFileError::MissingField {
-            path: path.to_path_buf(),
-            field: "extends",
-        })?;
+        let extends_value = table
+            .get("extends")
+            .ok_or_else(|| ThemeFileError::MissingField {
+                path: path.to_path_buf(),
+                field: "extends",
+            })?;
         let extends_str = extends_value
             .as_str()
             .ok_or_else(|| ThemeFileError::InvalidField {
@@ -94,13 +100,12 @@ impl ThemeFile {
                 field: "extends".to_string(),
                 reason: "expected \"graphite\" or \"porcelain\"".to_string(),
             })?;
-        let extends = Appearance::from_flag(extends_str).ok_or_else(|| {
-            ThemeFileError::InvalidField {
+        let extends =
+            Appearance::from_flag(extends_str).ok_or_else(|| ThemeFileError::InvalidField {
                 path: path.to_path_buf(),
                 field: "extends".to_string(),
                 reason: format!("expected \"graphite\" or \"porcelain\", got {extends_str:?}"),
-            }
-        })?;
+            })?;
 
         let name = match table.get("name") {
             None => path
@@ -127,11 +132,13 @@ impl ThemeFile {
         let mut palette = Palette::for_appearance(extends);
         let mut overrides = 0;
         if let Some(colors) = table.get("colors") {
-            let colors = colors.as_table().ok_or_else(|| ThemeFileError::InvalidField {
-                path: path.to_path_buf(),
-                field: "colors".to_string(),
-                reason: "expected a table of token = \"#rrggbb\"".to_string(),
-            })?;
+            let colors = colors
+                .as_table()
+                .ok_or_else(|| ThemeFileError::InvalidField {
+                    path: path.to_path_buf(),
+                    field: "colors".to_string(),
+                    reason: "expected a table of token = \"#rrggbb\"".to_string(),
+                })?;
             for (token, value) in colors {
                 let field = format!("colors.{token}");
                 let hex = value.as_str().ok_or_else(|| ThemeFileError::InvalidField {
@@ -243,7 +250,11 @@ impl fmt::Display for ThemeFileError {
                 write!(formatter, "{}: {message}", path.display())
             }
             Self::MissingField { path, field } => {
-                write!(formatter, "{}: missing required field `{field}`", path.display())
+                write!(
+                    formatter,
+                    "{}: missing required field `{field}`",
+                    path.display()
+                )
             }
             Self::UnsupportedVersion { path, found } => write!(
                 formatter,
@@ -552,8 +563,7 @@ window_bg = "#101012"
 
     #[test]
     fn invalid_extends_rejects_the_file() {
-        let error =
-            ThemeFile::parse(path(), "version = 1\nextends = \"neon\"\n").unwrap_err();
+        let error = ThemeFile::parse(path(), "version = 1\nextends = \"neon\"\n").unwrap_err();
         assert!(matches!(
             error,
             ThemeFileError::InvalidField { field, .. } if field == "extends"

--- a/crates/facet-tui/src/tree.rs
+++ b/crates/facet-tui/src/tree.rs
@@ -33,24 +33,13 @@ impl Row {
 
 /// Sidebar state. Visible rows rebuild whenever the workspace, collapse
 /// set, or search query changes.
+#[derive(Default)]
 pub struct TreeView {
     workspace: Option<Workspace>,
     collapsed: BTreeSet<FolderKey>,
     search: String,
     visible: Vec<Row>,
     selection: usize,
-}
-
-impl Default for TreeView {
-    fn default() -> Self {
-        Self {
-            workspace: None,
-            collapsed: BTreeSet::new(),
-            search: String::new(),
-            visible: Vec::new(),
-            selection: 0,
-        }
-    }
 }
 
 impl TreeView {

--- a/crates/facet/Cargo.toml
+++ b/crates/facet/Cargo.toml
@@ -23,6 +23,9 @@ ratatui = { version = "0.30", default-features = false, features = ["crossterm"]
 serde_json = "1"
 tokio = { version = "1.53.1", features = ["rt", "rt-multi-thread", "macros", "time", "signal"] }
 
+[features]
+lattice-turso = ["lattice/lattice-turso"]
+
 [dev-dependencies]
 rusqlite = { version = "0.40", features = ["bundled"] }
 tempfile = "3"

--- a/crates/facet/src/run.rs
+++ b/crates/facet/src/run.rs
@@ -17,7 +17,7 @@ use lattice::now_ms;
 use probe_core::{
     HttpRequest, resolve_environment_with_overrides, resolve_request, resolve_request_strict,
 };
-use probe_http::{ExecutionOptions, HttpEngine, HttpError, HttpResponse};
+use probe_http::{ExecutionOptions, HttpError, HttpResponse};
 use probe_opencollection::LoadedWorkspace;
 use serde_json::{Value, json};
 
@@ -315,11 +315,12 @@ pub(crate) fn execute(
         .enable_all()
         .build()
         .map_err(|error| FacetError::runtime(&error))?;
-    let engine = HttpEngine::new().map_err(|error| FacetError::http(&error))?;
+    let engine = facet_record::http_engine_from_env();
 
     let started_at = now_ms();
     let clock = Instant::now();
     let result = runtime.block_on(async {
+        let engine = engine?;
         if let Some(output) = output {
             engine
                 .execute_cancellable_to_file(request, &options, output, tokio::signal::ctrl_c())

--- a/crates/facet/src/theme.rs
+++ b/crates/facet/src/theme.rs
@@ -8,8 +8,8 @@
 
 use std::path::Path;
 
-use facet_tui::theme_file::{self, ThemeFile};
 use facet_tui::Appearance;
+use facet_tui::theme_file::{self, ThemeFile};
 use serde_json::json;
 
 use crate::{CommandOutput, FacetError, args};
@@ -55,7 +55,9 @@ fn check(args: &[String]) -> Result<CommandOutput, FacetError> {
 fn list(args: &[String]) -> Result<CommandOutput, FacetError> {
     let parsed = args::parse(args, &[], &[])?;
     if !parsed.positionals().is_empty() {
-        return Err(FacetError::invalid_arguments("theme list takes no arguments"));
+        return Err(FacetError::invalid_arguments(
+            "theme list takes no arguments",
+        ));
     }
     let entries = theme_file::list_themes();
     let mut lines = vec!["NAME\tSOURCE\tEXTENDS\tPATH".to_owned()];

--- a/crates/facet/tests/common/mod.rs
+++ b/crates/facet/tests/common/mod.rs
@@ -56,6 +56,8 @@ impl Sandbox {
             .env_remove("FACET_ACTOR")
             .env_remove("FACET_SESSION")
             .env_remove("FACET_NO_RECORD")
+            .env_remove("FACET_KUBECONFIG")
+            .env_remove("FACET_KUBE_CONTEXT")
             // Encrypted secrets backend: deterministic, no OS keyring prompts.
             .env("FACET_SECRET_KEY", "test-master-key")
             // Session metadata picks these up when present; goldens must not.

--- a/crates/facet/tests/common/mod.rs
+++ b/crates/facet/tests/common/mod.rs
@@ -263,10 +263,10 @@ fn serve_once_at(bind: &str, body: Vec<u8>, content_type: &str) -> (String, Join
 /// Error envelopes carry volatile `message` text; category and exitCode are the contract.
 pub(crate) fn normalize_error(value: Value) -> Value {
     let mut normalized = normalize(value);
-    if let Value::Object(root) = &mut normalized {
-        if let Some(Value::Object(error)) = root.get_mut("error") {
-            error.insert("message".to_owned(), json!("<message>"));
-        }
+    if let Value::Object(root) = &mut normalized
+        && let Some(Value::Object(error)) = root.get_mut("error")
+    {
+        error.insert("message".to_owned(), json!("<message>"));
     }
     normalized
 }

--- a/crates/facet/tests/facet_commands.rs
+++ b/crates/facet/tests/facet_commands.rs
@@ -461,7 +461,7 @@ fn transport_failure_is_recorded_with_null_status() {
     let history = sandbox.run_json(&["history", sandbox.root().to_str().unwrap()]);
     let row = &history["runs"][0];
     assert!(row["status"].is_null());
-    assert!(row["error"].as_str().unwrap().len() > 0);
+    assert!(!row["error"].as_str().unwrap().is_empty());
     assert_eq!(row["response"]["body"]["retention"], "none");
 }
 
@@ -2091,4 +2091,60 @@ fn theme_list_shows_built_ins_and_discovers_files() {
             .unwrap()
             .contains("unsupported theme version 9")
     );
+}
+
+#[cfg(feature = "lattice-turso")]
+#[test]
+fn turso_records_real_http_requests_and_recalls_sessions_across_cli_processes() {
+    let sandbox = Sandbox::new();
+    fs::create_dir(sandbox.root().join("config")).unwrap();
+    fs::write(
+        sandbox.root().join("config/config.toml"),
+        "[lattice]\nengine = \"turso\"\n",
+    )
+    .unwrap();
+    let started = sandbox.run_json(&[
+        "session",
+        "start",
+        "--actor",
+        "grok",
+        "--meta",
+        r#"{"omp":"session-1","herdr":"pane-1"}"#,
+    ]);
+    let session = started["session"]["id"].as_str().unwrap();
+    let result = record_run_with(
+        &sandbox,
+        &[("FACET_SESSION", session), ("FACET_ACTOR", "grok")],
+        &[],
+    );
+    assert_eq!(result["lattice"]["recorded"], true);
+    assert_eq!(result["lattice"]["indexed"], true);
+    let id = result["lattice"]["runId"].as_str().unwrap();
+    let history = sandbox.run_json(&["history", "--session", session]);
+    assert_eq!(history["runs"].as_array().unwrap().len(), 1);
+    assert_eq!(history["runs"][0]["id"], id);
+    let shown = sandbox.run_json(&["session", "show", session]);
+    assert_eq!(shown["session"]["id"], session);
+    for path in [".facet/lattice.db", "machine/lattice.db"] {
+        assert_eq!(
+            fs::read_to_string(sandbox.root().join(path).with_added_extension("engine")).unwrap(),
+            "turso\n"
+        );
+    }
+    // Read the live CLI data through the real Rust driver, independently of the
+    // adapter's engine field. No rusqlite open is used for either Turso file.
+    let config = lattice::LatticeConfig {
+        engine: lattice::Engine::Turso,
+        ..Default::default()
+    };
+    let store = lattice::WorkspaceStore::open(sandbox.root(), config.clone()).unwrap();
+    assert_eq!(store.engine(), lattice::Engine::Turso);
+    let run = store.run(id).unwrap().unwrap();
+    assert_eq!(store.response_body(&run).unwrap().unwrap(), ECHO_BODY);
+    let machine =
+        lattice::MachineStore::open_at(&sandbox.root().join("machine/lattice.db"), &config)
+            .unwrap();
+    assert_eq!(machine.engine(), lattice::Engine::Turso);
+    assert_eq!(machine.session(session).unwrap().unwrap().actor, "grok");
+    assert_eq!(machine.count_indexed_runs().unwrap(), 1);
 }

--- a/crates/facet/tests/facet_commands.rs
+++ b/crates/facet/tests/facet_commands.rs
@@ -2148,3 +2148,38 @@ fn turso_records_real_http_requests_and_recalls_sessions_across_cli_processes() 
     assert_eq!(machine.session(session).unwrap().unwrap().actor, "grok");
     assert_eq!(machine.count_indexed_runs().unwrap(), 1);
 }
+
+#[test]
+fn cluster_configuration_failure_is_recorded_without_sending_or_exposing_credentials() {
+    let sandbox = Sandbox::new();
+    let workspace = sandbox.workspace("https://127.0.0.1:1");
+    let config = sandbox.root().join("invalid-kubeconfig");
+    fs::write(&config, "client-key: [credential-canary-do-not-print").unwrap();
+    let output = sandbox
+        .facet()
+        .env("FACET_KUBECONFIG", &config)
+        .args([
+            "request",
+            "run",
+            workspace.to_str().unwrap(),
+            "items/0",
+            "--environment",
+            "local",
+            "--json",
+        ])
+        .output()
+        .unwrap();
+    assert!(!output.status.success());
+    let text = String::from_utf8(output.stdout).unwrap();
+    assert!(!text.contains("credential-canary-do-not-print"));
+    let result: Value = serde_json::from_str(&text).unwrap();
+    assert_eq!(result["error"]["details"]["lattice"]["recorded"], true);
+    let history = sandbox.run_json(&["history"]);
+    assert_eq!(history["runs"].as_array().unwrap().len(), 1);
+    assert!(history["runs"][0]["status"].is_null());
+    assert!(
+        !history
+            .to_string()
+            .contains("credential-canary-do-not-print")
+    );
+}

--- a/crates/http/Cargo.toml
+++ b/crates/http/Cargo.toml
@@ -13,3 +13,8 @@ tokio = { version = "1.53.1", features = ["rt", "macros", "time", "fs", "net", "
 [lints]
 workspace = true
 
+
+[dev-dependencies]
+rcgen = { version = "0.14.10", default-features = false, features = ["aws_lc_rs", "pem"] }
+rustls = { version = "0.23.42", default-features = false, features = ["aws_lc_rs", "std", "tls12"] }
+tokio-rustls = "0.26.5"

--- a/crates/http/src/cluster_tls.rs
+++ b/crates/http/src/cluster_tls.rs
@@ -1,0 +1,64 @@
+//! Verified, origin-scoped client-certificate transport. No credential bytes are
+//! exposed to request serialization, recording or Debug output.
+
+use reqwest::{Certificate, Identity, Url};
+
+use crate::HttpError;
+
+/// Client-certificate credentials restricted to one HTTPS origin.
+#[derive(Clone)]
+pub struct ClusterTls {
+    pub(crate) origin: Url,
+    pub(crate) roots: Vec<Certificate>,
+    pub(crate) identity: Identity,
+}
+
+impl std::fmt::Debug for ClusterTls {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ClusterTls")
+            .field("origin", &self.origin.as_str())
+            .finish_non_exhaustive()
+    }
+}
+
+impl ClusterTls {
+    /// Parses an HTTPS server origin, trusted CA PEM bundle, and combined client
+    /// certificate/private-key PEM. Rejects insecure or ambiguous server URLs.
+    pub fn from_pem(server: &str, ca: &[u8], client_identity: &[u8]) -> Result<Self, HttpError> {
+        let origin = Url::parse(server).map_err(|_| configuration("invalid cluster server URL"))?;
+        if origin.scheme() != "https"
+            || origin.host_str().is_none()
+            || !origin.username().is_empty()
+            || origin.password().is_some()
+            || origin.query().is_some()
+            || origin.fragment().is_some()
+            || origin.path() != "/"
+        {
+            return Err(configuration(
+                "cluster server must be an HTTPS origin without userinfo, path, query or fragment",
+            ));
+        }
+        let roots = Certificate::from_pem_bundle(ca)
+            .map_err(|_| configuration("invalid cluster CA PEM bundle"))?;
+        if roots.is_empty() {
+            return Err(configuration("cluster CA PEM bundle is empty"));
+        }
+        let identity = Identity::from_pem(client_identity)
+            .map_err(|_| configuration("invalid cluster client certificate/private-key PEM"))?;
+        Ok(Self {
+            origin,
+            roots,
+            identity,
+        })
+    }
+
+    pub(crate) fn permits(&self, url: &Url) -> bool {
+        url.origin() == self.origin.origin()
+            && url.username().is_empty()
+            && url.password().is_none()
+    }
+}
+
+pub(crate) fn configuration(message: &str) -> HttpError {
+    HttpError::ClientConfiguration(message.to_owned())
+}

--- a/crates/http/src/engine.rs
+++ b/crates/http/src/engine.rs
@@ -4,7 +4,7 @@ use probe_core::{HttpRequest, RequestSettings};
 use reqwest::{Client, header::HeaderMap, redirect::Policy};
 
 use crate::{
-    ExecutionOptions, HttpError, HttpResponse, ResponseHeader,
+    ClusterTls, ExecutionOptions, HttpError, HttpResponse, ResponseHeader,
     request::build_request,
     response::{CollectedBody, collect_bounded, map_reqwest_error, stream_to_file},
 };
@@ -12,16 +12,36 @@ use crate::{
 const DEFAULT_MAX_REDIRECTS: usize = 10;
 
 /// Reusable asynchronous HTTP engine shared by every interface.
-#[derive(Clone, Debug)]
+#[derive(Clone)]
 pub struct HttpEngine {
     default_client: Client,
+    cluster_tls: Option<ClusterTls>,
+}
+
+impl std::fmt::Debug for HttpEngine {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("HttpEngine")
+            .field("cluster_tls", &self.cluster_tls)
+            .finish_non_exhaustive()
+    }
 }
 
 impl HttpEngine {
     /// Creates an engine with the default redirect policy.
     pub fn new() -> Result<Self, HttpError> {
         Ok(Self {
-            default_client: build_client(true, DEFAULT_MAX_REDIRECTS)?,
+            default_client: build_client(true, DEFAULT_MAX_REDIRECTS, None)?,
+            cluster_tls: None,
+        })
+    }
+
+    /// Creates a verified client-certificate engine restricted to one cluster.
+    /// Credential material remains in the transport and is never added to the
+    /// request model, persisted history, or presentation output.
+    pub fn with_cluster_tls(cluster_tls: ClusterTls) -> Result<Self, HttpError> {
+        Ok(Self {
+            default_client: build_client(true, DEFAULT_MAX_REDIRECTS, Some(&cluster_tls))?,
+            cluster_tls: Some(cluster_tls),
         })
     }
 
@@ -105,8 +125,28 @@ impl HttpEngine {
     ) -> Result<HttpResponse, HttpError> {
         let client = self.client_for(&request.settings)?;
         let builder = build_request(&client, request, options).await?;
+        let built = builder.build().map_err(map_reqwest_error)?;
+        if let Some(tls) = &self.cluster_tls {
+            // Validate the final URL after path/query substitution, not the
+            // template URL. Never send certificate credentials to another origin.
+            if !tls.permits(built.url()) {
+                return Err(crate::cluster_tls::configuration(
+                    "request is outside the configured cluster origin",
+                ));
+            }
+            if built.headers().keys().any(|name| {
+                matches!(
+                    name.as_str(),
+                    "authorization" | "proxy-authorization" | "host"
+                ) || name.as_str().starts_with("impersonate-")
+            }) {
+                return Err(crate::cluster_tls::configuration(
+                    "cluster certificate profile cannot be combined with authentication, Host or impersonation headers",
+                ));
+            }
+        }
         let started = Instant::now();
-        let mut response = builder.send().await.map_err(map_reqwest_error)?;
+        let mut response = client.execute(built).await.map_err(map_reqwest_error)?;
         let expected_size = response.content_length();
         let status = response.status();
         let url = response.url().to_string();
@@ -148,19 +188,44 @@ impl HttpEngine {
         if follow && maximum == DEFAULT_MAX_REDIRECTS {
             Ok(Cow::Borrowed(&self.default_client))
         } else {
-            build_client(follow, maximum).map(Cow::Owned)
+            build_client(follow, maximum, self.cluster_tls.as_ref()).map(Cow::Owned)
         }
     }
 }
 
-fn build_client(follow_redirects: bool, maximum: usize) -> Result<Client, HttpError> {
-    let policy = if follow_redirects {
-        Policy::limited(maximum)
-    } else {
+fn build_client(
+    follow_redirects: bool,
+    maximum: usize,
+    cluster_tls: Option<&ClusterTls>,
+) -> Result<Client, HttpError> {
+    let policy = if !follow_redirects {
         Policy::none()
+    } else if let Some(tls) = cluster_tls {
+        let origin = tls.origin.origin();
+        Policy::custom(move |attempt| {
+            if attempt.url().origin() != origin
+                || !attempt.url().username().is_empty()
+                || attempt.url().password().is_some()
+            {
+                attempt.error("redirect is outside the configured cluster origin")
+            } else if attempt.previous().len() >= maximum {
+                attempt.error("too many redirects")
+            } else {
+                attempt.follow()
+            }
+        })
+    } else {
+        Policy::limited(maximum)
     };
-    Client::builder()
-        .redirect(policy)
+    let mut builder = Client::builder().redirect(policy);
+    if let Some(tls) = cluster_tls {
+        builder = builder
+            .tls_certs_only(tls.roots.clone())
+            .identity(tls.identity.clone())
+            .tls_sslkeylogfile(false)
+            .no_proxy();
+    }
+    builder
         .build()
         .map_err(|error| HttpError::ClientConfiguration(error.to_string()))
 }

--- a/crates/http/src/lib.rs
+++ b/crates/http/src/lib.rs
@@ -3,12 +3,14 @@
 #![forbid(unsafe_code)]
 
 mod cache;
+mod cluster_tls;
 mod engine;
 mod error;
 mod request;
 mod response;
 
 pub use cache::{ResponseBodyFile, ResponseCache};
+pub use cluster_tls::ClusterTls;
 pub use engine::HttpEngine;
 pub use error::HttpError;
 pub use response::{HttpResponse, ResponseHeader};

--- a/crates/http/tests/cluster_tls.rs
+++ b/crates/http/tests/cluster_tls.rs
@@ -1,0 +1,237 @@
+use probe_core::{Header, HttpRequest};
+use probe_http::{ClusterTls, ExecutionOptions, HttpEngine};
+use rustls::{
+    RootCertStore, ServerConfig,
+    pki_types::{CertificateDer, PrivateKeyDer, pem::PemObject},
+    server::WebPkiClientVerifier,
+};
+use std::{sync::Arc, time::Duration};
+use tokio::{
+    io::{AsyncReadExt, AsyncWriteExt},
+    net::TcpListener,
+    task::JoinHandle,
+};
+use tokio_rustls::TlsAcceptor;
+
+#[path = "../../../tests/support/cluster_pki.rs"]
+mod cluster_pki;
+use cluster_pki::Pki;
+
+type Captures = Vec<(Vec<u8>, String)>;
+async fn server(
+    pki: &Pki,
+    responses: Vec<String>,
+) -> (String, JoinHandle<Result<Captures, String>>) {
+    let mut roots = RootCertStore::empty();
+    roots
+        .add(CertificateDer::from_pem_slice(pki.ca.as_bytes()).unwrap())
+        .unwrap();
+    let provider = Arc::new(rustls::crypto::aws_lc_rs::default_provider());
+    let verifier = WebPkiClientVerifier::builder_with_provider(Arc::new(roots), provider.clone())
+        .build()
+        .unwrap();
+    let config = ServerConfig::builder_with_provider(provider)
+        .with_safe_default_protocol_versions()
+        .unwrap()
+        .with_client_cert_verifier(verifier)
+        .with_single_cert(
+            vec![CertificateDer::from_pem_slice(pki.server_cert.as_bytes()).unwrap()],
+            PrivateKeyDer::from_pem_slice(pki.server_key.as_bytes()).unwrap(),
+        )
+        .unwrap();
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let url = format!("https://{}", listener.local_addr().unwrap());
+    let task = tokio::spawn(async move {
+        tokio::time::timeout(Duration::from_secs(5), async {
+            let acceptor = TlsAcceptor::from(Arc::new(config));
+            let mut captured = Vec::new();
+            for response in responses {
+                let (socket, _) = listener.accept().await.map_err(|e| e.to_string())?;
+                let mut stream = acceptor.accept(socket).await.map_err(|e| e.to_string())?;
+                let peer = stream.get_ref().1.peer_certificates().unwrap()[0].to_vec();
+                let mut request = Vec::new();
+                while !request.ends_with(b"\r\n\r\n") {
+                    let byte = stream.read_u8().await.map_err(|e| e.to_string())?;
+                    request.push(byte);
+                    if request.len() > 8192 {
+                        return Err("oversized request".into());
+                    }
+                }
+                captured.push((peer, String::from_utf8(request).unwrap()));
+                stream
+                    .write_all(response.as_bytes())
+                    .await
+                    .map_err(|e| e.to_string())?;
+                stream.shutdown().await.map_err(|e| e.to_string())?;
+            }
+            Ok(captured)
+        })
+        .await
+        .map_err(|e| e.to_string())?
+    });
+    (url, task)
+}
+fn ok() -> String {
+    "HTTP/1.1 200 OK\r\nContent-Length: 2\r\nConnection: close\r\n\r\nok".into()
+}
+fn request(url: String) -> HttpRequest {
+    HttpRequest {
+        method: Some("GET".into()),
+        url: Some(url),
+        ..Default::default()
+    }
+}
+fn engine(url: &str, pki: &Pki) -> HttpEngine {
+    HttpEngine::with_cluster_tls(
+        ClusterTls::from_pem(url, pki.ca.as_bytes(), pki.client_pem().as_bytes()).unwrap(),
+    )
+    .unwrap()
+}
+
+#[tokio::test]
+async fn verifies_server_and_sends_the_client_certificate_without_request_secrets() {
+    let pki = Pki::new(&["127.0.0.1"]);
+    let (url, task) = server(&pki, vec![ok()]).await;
+    let client = engine(&url, &pki);
+    let debug = format!("{client:?}");
+    assert!(!debug.contains("PRIVATE KEY"));
+    assert!(!debug.contains(&pki.client_key));
+    let response = client
+        .execute(&request(format!("{url}/api")), &ExecutionOptions::default())
+        .await
+        .unwrap();
+    assert_eq!(response.status, 200);
+    let requests = task.await.unwrap().unwrap();
+    assert_eq!(
+        requests[0].0,
+        CertificateDer::from_pem_slice(pki.client_cert.as_bytes())
+            .unwrap()
+            .to_vec()
+    );
+    assert!(requests[0].1.starts_with("GET /api HTTP/1.1"));
+    assert!(!requests[0].1.to_lowercase().contains("authorization"));
+    assert!(!requests[0].1.contains("PRIVATE KEY"));
+}
+
+#[tokio::test]
+async fn rejects_foreign_ca_client_and_wrong_hostname() {
+    for case in ["ca", "client", "hostname"] {
+        let pki = Pki::new(if case == "hostname" {
+            &["localhost"]
+        } else {
+            &["127.0.0.1"]
+        });
+        let other = Pki::new(&["127.0.0.1"]);
+        let (url, task) = server(&pki, vec![ok()]).await;
+        let tls = ClusterTls::from_pem(
+            &url,
+            if case == "ca" {
+                other.ca.as_bytes()
+            } else {
+                pki.ca.as_bytes()
+            },
+            if case == "client" {
+                other.client_pem()
+            } else {
+                pki.client_pem()
+            }
+            .as_bytes(),
+        )
+        .unwrap();
+        let client = HttpEngine::with_cluster_tls(tls).unwrap();
+        assert!(
+            client
+                .execute(&request(url), &ExecutionOptions::default())
+                .await
+                .is_err(),
+            "{case}"
+        );
+        assert!(task.await.unwrap().is_err(), "{case}");
+    }
+}
+
+#[tokio::test]
+async fn refuses_out_of_scope_urls_and_conflicting_headers_before_connecting() {
+    let pki = Pki::new(&["127.0.0.1"]);
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let url = format!("https://{}", listener.local_addr().unwrap());
+    let client = engine(&url, &pki);
+    for foreign in [
+        url.replace("https:", "http:"),
+        format!(
+            "https://localhost:{}/",
+            listener.local_addr().unwrap().port()
+        ),
+        url.replace("https://", "https://name:password@"),
+    ] {
+        assert!(
+            client
+                .execute(&request(foreign), &ExecutionOptions::default())
+                .await
+                .unwrap_err()
+                .is_configuration()
+        );
+    }
+    for name in [
+        "Authorization",
+        "Host",
+        "Proxy-Authorization",
+        "Impersonate-User",
+    ] {
+        let mut req = request(url.clone());
+        req.headers.push(Header {
+            name: name.into(),
+            value: "not-sent".into(),
+            disabled: false,
+        });
+        assert!(
+            client
+                .execute(&req, &ExecutionOptions::default())
+                .await
+                .unwrap_err()
+                .is_configuration()
+        );
+    }
+    assert!(
+        tokio::time::timeout(Duration::from_millis(100), listener.accept())
+            .await
+            .is_err()
+    );
+}
+
+#[tokio::test]
+async fn permits_same_origin_redirects_but_never_connects_to_a_foreign_target() {
+    let pki = Pki::new(&["127.0.0.1"]);
+    let (url, task) = server(&pki, vec!["HTTP/1.1 302 Found\r\nLocation: /next\r\nContent-Length: 0\r\nConnection: close\r\n\r\n".into(), ok()]).await;
+    let client = engine(&url, &pki);
+    let mut req = request(url.clone());
+    req.settings.max_redirects = Some(2); // alternate client preserves credentials/policy
+    assert_eq!(
+        client
+            .execute(&req, &ExecutionOptions::default())
+            .await
+            .unwrap()
+            .status,
+        200
+    );
+    assert!(
+        task.await.unwrap().unwrap()[1]
+            .1
+            .starts_with("GET /next HTTP/1.1")
+    );
+    let target = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let (url, task) = server(&pki, vec![format!("HTTP/1.1 302 Found\r\nLocation: https://{}/escape\r\nContent-Length: 0\r\nConnection: close\r\n\r\n", target.local_addr().unwrap())]).await;
+    let client = engine(&url, &pki);
+    assert!(
+        client
+            .execute(&request(url), &ExecutionOptions::default())
+            .await
+            .is_err()
+    );
+    assert_eq!(task.await.unwrap().unwrap().len(), 1);
+    assert!(
+        tokio::time::timeout(Duration::from_millis(100), target.accept())
+            .await
+            .is_err()
+    );
+}

--- a/crates/lattice/Cargo.toml
+++ b/crates/lattice/Cargo.toml
@@ -4,7 +4,7 @@ version.workspace = true
 edition.workspace = true
 license = "MIT"
 rust-version.workspace = true
-description = "Facet run-history store: SQLite beside the OpenCollection YAML"
+description = "Facet run-history store: SQLite or Rust Turso beside OpenCollection YAML"
 
 [dependencies]
 base64 = "0.23.1"
@@ -13,77 +13,48 @@ directories = "6"
 hkdf = "0.13.0"
 hmac = "0.13.0"
 keyring = "4.2.0"
-# Turso/libSQL backend (Surface 3/4 future; not the default engine). Optional so
-# the default build pulls no libsql/tokio. See `lattice-turso` feature below.
-libsql = { version = "0.9", optional = true }
-# DuckDB in-process analytics (apiary-only; NEVER in lathe default members).
-# The default engine stays rusqlite; DuckDB attaches SQLite files externally for
-# analytics. This optional dep is only compiled when `lattice-duckdb` is on.
-# `bundled` builds libduckdb from source (heavy C++ build) so the crate is
-# self-contained on apiary.
+# Actual Rust Turso engine, pinned to the reviewed M1 source. No libSQL and
+# no optional sync/FTS/global allocator; the local driver needs no Tokio runtime.
+turso = { git = "https://github.com/tursodatabase/turso", rev = "87c7a8516511c3ad2745c25b1079ea5c90112692", default-features = false, optional = true }
+turso_parser = { git = "https://github.com/tursodatabase/turso", rev = "87c7a8516511c3ad2745c25b1079ea5c90112692", optional = true }
+futures = { version = "0.3", default-features = false, features = ["std", "executor"], optional = true }
+# Optional SQLite analytics smoke; bundled DuckDB is a heavy native build.
+# Keep this off in ordinary installations and budget build-host resources.
 duckdb = { version = "1.10505.0", optional = true, features = ["bundled"] }
-# HedronDB knowledge-graph engine (complement to Turso; apiary-only for the
-# smoke). `hedron-core` is a separate repo (publish = false), pulled as a git
-# dep only when `lattice-hedron` is on, pinned to the `facet-pin-align` proposal
-# branch which bumps `rusqlite` to 0.40 (bundled) to match this crate's 0.40
-# (bundled) — both engines share one `libsqlite3-sys` and coexist in one binary
-# (the `links = "sqlite3"` blocker is resolved by the alignment, not patched).
-# Not the default engine; never in lathe default-members. See
-# `agents/backend/notes/2026-09-07-evaluate-hedrondb.md` and `docs/FACET.md`
-# § Engines.
+# Separate knowledge-graph store. This existing coexistence smoke uses the
+# upstream rusqlite-aligned proposal pin; it is not an intent/HQL adapter.
 hedron-core = { git = "https://github.com/VirtualMachinist/hedrondb", rev = "c7210486f915b19d6b1cb9a8d9e0bea25782bb1c", optional = true }
 rand = "0.9"
-rusqlite = { version = "0.40", features = ["bundled"] }
+rusqlite = { version = "0.40", features = ["bundled", "hooks"] }
 serde = { version = "1", features = ["derive"] }
 sha2 = "0.11"
 toml = "1"
 
 [dev-dependencies]
-rusqlite = { version = "0.40", features = ["bundled"] }
+rusqlite = { version = "0.40", features = ["bundled", "hooks"] }
 tempfile = "3"
-# Only referenced by the `lattice-turso` smoke test (gated by
-# `required-features` on the `turso` test target), so a default
-# `cargo test -p lattice` (feature off) never compiles tokio.
+# The Turso application test also verifies use from inside a Tokio runtime.
 tokio = { version = "1.53.1", default-features = false, features = ["macros", "rt"] }
 
 [features]
-# Turso/libSQL backend. Same on-disk file format as rusqlite (libSQL is a
-# SQLite fork); flipping the flag requires no migration. Not the default
-# engine — rusqlite stays the default. Enables libsql (tokio is already a
-# dev-dep, used only by the gated smoke test).
-lattice-turso = ["dep:libsql"]
-# DuckDB in-process analytics. APIARY-ONLY: never enabled in lathe default
-# members. The default engine stays rusqlite; DuckDB attaches the SQLite
-# lattice file externally for analytics (see the `lattice-duckdb` smoke test
-# and `agents/backend/notes/`). Heavy native build; only compile on apiary.
+# Compiles the Rust Turso adapter. Runtime selection remains explicit in config.
+lattice-turso = ["dep:turso", "dep:turso_parser", "dep:futures"]
+# Optional in-process analytics against SQLite stores.
 lattice-duckdb = ["dep:duckdb"]
-# HedronDB knowledge-graph engine (complement to Turso). APIARY-ONLY: never
-# enabled in lathe default members. `hedron-core` is a separate-schema store
-# (nodes/edges/desired_states/events, HQL — not SQL over `lattice.db`), so it
-# is a projection complement, not a same-file read engine like Turso. The
-# gated smoke proves coexistence (hedron-core + this crate's rusqlite 0.40 link
-# and run in one binary); the projection mapping is a later slice. Not the
-# default engine. See `docs/FACET.md` § Engines.
+# Separate-schema HedronDB coexistence smoke, not a Lattice storage engine.
 lattice-hedron = ["dep:hedron-core"]
 
-# Feature-gated Turso smoke test: only built when `lattice-turso` is on, so a
-# default `cargo test -p lattice` (feature off) never pulls libsql/tokio.
+# Application storage contract tests for the actual Rust Turso backend.
 [[test]]
 name = "turso"
 required-features = ["lattice-turso"]
 
-# Feature-gated DuckDB in-process smoke test: only built when
-# `lattice-duckdb` is on. Never run on lathe.
+# Optional heavy analytics smoke.
 [[test]]
 name = "duckdb"
 required-features = ["lattice-duckdb"]
 
-# Feature-gated HedronDB smoke test: only built when `lattice-hedron` is on.
-# Never run on lathe (apiary-only). Proves hedron-core can open its own store
-# and answer an HQL read inside the lattice test binary that also links
-# rusqlite 0.40 (the default engine) — i.e. the two bundled-SQLite engines
-# coexist. It does NOT open `lattice.db` (hedron-core's Store bootstraps its
-# own schema; see the evaluate note).
+# Separate HedronDB store plus SQLite Lattice in one binary.
 [[test]]
 name = "hedron"
 required-features = ["lattice-hedron"]

--- a/crates/lattice/src/config.rs
+++ b/crates/lattice/src/config.rs
@@ -40,9 +40,33 @@ impl fmt::Display for Retention {
     }
 }
 
+/// Engine used for both workspace history and machine state.
+#[derive(Clone, Copy, Debug, Default, Deserialize, Eq, PartialEq)]
+#[serde(rename_all = "lowercase")]
+pub enum Engine {
+    /// Bundled SQLite, the default for existing installations.
+    #[default]
+    Sqlite,
+    /// The Rust tursodatabase/turso engine (requires `lattice-turso`).
+    Turso,
+}
+
+impl Engine {
+    /// Stable engine identifier used by configuration and database markers.
+    #[must_use]
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Sqlite => "sqlite",
+            Self::Turso => "turso",
+        }
+    }
+}
+
 /// Effective Lattice configuration.
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct LatticeConfig {
+    /// Explicit storage engine; compilation alone never changes it.
+    pub engine: Engine,
     /// Bodies at or under this many bytes are stored inline in the row.
     pub inline_body_max: u64,
     /// Run retention window applied by `gc`.
@@ -56,6 +80,7 @@ pub struct LatticeConfig {
 impl Default for LatticeConfig {
     fn default() -> Self {
         Self {
+            engine: Engine::Sqlite,
             inline_body_max: DEFAULT_INLINE_BODY_MAX,
             history_retention: Retention::Unlimited,
             wal: true,
@@ -108,6 +133,7 @@ struct ConfigFile {
 
 #[derive(Debug, Default, Deserialize)]
 struct LatticeSection {
+    engine: Option<Engine>,
     inline_body_max: Option<String>,
     history_retention: Option<String>,
     wal: Option<bool>,
@@ -143,6 +169,9 @@ impl LatticeConfig {
     pub fn apply_source(&mut self, source: &str) -> Result<(), ConfigError> {
         let file: ConfigFile =
             toml::from_str(source).map_err(|error| ConfigError::Toml(error.to_string()))?;
+        if let Some(value) = file.lattice.engine {
+            self.engine = value;
+        }
         if let Some(value) = file.lattice.inline_body_max {
             self.inline_body_max = parse_byte_size(&value)?;
         }
@@ -236,5 +265,41 @@ mod tests {
         let mut config = LatticeConfig::default();
         config.apply_source("").unwrap();
         assert_eq!(config, LatticeConfig::default());
+    }
+}
+
+#[cfg(test)]
+mod engine_tests {
+    use super::*;
+
+    #[test]
+    fn engine_is_explicit_and_unknown_names_are_rejected() {
+        let mut config = LatticeConfig::default();
+        assert_eq!(config.engine, Engine::Sqlite);
+        config
+            .apply_source("[lattice]\nengine = \"turso\"")
+            .unwrap();
+        assert_eq!(config.engine, Engine::Turso);
+        assert!(
+            config
+                .apply_source("[lattice]\nengine = \"libsql\"")
+                .is_err()
+        );
+    }
+
+    #[cfg(not(feature = "lattice-turso"))]
+    #[test]
+    fn unavailable_engine_never_creates_a_sqlite_database() {
+        let dir = tempfile::tempdir().unwrap();
+        let config = LatticeConfig {
+            engine: Engine::Turso,
+            ..LatticeConfig::default()
+        };
+        assert!(matches!(
+            crate::WorkspaceStore::open(dir.path(), config),
+            Err(crate::LatticeError::Engine(_))
+        ));
+        assert!(!dir.path().join(".facet/lattice.db").exists());
+        assert!(!dir.path().join(".facet/lattice.db.engine").exists());
     }
 }

--- a/crates/lattice/src/database.rs
+++ b/crates/lattice/src/database.rs
@@ -1,0 +1,518 @@
+//! Narrow synchronous storage boundary shared by both Lattice stores.
+//!
+//! The local Turso driver polls its own I/O and does not need Tokio. Using the
+//! futures executor preserves the existing synchronous application API, including
+//! callers already inside Tokio. Like SQLite, this work belongs off the UI thread.
+//! SQL, migrations, bodies and application semantics stay in store/machine.
+
+use std::{fs, io::Write, ops::Deref, path::Path, time::Duration};
+
+#[cfg(feature = "lattice-turso")]
+use futures::executor::block_on;
+use rusqlite::{
+    ToSql,
+    types::{FromSql, FromSqlError, ToSqlOutput, Value, ValueRef},
+};
+
+use crate::{Engine, LatticeConfig, LatticeError, io_error};
+
+type Result<T> = std::result::Result<T, LatticeError>;
+
+pub(crate) enum Connection {
+    Sqlite(rusqlite::Connection),
+    #[cfg(feature = "lattice-turso")]
+    Turso {
+        conn: turso::Connection,
+        _database: turso::Database,
+    },
+}
+
+impl std::fmt::Debug for Connection {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("Connection")
+            .field("engine", &self.engine())
+            .finish_non_exhaustive()
+    }
+}
+
+impl Connection {
+    pub(crate) fn open(path: &Path, config: &LatticeConfig, read_only: bool) -> Result<Self> {
+        #[cfg(not(feature = "lattice-turso"))]
+        if config.engine == Engine::Turso {
+            return Err(LatticeError::Engine(
+                "Turso requires a build with the lattice-turso feature".into(),
+            ));
+        }
+        #[cfg(feature = "lattice-turso")]
+        if config.engine == Engine::Turso && !config.wal {
+            return Err(LatticeError::Engine(
+                "the Turso backend requires wal = true".into(),
+            ));
+        }
+        verify_engine(path, config.engine, read_only)?;
+        let connection = match config.engine {
+            Engine::Sqlite => {
+                let flags = if read_only {
+                    rusqlite::OpenFlags::SQLITE_OPEN_READ_ONLY
+                } else {
+                    rusqlite::OpenFlags::SQLITE_OPEN_READ_WRITE
+                        | rusqlite::OpenFlags::SQLITE_OPEN_CREATE
+                };
+                let conn = rusqlite::Connection::open_with_flags(path, flags)?;
+                conn.busy_timeout(Duration::from_millis(config.busy_timeout_ms))?;
+                if read_only {
+                    conn.pragma_update(None, "query_only", true)?;
+                    // ATTACH is considered read-only by SQLite, even with a
+                    // comment prefix. Authorize the parsed action, not a token.
+                    conn.authorizer(Some(|ctx: rusqlite::hooks::AuthContext<'_>| {
+                        match ctx.action {
+                            rusqlite::hooks::AuthAction::Attach { .. }
+                            | rusqlite::hooks::AuthAction::Detach { .. } => {
+                                rusqlite::hooks::Authorization::Deny
+                            }
+                            _ => rusqlite::hooks::Authorization::Allow,
+                        }
+                    }))?;
+                } else if config.wal {
+                    conn.pragma_update(None, "journal_mode", "WAL")?;
+                    conn.pragma_update(None, "synchronous", "NORMAL")?;
+                }
+                Self::Sqlite(conn)
+            }
+            #[cfg(feature = "lattice-turso")]
+            Engine::Turso => {
+                let name = path.to_str().ok_or_else(|| {
+                    LatticeError::Engine("Turso database path must be UTF-8".into())
+                })?;
+                let database = block_on(
+                    turso::Builder::new_local(name)
+                        .read_only(read_only)
+                        .experimental_multiprocess_wal(true)
+                        .build(),
+                )?;
+                let conn = database.connect()?;
+                conn.busy_timeout(Duration::from_millis(config.busy_timeout_ms))?;
+                Self::Turso {
+                    conn,
+                    _database: database,
+                }
+            }
+            #[cfg(not(feature = "lattice-turso"))]
+            Engine::Turso => unreachable!("feature checked before any filesystem change"),
+        };
+        Ok(connection)
+    }
+
+    pub(crate) fn engine(&self) -> Engine {
+        match self {
+            Self::Sqlite(_) => Engine::Sqlite,
+            #[cfg(feature = "lattice-turso")]
+            Self::Turso { .. } => Engine::Turso,
+        }
+    }
+
+    pub(crate) fn execute(&self, sql: &str, params: impl Bind) -> Result<usize> {
+        let values = params.values()?;
+        match self {
+            Self::Sqlite(conn) => Ok(conn.execute(sql, rusqlite::params_from_iter(values))?),
+            #[cfg(feature = "lattice-turso")]
+            Self::Turso { conn, .. } => {
+                let changed = block_on(conn.execute(
+                    sql,
+                    turso::params_from_iter(values.into_iter().map(to_turso)),
+                ))?;
+                usize::try_from(changed)
+                    .map_err(|_| LatticeError::Engine("affected row count exceeds usize".into()))
+            }
+        }
+    }
+
+    pub(crate) fn execute_batch(&self, sql: &str) -> Result<()> {
+        match self {
+            Self::Sqlite(conn) => Ok(conn.execute_batch(sql)?),
+            #[cfg(feature = "lattice-turso")]
+            Self::Turso { conn, .. } => Ok(block_on(conn.execute_batch(sql))?),
+        }
+    }
+
+    pub(crate) fn prepare(&self, sql: &str) -> Result<Statement<'_>> {
+        match self {
+            Self::Sqlite(conn) => Ok(Statement::Sqlite(conn.prepare_cached(sql)?)),
+            #[cfg(feature = "lattice-turso")]
+            Self::Turso { conn, .. } => Ok(Statement::Turso(block_on(conn.prepare_cached(sql))?)),
+        }
+    }
+
+    pub(crate) fn prepare_read_only(&self, sql: &str) -> Result<Statement<'_>> {
+        #[cfg(feature = "lattice-turso")]
+        if matches!(self, Self::Turso { .. }) {
+            use turso_parser::{
+                ast::{Cmd, Stmt},
+                parser::Parser,
+            };
+            let mut parser = Parser::new(sql.as_bytes());
+            let command = parser
+                .next_cmd()
+                .map_err(|error| LatticeError::Query(error.to_string()))?;
+            // SELECT includes read-only WITH/VALUES/UNION. Refuse ATTACH,
+            // PRAGMA assignments, DML and multi-statement inputs before prepare.
+            if !matches!(
+                command,
+                Some(
+                    Cmd::Stmt(Stmt::Select(_))
+                        | Cmd::Explain(Stmt::Select(_))
+                        | Cmd::ExplainQueryPlan {
+                            stmt: Stmt::Select(_),
+                            ..
+                        }
+                )
+            ) {
+                return Err(LatticeError::ReadOnlyQuery);
+            }
+            if parser
+                .next_cmd()
+                .map_err(|error| LatticeError::Query(error.to_string()))?
+                .is_some()
+            {
+                return Err(LatticeError::ReadOnlyQuery);
+            }
+        }
+        let statement = self.prepare(sql).map_err(|error| {
+            // Preserve driver errors (I/O, corruption, busy) as storage errors.
+            #[cfg(feature = "lattice-turso")]
+            if let LatticeError::Turso(turso::Error::Error(message)) = &error {
+                return LatticeError::Query(message.clone());
+            }
+            if let LatticeError::Sqlite(rusqlite::Error::SqliteFailure(failure, _)) = &error
+                && failure.code == rusqlite::ErrorCode::AuthorizationForStatementDenied
+            {
+                return LatticeError::ReadOnlyQuery;
+            }
+            error
+        })?;
+        #[allow(irrefutable_let_patterns)]
+        if let Statement::Sqlite(inner) = &statement
+            && !inner.readonly()
+        {
+            return Err(LatticeError::ReadOnlyQuery);
+        }
+        Ok(statement)
+    }
+
+    pub(crate) fn query_row<T>(
+        &self,
+        sql: &str,
+        params: impl Bind,
+        f: impl FnOnce(&Row) -> rusqlite::Result<T>,
+    ) -> Result<T> {
+        let mut statement = self.prepare(sql)?;
+        let mut rows = statement.query(params)?;
+        let row = rows.next()?.ok_or(rusqlite::Error::QueryReturnedNoRows)?;
+        Ok(f(row)?)
+    }
+
+    pub(crate) fn transaction(&self) -> Result<Transaction<'_>> {
+        self.execute_batch("BEGIN IMMEDIATE")?;
+        Ok(Transaction {
+            conn: self,
+            committed: false,
+        })
+    }
+}
+
+/// Never infer Turso compatibility from a SQLite header. Legacy unmarked files
+/// belong to SQLite; changing configuration cannot silently convert them.
+fn verify_engine(path: &Path, engine: Engine, read_only: bool) -> Result<()> {
+    let marker = path.with_added_extension("engine");
+    match fs::read_to_string(&marker) {
+        Ok(value) if value == format!("{}\n", engine.as_str()) => return Ok(()),
+        Ok(value) => {
+            return Err(LatticeError::Engine(format!(
+                "{} belongs to {:?}, requested {}; use a separate store or explicit conversion",
+                path.display(),
+                value.trim(),
+                engine.as_str()
+            )));
+        }
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+        Err(error) => return Err(io_error(&marker, error)),
+    }
+    if path.exists() && engine != Engine::Sqlite {
+        return Err(LatticeError::Engine(format!(
+            "{} is an unmarked SQLite store; refusing a Turso open",
+            path.display()
+        )));
+    }
+    if read_only {
+        if engine == Engine::Sqlite {
+            return Ok(());
+        }
+        return Err(LatticeError::Engine(
+            "Turso store is missing its engine marker".into(),
+        ));
+    }
+    match fs::OpenOptions::new()
+        .write(true)
+        .create_new(true)
+        .open(&marker)
+    {
+        Ok(mut file) => {
+            writeln!(file, "{}", engine.as_str()).map_err(|error| io_error(&marker, error))?;
+            file.sync_all().map_err(|error| io_error(&marker, error))?;
+            Ok(())
+        }
+        Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => {
+            verify_engine(path, engine, true)
+        }
+        Err(error) => Err(io_error(&marker, error)),
+    }
+}
+
+pub(crate) trait Bind {
+    fn values(self) -> rusqlite::Result<Vec<Value>>;
+}
+impl Bind for [Value; 0] {
+    fn values(self) -> rusqlite::Result<Vec<Value>> {
+        Ok(Vec::new())
+    }
+}
+impl Bind for Vec<Value> {
+    fn values(self) -> rusqlite::Result<Vec<Value>> {
+        Ok(self)
+    }
+}
+impl Bind for &[&dyn ToSql] {
+    fn values(self) -> rusqlite::Result<Vec<Value>> {
+        self.iter()
+            .map(|value| match value.to_sql()? {
+                ToSqlOutput::Borrowed(value) => Value::column_result(value)
+                    .map_err(|error| rusqlite::Error::ToSqlConversionFailure(Box::new(error))),
+                ToSqlOutput::Owned(value) => Ok(value),
+                _ => Err(rusqlite::Error::InvalidParameterName(
+                    "unsupported Lattice parameter type".into(),
+                )),
+            })
+            .collect()
+    }
+}
+
+pub(crate) enum Statement<'conn> {
+    Sqlite(rusqlite::CachedStatement<'conn>),
+    #[cfg(feature = "lattice-turso")]
+    Turso(turso::Statement),
+}
+impl Statement<'_> {
+    pub(crate) fn column_names(&self) -> Vec<String> {
+        match self {
+            Self::Sqlite(stmt) => stmt.column_names().into_iter().map(str::to_owned).collect(),
+            #[cfg(feature = "lattice-turso")]
+            Self::Turso(stmt) => stmt.column_names(),
+        }
+    }
+    pub(crate) fn query(&mut self, params: impl Bind) -> Result<Rows<'_>> {
+        let values = params.values()?;
+        let inner = match self {
+            Self::Sqlite(stmt) => {
+                RowsInner::Sqlite(stmt.query(rusqlite::params_from_iter(values))?)
+            }
+            #[cfg(feature = "lattice-turso")]
+            Self::Turso(stmt) => RowsInner::Turso(block_on(
+                stmt.query(turso::params_from_iter(values.into_iter().map(to_turso))),
+            )?),
+        };
+        Ok(Rows {
+            inner,
+            current: None,
+        })
+    }
+    pub(crate) fn query_map<'a, T, F: FnMut(&Row) -> rusqlite::Result<T> + 'a>(
+        &'a mut self,
+        params: impl Bind,
+        f: F,
+    ) -> Result<impl Iterator<Item = Result<T>> + 'a> {
+        let mut rows = self.query(params)?;
+        let mut f = f;
+        let mut ended = false;
+        Ok(std::iter::from_fn(move || {
+            if ended {
+                return None;
+            }
+            match rows.next() {
+                Ok(Some(row)) => Some(f(row).map_err(Into::into)),
+                Ok(None) => {
+                    ended = true;
+                    None
+                }
+                Err(error) => {
+                    ended = true;
+                    Some(Err(error))
+                }
+            }
+        }))
+    }
+}
+
+enum RowsInner<'stmt> {
+    Sqlite(rusqlite::Rows<'stmt>),
+    #[cfg(feature = "lattice-turso")]
+    Turso(turso::Rows),
+}
+pub(crate) struct Rows<'stmt> {
+    inner: RowsInner<'stmt>,
+    current: Option<Row>,
+}
+impl Rows<'_> {
+    pub(crate) fn next(&mut self) -> Result<Option<&Row>> {
+        self.current = match &mut self.inner {
+            RowsInner::Sqlite(rows) => rows
+                .next()?
+                .map(|row| {
+                    (0..row.as_ref().column_count())
+                        .map(|index| row.get(index))
+                        .collect::<rusqlite::Result<Vec<Value>>>()
+                        .map(Row)
+                })
+                .transpose()?,
+            #[cfg(feature = "lattice-turso")]
+            RowsInner::Turso(rows) => block_on(rows.next())?
+                .map(|row| {
+                    (0..row.column_count())
+                        .map(|index| row.get_value(index).map(from_turso))
+                        .collect::<turso::Result<Vec<Value>>>()
+                        .map(Row)
+                })
+                .transpose()?,
+        };
+        Ok(self.current.as_ref())
+    }
+}
+pub(crate) struct Row(Vec<Value>);
+impl Row {
+    pub(crate) fn get<T: FromSql>(&self, index: usize) -> rusqlite::Result<T> {
+        let value = self
+            .0
+            .get(index)
+            .ok_or(rusqlite::Error::InvalidColumnIndex(index))?;
+        T::column_result(ValueRef::from(value)).map_err(|error| match error {
+            FromSqlError::InvalidType => {
+                rusqlite::Error::InvalidColumnType(index, index.to_string(), value.data_type())
+            }
+            FromSqlError::OutOfRange(value) => {
+                rusqlite::Error::IntegralValueOutOfRange(index, value)
+            }
+            other => {
+                rusqlite::Error::FromSqlConversionFailure(index, value.data_type(), Box::new(other))
+            }
+        })
+    }
+}
+
+pub(crate) struct Transaction<'conn> {
+    conn: &'conn Connection,
+    committed: bool,
+}
+impl Deref for Transaction<'_> {
+    type Target = Connection;
+    fn deref(&self) -> &Connection {
+        self.conn
+    }
+}
+impl Transaction<'_> {
+    pub(crate) fn commit(mut self) -> Result<()> {
+        self.conn.execute_batch("COMMIT")?;
+        self.committed = true;
+        Ok(())
+    }
+}
+impl Drop for Transaction<'_> {
+    fn drop(&mut self) {
+        if !self.committed {
+            let _ = self.conn.execute_batch("ROLLBACK");
+        }
+    }
+}
+
+#[cfg(feature = "lattice-turso")]
+fn to_turso(value: Value) -> turso::Value {
+    match value {
+        Value::Null => turso::Value::Null,
+        Value::Integer(v) => turso::Value::Integer(v),
+        Value::Real(v) => turso::Value::Real(v),
+        Value::Text(v) => turso::Value::Text(v),
+        Value::Blob(v) => turso::Value::Blob(v),
+    }
+}
+#[cfg(feature = "lattice-turso")]
+fn from_turso(value: turso::Value) -> Value {
+    match value {
+        turso::Value::Null => Value::Null,
+        turso::Value::Integer(v) => Value::Integer(v),
+        turso::Value::Real(v) => Value::Real(v),
+        turso::Value::Text(v) => Value::Text(v),
+        turso::Value::Blob(v) => Value::Blob(v),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn failed_transaction_rolls_back_on_each_engine() {
+        let mut engines = vec![Engine::Sqlite];
+        if cfg!(feature = "lattice-turso") {
+            engines.push(Engine::Turso);
+        }
+        for engine in engines {
+            let dir = tempfile::tempdir().unwrap();
+            let conn = Connection::open(
+                &dir.path().join("transaction.db"),
+                &LatticeConfig {
+                    engine,
+                    ..LatticeConfig::default()
+                },
+                false,
+            )
+            .unwrap();
+            conn.execute_batch(
+                "CREATE TABLE entries (id INTEGER PRIMARY KEY, value TEXT NOT NULL)",
+            )
+            .unwrap();
+            {
+                let tx = conn.transaction().unwrap();
+                tx.execute("INSERT INTO entries VALUES (1, 'first')", [])
+                    .unwrap();
+                assert!(
+                    tx.execute("INSERT INTO entries VALUES (1, 'duplicate')", [])
+                        .is_err()
+                );
+            }
+            assert_eq!(
+                conn.query_row("SELECT count(*) FROM entries", [], |row| row.get::<i64>(0))
+                    .unwrap(),
+                0
+            );
+            let tx = conn.transaction().unwrap();
+            tx.execute("INSERT INTO entries VALUES (2, 'committed')", [])
+                .unwrap();
+            tx.commit().unwrap();
+            assert_eq!(
+                conn.query_row("SELECT count(*) FROM entries", [], |row| row.get::<i64>(0))
+                    .unwrap(),
+                1
+            );
+        }
+    }
+
+    #[test]
+    fn sqlite_authorizer_blocks_commented_attach() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = crate::WorkspaceStore::open(dir.path(), LatticeConfig::default()).unwrap();
+        for sql in [
+            "/* prefix */ ATTACH ':memory:' AS other",
+            "-- prefix\nATTACH ':memory:' AS other",
+        ] {
+            assert!(matches!(store.query(sql), Err(LatticeError::ReadOnlyQuery)));
+        }
+    }
+}

--- a/crates/lattice/src/lib.rs
+++ b/crates/lattice/src/lib.rs
@@ -2,7 +2,7 @@
 //!
 //! Lattice sits beside an OpenCollection workspace and remembers every run.
 //! It never holds the collection itself; OpenCollection YAML on disk stays
-//! canonical and Git stays the sync layer. Two SQLite files:
+//! canonical and Git stays the sync layer. Two separate database files:
 //!
 //! - **Workspace store** `.facet/lattice.db` next to the YAML. Run history
 //!   for that workspace. Bodies are inline at or under `inline_body_max`,
@@ -11,20 +11,15 @@
 //!   Cross-workspace state: workspace registry, run index, sessions,
 //!   environments, preferences.
 //!
-//! Decisions and defaults come from `FACET_HANDOFF_BRIEF.md` (Surfaces 1,
-//! 3, 4, 5). Engine order: bundled SQLite now, Turso behind a feature later.
-//! DuckDB ATTACHes the SQLite file out of process (`scripts/duckdb-attach-demo.sh`);
-//! the in-process `lattice-duckdb` feature is apiary-only, never lathe.
-//!
-//! **Next slice** (sessions, recall, replay, hash-diff, secret hydration,
-//! `--expect`): `docs/FACET.md` § Next slice. The `sessions` table and
-//! [`WorkspaceStore::run`] exist; they have no CLI yet. `FACET_SESSION` is
-//! written onto the run row without minting a parent session.
+//! Bundled SQLite is the default. With `lattice-turso`, explicit configuration
+//! selects the actual Rust Turso engine for both stores. See
+//! `docs/LATTICE-ENGINES.md` for pins, file safety, configuration and limitations.
 
 #![forbid(unsafe_code)]
 
 mod blobs;
 mod config;
+mod database;
 mod machine;
 mod secrets;
 mod store;
@@ -33,7 +28,7 @@ mod ulid;
 use std::{fmt, io, path::PathBuf};
 
 pub use blobs::{BodyInput, StoredBody, sha256_hex};
-pub use config::{ConfigError, LatticeConfig, Retention, parse_byte_size, parse_retention};
+pub use config::{ConfigError, Engine, LatticeConfig, Retention, parse_byte_size, parse_retention};
 pub use machine::{
     EnvironmentRow, MachineStore, SessionQuery, SessionRow, machine_config_dir, machine_data_dir,
 };
@@ -57,6 +52,13 @@ pub const MACHINE_SCHEMA_VERSION: i64 = 2;
 /// Failures raised by Lattice.
 #[derive(Debug)]
 pub enum LatticeError {
+    /// The selected database engine cannot be opened with this configuration.
+    Engine(String),
+    /// A caller-provided SQL statement could not be parsed or prepared.
+    Query(String),
+    /// Actual Rust Turso driver failure; never mapped to a SQLite fallback.
+    #[cfg(feature = "lattice-turso")]
+    Turso(turso::Error),
     /// SQLite reported an error.
     Sqlite(rusqlite::Error),
     /// A filesystem operation failed.
@@ -79,6 +81,10 @@ pub enum LatticeError {
 impl fmt::Display for LatticeError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
+            Self::Engine(message) => write!(f, "lattice engine error: {message}"),
+            Self::Query(message) => write!(f, "lattice query error: {message}"),
+            #[cfg(feature = "lattice-turso")]
+            Self::Turso(error) => write!(f, "lattice Turso error: {error}"),
             Self::Sqlite(error) => write!(f, "lattice store error: {error}"),
             Self::Io { path, source } => {
                 write!(f, "lattice I/O error at {}: {source}", path.display())
@@ -101,6 +107,9 @@ impl std::error::Error for LatticeError {
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
         match self {
             Self::Sqlite(error) => Some(error),
+            Self::Engine(_) | Self::Query(_) => None,
+            #[cfg(feature = "lattice-turso")]
+            Self::Turso(error) => Some(error),
             Self::Io { source, .. } => Some(source),
             Self::Config(error) => Some(error),
             Self::Secret(error) => Some(error),
@@ -112,6 +121,13 @@ impl std::error::Error for LatticeError {
 impl From<rusqlite::Error> for LatticeError {
     fn from(error: rusqlite::Error) -> Self {
         Self::Sqlite(error)
+    }
+}
+
+#[cfg(feature = "lattice-turso")]
+impl From<turso::Error> for LatticeError {
+    fn from(error: turso::Error) -> Self {
+        Self::Turso(error)
     }
 }
 
@@ -133,7 +149,7 @@ impl LatticeError {
     #[must_use]
     pub fn is_query_error(&self) -> bool {
         match self {
-            Self::ReadOnlyQuery => true,
+            Self::ReadOnlyQuery | Self::Query(_) => true,
             Self::Sqlite(rusqlite::Error::SqliteFailure(failure, _)) => {
                 failure.code == rusqlite::ErrorCode::Unknown
                     || failure.code == rusqlite::ErrorCode::ReadOnly

--- a/crates/lattice/src/machine.rs
+++ b/crates/lattice/src/machine.rs
@@ -5,7 +5,8 @@ use std::{
     path::{Path, PathBuf},
 };
 
-use rusqlite::{Connection, params, types::Value};
+use crate::database::{Connection, Row};
+use rusqlite::{params, types::Value};
 
 use crate::{
     DB_FILE, LatticeConfig, LatticeError, RunRow, io_error,
@@ -109,13 +110,19 @@ impl MachineStore {
         &self.path
     }
 
+    /// Engine executing operations for this store.
+    #[must_use]
+    pub fn engine(&self) -> crate::Engine {
+        self.conn.engine()
+    }
+
     /// Highest applied migration.
     pub fn schema_version(&self) -> Result<i64, LatticeError> {
-        Ok(self.conn.query_row(
+        self.conn.query_row(
             "SELECT coalesce(max(version), 0) FROM schema_version",
             [],
             |row| row.get(0),
-        )?)
+        )
     }
 
     /// Registers or refreshes a workspace.
@@ -183,16 +190,15 @@ impl MachineStore {
             |row| Ok((row.get(0)?, row.get(1)?)),
         ) {
             Ok(pair) => Ok(Some(pair)),
-            Err(rusqlite::Error::QueryReturnedNoRows) => Ok(None),
-            Err(other) => Err(other.into()),
+            Err(LatticeError::Sqlite(rusqlite::Error::QueryReturnedNoRows)) => Ok(None),
+            Err(other) => Err(other),
         }
     }
 
     /// Total pointer rows.
     pub fn count_indexed_runs(&self) -> Result<i64, LatticeError> {
-        Ok(self
-            .conn
-            .query_row("SELECT count(*) FROM run_index", [], |row| row.get(0))?)
+        self.conn
+            .query_row("SELECT count(*) FROM run_index", [], |row| row.get(0))
     }
 
     // ----- Sessions (Goal 1) --------------------------------------------
@@ -251,8 +257,8 @@ impl MachineStore {
             row_to_session,
         ) {
             Ok(row) => Some(row),
-            Err(rusqlite::Error::QueryReturnedNoRows) => None,
-            Err(other) => return Err(other.into()),
+            Err(LatticeError::Sqlite(rusqlite::Error::QueryReturnedNoRows)) => None,
+            Err(other) => return Err(other),
         };
         Ok(row)
     }
@@ -279,7 +285,7 @@ impl MachineStore {
         ));
 
         let mut statement = self.conn.prepare(&sql)?;
-        let mut rows = statement.query(rusqlite::params_from_iter(values))?;
+        let mut rows = statement.query(values)?;
         let mut out = Vec::new();
         while let Some(row) = rows.next()? {
             out.push(row_to_session(row)?);
@@ -304,11 +310,11 @@ impl MachineStore {
         match self.conn.query_row(
             "SELECT value FROM preferences WHERE key = ?1",
             params![key],
-            |row| row.get::<_, String>(0),
+            |row| row.get::<String>(0),
         ) {
             Ok(value) => Ok(Some(value)),
-            Err(rusqlite::Error::QueryReturnedNoRows) => Ok(None),
-            Err(other) => Err(other.into()),
+            Err(LatticeError::Sqlite(rusqlite::Error::QueryReturnedNoRows)) => Ok(None),
+            Err(other) => Err(other),
         }
     }
 
@@ -375,11 +381,11 @@ impl MachineStore {
         let old_ref: Option<String> = match self.conn.query_row(
             "SELECT secret_ref FROM environments WHERE workspace_id = ?1 AND name = ?2 AND key = ?3",
             params![workspace_id, name, key],
-            |row| row.get::<_, Option<String>>(0),
+            |row| row.get::<Option<String>>(0),
         ) {
             Ok(value) => value,
-            Err(rusqlite::Error::QueryReturnedNoRows) => None,
-            Err(other) => return Err(other.into()),
+            Err(LatticeError::Sqlite(rusqlite::Error::QueryReturnedNoRows)) => None,
+            Err(other) => return Err(other),
         };
 
         let (stored_value, stored_ref): (Option<String>, Option<String>) = if secret {
@@ -437,16 +443,11 @@ impl MachineStore {
             "SELECT value, secret_ref FROM environments \
              WHERE workspace_id = ?1 AND name = ?2 AND key = ?3",
             params![workspace_id, name, key],
-            |row| {
-                Ok((
-                    row.get::<_, Option<String>>(0)?,
-                    row.get::<_, Option<String>>(1)?,
-                ))
-            },
+            |row| Ok((row.get::<Option<String>>(0)?, row.get::<Option<String>>(1)?)),
         ) {
             Ok(pair) => Some(pair),
-            Err(rusqlite::Error::QueryReturnedNoRows) => None,
-            Err(other) => return Err(other.into()),
+            Err(LatticeError::Sqlite(rusqlite::Error::QueryReturnedNoRows)) => None,
+            Err(other) => return Err(other),
         };
         let Some((value, secret_ref)) = row else {
             return Ok(None);
@@ -503,11 +504,11 @@ impl MachineStore {
             "SELECT secret_ref FROM environments \
              WHERE workspace_id = ?1 AND name = ?2 AND key = ?3",
             params![workspace_id, name, key],
-            |row| row.get::<_, Option<String>>(0),
+            |row| row.get::<Option<String>>(0),
         ) {
             Ok(value) => value,
-            Err(rusqlite::Error::QueryReturnedNoRows) => None,
-            Err(other) => return Err(other.into()),
+            Err(LatticeError::Sqlite(rusqlite::Error::QueryReturnedNoRows)) => None,
+            Err(other) => return Err(other),
         };
         let removed = self.conn.execute(
             "DELETE FROM environments WHERE workspace_id = ?1 AND name = ?2 AND key = ?3",
@@ -537,7 +538,7 @@ pub struct EnvironmentRow {
     pub updated_at: i64,
 }
 
-fn row_to_session(row: &rusqlite::Row<'_>) -> rusqlite::Result<SessionRow> {
+fn row_to_session(row: &Row) -> rusqlite::Result<SessionRow> {
     Ok(SessionRow {
         id: row.get(0)?,
         actor: row.get(1)?,

--- a/crates/lattice/src/store.rs
+++ b/crates/lattice/src/store.rs
@@ -5,10 +5,10 @@ use std::{
     fs,
     io::Write,
     path::{Path, PathBuf},
-    time::Duration,
 };
 
-use rusqlite::{Connection, OpenFlags, TransactionBehavior, params, types::Value};
+use crate::database::{Connection, Row};
+use rusqlite::{params, types::Value};
 use serde::Deserialize;
 
 use crate::{
@@ -36,6 +36,7 @@ const WORKSPACE_MIGRATIONS: &[&str] = &[
 
 const GITIGNORE: &str = "# Lattice run history is machine-local. workspace.toml and config.toml are shared.\n\
 lattice.db\n\
+lattice.db.engine\n\
 lattice.db-wal\n\
 lattice.db-shm\n\
 lattice.db-journal\n\
@@ -293,6 +294,7 @@ impl WorkspaceStore {
         ensure_file(&facet_dir.join(".gitignore"), GITIGNORE)?;
         let workspace_id = ensure_workspace_id(&facet_dir)?;
         let conn = open_connection(&facet_dir.join(DB_FILE), &config)?;
+        validate_schema(&conn, WORKSPACE_MIGRATIONS.len())?;
         // Before applying the v2 migration (which drops the inline req_body
         // column), hydrate any v1 inline request bodies into blob files so no
         // body is lost. No-op on fresh stores and stores already at v2.
@@ -346,13 +348,19 @@ impl WorkspaceStore {
         &self.workspace_id
     }
 
+    /// Engine executing operations for this store.
+    #[must_use]
+    pub fn engine(&self) -> crate::Engine {
+        self.conn.engine()
+    }
+
     /// Highest applied migration.
     pub fn schema_version(&self) -> Result<i64, LatticeError> {
-        Ok(self.conn.query_row(
+        self.conn.query_row(
             "SELECT coalesce(max(version), 0) FROM schema_version",
             [],
             |row| row.get(0),
-        )?)
+        )
     }
 
     /// Records one run. Blob files are written before the short write
@@ -367,7 +375,7 @@ impl WorkspaceStore {
         let res_body = blobs::place(&blobs_dir, run.res_body, threshold)?;
         let now = now_ms();
 
-        let tx = rusqlite::Transaction::new_unchecked(&self.conn, TransactionBehavior::Immediate)?;
+        let tx = self.conn.transaction()?;
         for (stored, content_type) in [(&req_body, None), (&res_body, run.res_content_type)] {
             if let Some(hash) = &stored.hash {
                 tx.execute(
@@ -418,7 +426,7 @@ impl WorkspaceStore {
     pub fn run(&self, id: &str) -> Result<Option<RunRow>, LatticeError> {
         let mut statement = self
             .conn
-            .prepare_cached(&format!("SELECT {RUN_COLUMNS} FROM runs WHERE id = ?1"))?;
+            .prepare(&format!("SELECT {RUN_COLUMNS} FROM runs WHERE id = ?1"))?;
         let mut rows = statement.query(params![id])?;
         match rows.next()? {
             Some(row) => Ok(Some(row_to_run(row)?)),
@@ -478,7 +486,7 @@ impl WorkspaceStore {
         values.push(Value::Integer(to_i64(query.limit as u64)));
 
         let mut statement = self.conn.prepare(&sql)?;
-        let mut rows = statement.query(rusqlite::params_from_iter(values))?;
+        let mut rows = statement.query(values)?;
         let mut runs = Vec::new();
         while let Some(row) = rows.next()? {
             runs.push(row_to_run(row)?);
@@ -488,9 +496,8 @@ impl WorkspaceStore {
 
     /// Total run rows.
     pub fn count_runs(&self) -> Result<i64, LatticeError> {
-        Ok(self
-            .conn
-            .query_row("SELECT count(*) FROM runs", [], |row| row.get(0))?)
+        self.conn
+            .query_row("SELECT count(*) FROM runs", [], |row| row.get(0))
     }
 
     /// Reads a run's request body per the reader rule. Request bodies are
@@ -543,7 +550,7 @@ impl WorkspaceStore {
             )
             .map(Some)
             .or_else(|error| match error {
-                rusqlite::Error::QueryReturnedNoRows => Ok(None),
+                LatticeError::Sqlite(rusqlite::Error::QueryReturnedNoRows) => Ok(None),
                 other => Err(other),
             })?;
         let (len, content_type) = registered
@@ -559,41 +566,15 @@ impl WorkspaceStore {
 
     /// Runs one read-only SQL statement on a separate read-only connection.
     pub fn query(&self, sql: &str) -> Result<SqlResult, LatticeError> {
-        let conn = Connection::open_with_flags(
-            self.facet_dir.join(DB_FILE),
-            OpenFlags::SQLITE_OPEN_READ_ONLY | OpenFlags::SQLITE_OPEN_NO_MUTEX,
-        )?;
-        conn.busy_timeout(Duration::from_millis(self.config.busy_timeout_ms))?;
-        conn.pragma_update(None, "query_only", true)?;
-        // `--sql` is read-only against the workspace store only. `ATTACH` opens
-        // another database (e.g. the machine store, which holds `environments`
-        // and `secret_ref`) and `sqlite3_stmt_readonly` reports ATTACH as
-        // read-only because it does not touch the main db file. Refuse it
-        // explicitly so `--sql` can never reach the machine store.
-        if sql
-            .trim()
-            .split_ascii_whitespace()
-            .next()
-            .map(|token| token.eq_ignore_ascii_case("ATTACH"))
-            .unwrap_or(false)
-        {
-            return Err(LatticeError::ReadOnlyQuery);
-        }
-        let mut statement = conn.prepare(sql)?;
-        if !statement.readonly() {
-            return Err(LatticeError::ReadOnlyQuery);
-        }
-        let columns: Vec<String> = statement
-            .column_names()
-            .into_iter()
-            .map(str::to_owned)
-            .collect();
+        let conn = Connection::open(&self.facet_dir.join(DB_FILE), &self.config, true)?;
+        let mut statement = conn.prepare_read_only(sql)?;
+        let columns = statement.column_names();
         let mut rows = statement.query([])?;
         let mut out = Vec::new();
         while let Some(row) = rows.next()? {
             let mut values = Vec::with_capacity(columns.len());
             for index in 0..columns.len() {
-                values.push(row.get::<_, Value>(index)?);
+                values.push(row.get::<Value>(index)?);
             }
             out.push(values);
         }
@@ -623,7 +604,7 @@ impl WorkspaceStore {
             let mut statement = self.conn.prepare(live_sql)?;
             let mut rows = statement.query(params![floor])?;
             while let Some(row) = rows.next()? {
-                live.insert(row.get::<_, String>(0)?);
+                live.insert(row.get::<String>(0)?);
             }
         }
 
@@ -647,7 +628,7 @@ impl WorkspaceStore {
             let mut rows = statement.query([])?;
             let mut count = 0;
             while let Some(row) = rows.next()? {
-                if !live.contains(&row.get::<_, String>(0)?) {
+                if !live.contains(&row.get::<String>(0)?) {
                     count += 1;
                 }
             }
@@ -655,16 +636,16 @@ impl WorkspaceStore {
         };
 
         if apply {
-            let tx =
-                rusqlite::Transaction::new_unchecked(&self.conn, TransactionBehavior::Immediate)?;
+            let tx = self.conn.transaction()?;
             if let Some(cutoff) = cutoff {
                 tx.execute("DELETE FROM runs WHERE started_at < ?1", params![cutoff])?;
             }
             {
                 let mut statement = tx.prepare("SELECT hash FROM blobs")?;
                 let stale: Vec<String> = statement
-                    .query_map([], |row| row.get::<_, String>(0))?
-                    .filter_map(Result::ok)
+                    .query_map([], |row| row.get::<String>(0))?
+                    .collect::<Result<Vec<_>, _>>()?
+                    .into_iter()
                     .filter(|hash| !live.contains(hash))
                     .collect();
                 for hash in stale {
@@ -693,7 +674,7 @@ fn to_i64(value: u64) -> i64 {
     i64::try_from(value).unwrap_or(i64::MAX)
 }
 
-fn row_to_run(row: &rusqlite::Row<'_>) -> rusqlite::Result<RunRow> {
+fn row_to_run(row: &Row) -> rusqlite::Result<RunRow> {
     Ok(RunRow {
         id: row.get(0)?,
         started_at: row.get(1)?,
@@ -710,12 +691,12 @@ fn row_to_run(row: &rusqlite::Row<'_>) -> rusqlite::Result<RunRow> {
         // Request bodies are hash-only (v2): no inline column, so
         // inline_present is always false. The reader only consults the hash.
         req_body: BodyRef {
-            len: row.get::<_, Option<i64>>(12)?.map(i64::unsigned_abs),
+            len: row.get::<Option<i64>>(12)?.map(i64::unsigned_abs),
             hash: row.get(13)?,
             inline_present: false,
         },
         res_body: BodyRef {
-            len: row.get::<_, Option<i64>>(14)?.map(i64::unsigned_abs),
+            len: row.get::<Option<i64>>(14)?.map(i64::unsigned_abs),
             hash: row.get(15)?,
             inline_present: row.get(16)?,
         },
@@ -757,13 +738,7 @@ pub(crate) fn open_connection(
     path: &Path,
     config: &LatticeConfig,
 ) -> Result<Connection, LatticeError> {
-    let conn = Connection::open(path)?;
-    conn.busy_timeout(Duration::from_millis(config.busy_timeout_ms))?;
-    if config.wal {
-        let _mode: String = conn.query_row("PRAGMA journal_mode = WAL", [], |row| row.get(0))?;
-        conn.pragma_update(None, "synchronous", "NORMAL")?;
-    }
-    Ok(conn)
+    Connection::open(path, config, false)
 }
 
 /// v1 -> v2 data migration: before the SQL migration drops the inline
@@ -773,13 +748,11 @@ pub(crate) fn open_connection(
 /// (the column is gone). Idempotent: identical content shares one file.
 fn hydrate_inline_request_bodies(conn: &Connection, blobs_dir: &Path) -> Result<(), LatticeError> {
     // Only meaningful when the v1 `runs` table still has `req_body`.
-    let has_req_body: i64 = conn
-        .query_row(
-            "SELECT count(*) FROM pragma_table_info('runs') WHERE name = 'req_body'",
-            [],
-            |row| row.get(0),
-        )
-        .unwrap_or(0);
+    let has_req_body: i64 = conn.query_row(
+        "SELECT count(*) FROM pragma_table_info('runs') WHERE name = 'req_body'",
+        [],
+        |row| row.get(0),
+    )?;
     if has_req_body == 0 {
         return Ok(());
     }
@@ -788,15 +761,14 @@ fn hydrate_inline_request_bodies(conn: &Connection, blobs_dir: &Path) -> Result<
     )?;
     let rows: Vec<(String, Vec<u8>)> = statement
         .query_map([], |row| Ok((row.get(0)?, row.get(1)?)))?
-        .filter_map(Result::ok)
-        .collect();
+        .collect::<Result<Vec<_>, _>>()?;
     drop(statement);
     if rows.is_empty() {
         return Ok(());
     }
     fs::create_dir_all(blobs_dir).map_err(|error| io_error(blobs_dir, error))?;
     let now = now_ms();
-    let tx = rusqlite::Transaction::new_unchecked(conn, TransactionBehavior::Immediate)?;
+    let tx = conn.transaction()?;
     for (id, bytes) in rows {
         let len = bytes.len() as u64;
         let hash = blobs::sha256_hex(&bytes);
@@ -817,21 +789,8 @@ fn hydrate_inline_request_bodies(conn: &Connection, blobs_dir: &Path) -> Result<
 /// Applies numbered migrations above the current `schema_version` inside one
 /// immediate transaction, so concurrent first opens serialize.
 pub(crate) fn migrate(conn: &Connection, migrations: &[&str]) -> Result<(), LatticeError> {
-    let tx = rusqlite::Transaction::new_unchecked(conn, TransactionBehavior::Immediate)?;
-    let has_table: i64 = tx.query_row(
-        "SELECT count(*) FROM sqlite_master WHERE type = 'table' AND name = 'schema_version'",
-        [],
-        |row| row.get(0),
-    )?;
-    let current: i64 = if has_table > 0 {
-        tx.query_row(
-            "SELECT coalesce(max(version), 0) FROM schema_version",
-            [],
-            |row| row.get(0),
-        )?
-    } else {
-        0
-    };
+    let tx = conn.transaction()?;
+    let current = validate_schema(&tx, migrations.len())?;
     for (index, sql) in migrations.iter().enumerate() {
         let version = to_i64(index as u64 + 1);
         if version > current {
@@ -840,4 +799,28 @@ pub(crate) fn migrate(conn: &Connection, migrations: &[&str]) -> Result<(), Latt
     }
     tx.commit()?;
     Ok(())
+}
+
+fn validate_schema(conn: &Connection, maximum: usize) -> Result<i64, LatticeError> {
+    let has_table: i64 = conn.query_row(
+        "SELECT count(*) FROM sqlite_master WHERE type = 'table' AND name = 'schema_version'",
+        [],
+        |row| row.get(0),
+    )?;
+    let current: i64 = if has_table > 0 {
+        conn.query_row(
+            "SELECT coalesce(max(version), 0) FROM schema_version",
+            [],
+            |row| row.get(0),
+        )?
+    } else {
+        0
+    };
+    if current < 0 || current > maximum as i64 {
+        return Err(LatticeError::Engine(format!(
+            "unsupported schema version {current}; maximum is {}",
+            maximum
+        )));
+    }
+    Ok(current)
 }

--- a/crates/lattice/tests/duckdb.rs
+++ b/crates/lattice/tests/duckdb.rs
@@ -37,11 +37,7 @@ fn seed_store(root: &Path) -> std::path::PathBuf {
         .spawn()
         .and_then(|mut child| {
             use std::io::Write;
-            child
-                .stdin
-                .take()
-                .unwrap()
-                .write_all(schema.as_bytes())?;
+            child.stdin.take().unwrap().write_all(schema.as_bytes())?;
             child.wait().map(|_| ())
         })
         .expect("sqlite3 CLI to apply the schema");

--- a/crates/lattice/tests/hedron.rs
+++ b/crates/lattice/tests/hedron.rs
@@ -45,7 +45,11 @@ fn hedron_core_coexists_with_rusqlite_default_engine() {
 
     // Write path: bootstrap the store and put a document node.
     let mut store = Store::open(&db).expect("open hedron store");
-    let Bootstrap { vault, agent: _, token } = store
+    let Bootstrap {
+        vault,
+        agent: _,
+        token,
+    } = store
         .bootstrap("lattice", "facet", "/tmp/htec")
         .expect("bootstrap vault + agent");
     let doc = Node::brief_document(vault.id, "smoke", "2026-09-07").expect("build doc node");

--- a/crates/lattice/tests/turso.rs
+++ b/crates/lattice/tests/turso.rs
@@ -1,142 +1,340 @@
-//! Turso/libSQL smoke (Surface 3/4 future path).
-//!
-//! Behind the `lattice-turso` cargo feature. Proves Turso (libSQL local mode)
-//! can open/write/read a workspace store file. libSQL is a SQLite fork, so the
-//! on-disk file format is identical to rusqlite's; flipping the engine flag
-//! requires no migration.
-//!
-//! This test is **libsql-only** on purpose. The lattice test binary also
-//! links rusqlite (the default engine); if a test calls rusqlite first, rusqlite
-//! initializes the process-global SQLite and libsql's later
-//! `sqlite3_config(SERIALIZED)` returns `SQLITE_MISUSE`. Keeping this test
-//! libsql-only lets libsql initialize first. Cross-engine interop (a file
-//! written by libsql read back by rusqlite) is verified out-of-band with the
-//! `sqlite3` CLI — see `agents/backend/notes/`.
-//!
-//! Verified still true 2026-09-06 (libsql 0.9.30): `Builder::build()` alone
-//! defers init and looks fine, but the moment libsql uses a connection
-//! (`connect` + `execute`) after rusqlite opened the same file, libsql's
-//! threading-safety assert fires (`SQLITE_MISUSE` 21) at
-//! `libsql-0.9.30/src/local/database.rs:323`. So the libsql-only design
-//! stays. Do not be fooled by a `build()`-only check; exercise the connection.
-//!
-//! Run on the build host (apiary), not lathe:
-//!
-//! ```text
-//! cargo test -p lattice --features lattice-turso --test turso
-//! ```
-//!
-//! The default `cargo test -p lattice` (feature off) does not build this
-//! file or pull libsql/tokio.
-
+//! Actual Rust Turso through both application stores, never libSQL.
 #![cfg(feature = "lattice-turso")]
 
-use std::path::Path;
+use lattice::{
+    BodyInput, Engine, HistoryQuery, LatticeConfig, LatticeError, MachineStore, NewRun,
+    SessionQuery, SqlValue, WorkspaceStore,
+};
 
-use libsql::Builder;
-
-/// The workspace-store migration, embedded so the smoke can lay down the
-/// schema through libsql without touching rusqlite. Source of truth:
-/// `crates/lattice/migrations/workspace/0001_init.sql`.
-const WORKSPACE_SCHEMA: &str = include_str!("../migrations/workspace/0001_init.sql");
-
-/// Opens (creating when needed) the workspace store file through Turso
-/// (libSQL local mode) and runs the schema migration. Local mode does no
-/// networking; it opens the SQLite-compatible file in place.
-async fn turso_open(root: &Path) -> libsql::Result<libsql::Connection> {
-    let db_path = root.join(lattice::FACET_DIR).join(lattice::DB_FILE);
-    std::fs::create_dir_all(root.join(lattice::FACET_DIR)).unwrap();
-    let db = Builder::new_local(&db_path).build().await?;
-    let conn = db.connect()?;
-    // The migration is not idempotent (CREATE TABLE, not IF NOT EXISTS), so
-    // only run it when the schema_version table is absent.
-    let mut rows = conn
-        .query(
-            "SELECT count(*) FROM sqlite_master WHERE type = 'table' AND name = 'schema_version'",
-            (),
-        )
-        .await?;
-    let row = rows.next().await?.unwrap();
-    if *row.get_value(0).unwrap().as_integer().unwrap() == 0 {
-        conn.execute_batch(WORKSPACE_SCHEMA).await?;
+fn config() -> LatticeConfig {
+    LatticeConfig {
+        engine: Engine::Turso,
+        inline_body_max: 8,
+        ..LatticeConfig::default()
     }
-    Ok(conn)
 }
 
 #[tokio::test]
-async fn turso_opens_writes_and_reads_a_workspace_store() {
-    // If TURSO_KEEP_DB is set, write the store there and leave it on disk so the
-    // file can be inspected with the `sqlite3` CLI (cross-engine interop
-    // check). Otherwise use a tempdir that is cleaned up.
-    let root: std::path::PathBuf = match std::env::var_os("TURSO_KEEP_DB") {
-        Some(path) => {
-            let path = std::path::PathBuf::from(path);
-            std::fs::create_dir_all(&path).unwrap();
-            path
-        }
-        None => tempfile::tempdir().unwrap().path().to_owned(),
-    };
-    let conn = turso_open(&root).await.unwrap();
-
-    // Write a run row through Turso.
-    conn
-        .execute(
-            "INSERT INTO runs (id, started_at, request_path, request_hash, method, url, actor) \
-             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)",
-            libsql::params!(
-                "01JABCTURSO00000000",
-                lattice::now_ms(),
-                "users/list-users.yml",
-                "deadbeef",
-                "GET",
-                "http://127.0.0.1/users",
-                "agent-turso",
-            ),
+async fn application_history_sessions_bodies_and_reopen_inside_tokio() {
+    let dir = tempfile::tempdir().unwrap();
+    let machine_path = dir.path().join("machine.db");
+    let store = WorkspaceStore::open(dir.path(), config()).unwrap();
+    let machine = MachineStore::open_at(&machine_path, &config()).unwrap();
+    assert_eq!(store.engine(), Engine::Turso);
+    assert_eq!(machine.engine(), Engine::Turso);
+    assert_eq!(
+        store.schema_version().unwrap(),
+        lattice::WORKSPACE_SCHEMA_VERSION
+    );
+    assert_eq!(
+        machine.schema_version().unwrap(),
+        lattice::MACHINE_SCHEMA_VERSION
+    );
+    let session = machine
+        .start_session("grok", Some(r#"{"herdr":"pane-1","omp":"session-1"}"#), 100)
+        .unwrap();
+    machine
+        .touch_workspace(
+            store.workspace_id(),
+            dir.path(),
+            Some("Turso contract"),
+            101,
         )
-        .await
         .unwrap();
-
-    // Read it back through Turso.
-    let mut rows = conn
-        .query(
-            "SELECT id, request_path, actor, method FROM runs WHERE actor = ?1",
-            libsql::params!("agent-turso"),
-        )
-        .await
+    machine.set_preference("editor.theme", "dark").unwrap();
+    let run = store
+        .record_run(&NewRun {
+            started_at: 102,
+            request_path: "cluster.yml",
+            request_hash: "abc",
+            method: "POST",
+            url: "https://cluster/api",
+            status: Some(201),
+            actor: "grok",
+            session_id: Some(&session.id),
+            environment: Some("m1"),
+            req_body: BodyInput::Bytes(b"request body"),
+            res_body: BodyInput::Bytes(b"tiny"),
+            tags: Some(r#"["m1","cluster"]"#),
+            ..NewRun::default()
+        })
         .unwrap();
-    let row = rows.next().await.unwrap().unwrap();
-    assert_eq!(row.get_value(0).unwrap().as_text().unwrap(), "01JABCTURSO00000000");
-    assert_eq!(row.get_value(1).unwrap().as_text().unwrap(), "users/list-users.yml");
-    assert_eq!(row.get_value(2).unwrap().as_text().unwrap(), "agent-turso");
-    assert_eq!(row.get_value(3).unwrap().as_text().unwrap(), "GET");
-
-    // The schema_version row landed.
-    let mut meta = conn
-        .query("SELECT count(*) FROM schema_version", ())
-        .await
+    machine.index_run(&run, store.workspace_id()).unwrap();
+    let replay = store
+        .record_run(&NewRun {
+            started_at: 103,
+            replayed_from: Some(&run.id),
+            res_body: BodyInput::Bytes(b"a large response body"),
+            ..NewRun::default()
+        })
         .unwrap();
-    let row = meta.next().await.unwrap().unwrap();
-    assert_eq!(*row.get_value(0).unwrap().as_integer().unwrap(), 1);
-
-    // Reopening the same file through Turso sees the row (persistence).
-    drop(conn);
-    let conn2 = turso_open(&root).await.unwrap();
-    let mut rows = conn2
-        .query("SELECT count(*) FROM runs", ())
-        .await
+    assert_eq!(store.request_body(&run).unwrap().unwrap(), b"request body");
+    assert_eq!(store.response_body(&run).unwrap().unwrap(), b"tiny");
+    assert_eq!(
+        store.response_body(&replay).unwrap().unwrap(),
+        b"a large response body"
+    );
+    let history = store
+        .history(&HistoryQuery {
+            limit: 10,
+            actor: Some("grok".into()),
+            session_id: Some(session.id.clone()),
+            environment: Some("m1".into()),
+            tags: vec!["m1".into(), "cluster".into()],
+            ..HistoryQuery::default()
+        })
         .unwrap();
-    let row = rows.next().await.unwrap().unwrap();
-    assert_eq!(*row.get_value(0).unwrap().as_integer().unwrap(), 1);
-    drop(conn2);
+    assert_eq!(history.len(), 1);
+    assert_eq!(history[0].id, run.id);
+    assert_eq!(
+        store
+            .query("WITH selected AS (SELECT id FROM runs) SELECT count(*) FROM selected")
+            .unwrap()
+            .rows,
+        vec![vec![SqlValue::Integer(2)]]
+    );
+    assert!(store.gc(false).unwrap().orphans.is_empty());
+    let workspace_id = store.workspace_id().to_owned();
+    drop(store);
+    drop(machine);
+    let store = WorkspaceStore::open(dir.path(), config()).unwrap();
+    let machine = MachineStore::open_at(&machine_path, &config()).unwrap();
+    assert_eq!(store.workspace_id(), workspace_id);
+    assert_eq!(store.run(&run.id).unwrap().unwrap(), run);
+    assert_eq!(
+        store
+            .run(&replay.id)
+            .unwrap()
+            .unwrap()
+            .replayed_from
+            .as_deref(),
+        Some(run.id.as_str())
+    );
+    assert_eq!(
+        machine.indexed_run(&run.id).unwrap().unwrap().0,
+        workspace_id
+    );
+    assert_eq!(
+        machine.preference("editor.theme").unwrap().as_deref(),
+        Some("dark")
+    );
+    assert_eq!(
+        machine
+            .sessions(&SessionQuery {
+                limit: 10,
+                actor: Some("grok".into()),
+                open_only: true
+            })
+            .unwrap(),
+        vec![session.clone()]
+    );
+    assert_eq!(
+        machine.session(&session.id).unwrap().unwrap().meta,
+        session.meta
+    );
+    assert_eq!(
+        machine
+            .end_session(&session.id, 200)
+            .unwrap()
+            .unwrap()
+            .ended_at,
+        Some(200)
+    );
+    assert_eq!(
+        machine
+            .end_session(&session.id, 300)
+            .unwrap()
+            .unwrap()
+            .ended_at,
+        Some(200)
+    );
+}
 
-    // Cross-engine interop: when keeping the file, confirm the `sqlite3` CLI
-    // (system SQLite, separate from both bundled engines) can read the row
-    // libsql wrote. This is run out-of-band after the test, see notes.
-    if std::env::var_os("TURSO_KEEP_DB").is_some() {
-        eprintln!(
-            "TURSO_KEEP_DB at {} — verify with: sqlite3 {}/.facet/lattice.db 'SELECT id, actor FROM runs;'",
-            root.display(),
-            root.display()
+#[test]
+fn read_only_queries_reject_writes_attach_comments_and_multiple_statements() {
+    let dir = tempfile::tempdir().unwrap();
+    let store = WorkspaceStore::open(dir.path(), config()).unwrap();
+    for sql in [
+        "DELETE FROM runs",
+        "WITH x AS (SELECT 1) DELETE FROM runs",
+        "PRAGMA user_version = 99",
+        "/* prefix */ ATTACH ':memory:' AS other",
+        "-- prefix\nATTACH ':memory:' AS other",
+        "SELECT 1; DELETE FROM runs",
+        "SELECT 1; ATTACH ':memory:' AS other",
+        "VACUUM INTO 'escaped.db'",
+    ] {
+        assert!(
+            matches!(store.query(sql), Err(LatticeError::ReadOnlyQuery)),
+            "{sql}"
         );
     }
+    assert!(
+        store
+            .query("SELECT absent FROM runs")
+            .unwrap_err()
+            .is_query_error()
+    );
+    assert_eq!(store.count_runs().unwrap(), 0);
+    assert_eq!(
+        store
+            .query("/* allowed */ SELECT 1 AS result")
+            .unwrap()
+            .columns,
+        ["result"]
+    );
+}
+
+#[test]
+fn explicit_selection_protects_existing_files_in_both_directions() {
+    let dir = tempfile::tempdir().unwrap();
+    let store = WorkspaceStore::open(dir.path(), LatticeConfig::default()).unwrap();
+    store.record_run(&NewRun::default()).unwrap();
+    drop(store);
+    let path = dir.path().join(".facet/lattice.db");
+    let bytes = std::fs::read(&path).unwrap();
+    assert!(matches!(
+        WorkspaceStore::open(dir.path(), config()),
+        Err(LatticeError::Engine(_))
+    ));
+    assert_eq!(std::fs::read(&path).unwrap(), bytes);
+    std::fs::remove_file(path.with_added_extension("engine")).unwrap();
+    assert!(matches!(
+        WorkspaceStore::open(dir.path(), config()),
+        Err(LatticeError::Engine(_))
+    ));
+    assert_eq!(std::fs::read(&path).unwrap(), bytes);
+    let other = tempfile::tempdir().unwrap();
+    WorkspaceStore::open(other.path(), config()).unwrap();
+    assert!(matches!(
+        WorkspaceStore::open(other.path(), LatticeConfig::default()),
+        Err(LatticeError::Engine(_))
+    ));
+}
+
+#[test]
+fn concurrent_application_writers_retain_every_run() {
+    let dir = tempfile::tempdir().unwrap();
+    WorkspaceStore::open(dir.path(), config()).unwrap();
+    let writers: Vec<_> = (0..4)
+        .map(|writer| {
+            let root = dir.path().to_owned();
+            std::thread::spawn(move || {
+                let store = WorkspaceStore::open(&root, config()).unwrap();
+                for index in 0..10 {
+                    store
+                        .record_run(&NewRun {
+                            started_at: index,
+                            actor: &format!("writer-{writer}"),
+                            ..NewRun::default()
+                        })
+                        .unwrap();
+                    assert!(
+                        !store
+                            .history(&HistoryQuery {
+                                limit: 5,
+                                ..HistoryQuery::default()
+                            })
+                            .unwrap()
+                            .is_empty()
+                    );
+                }
+            })
+        })
+        .collect();
+    for writer in writers {
+        writer.join().unwrap();
+    }
+    assert_eq!(
+        WorkspaceStore::open(dir.path(), config())
+            .unwrap()
+            .count_runs()
+            .unwrap(),
+        40
+    );
+}
+
+#[test]
+fn legacy_request_body_migration_preserves_bytes_and_future_schema_is_rejected() {
+    use futures::executor::block_on;
+    for future in [false, true] {
+        let dir = tempfile::tempdir().unwrap();
+        let facet = dir.path().join(".facet");
+        std::fs::create_dir(&facet).unwrap();
+        let path = facet.join("lattice.db");
+        std::fs::write(path.with_added_extension("engine"), "turso\n").unwrap();
+        let db = block_on(
+            turso::Builder::new_local(path.to_str().unwrap())
+                .experimental_multiprocess_wal(true)
+                .build(),
+        )
+        .unwrap();
+        let conn = db.connect().unwrap();
+        block_on(conn.execute_batch(include_str!("../migrations/workspace/0001_init.sql")))
+            .unwrap();
+        block_on(conn.execute("INSERT INTO runs (id, started_at, request_path, request_hash, method, url, req_body) VALUES ('old', 1, 'old.yml', 'hash', 'POST', 'http://local', ?1)", turso::params![b"preserve legacy bytes".to_vec()])).unwrap();
+        if future {
+            block_on(conn.execute_batch("INSERT INTO schema_version VALUES (100, 1)")).unwrap();
+        }
+        drop(conn);
+        drop(db);
+        if future {
+            assert!(matches!(
+                WorkspaceStore::open(dir.path(), config()),
+                Err(LatticeError::Engine(_))
+            ));
+            assert!(
+                !facet.join("blobs").exists(),
+                "reject before body hydration"
+            );
+        } else {
+            let store = WorkspaceStore::open(dir.path(), config()).unwrap();
+            let run = store.run("old").unwrap().unwrap();
+            assert_eq!(
+                store.request_body(&run).unwrap().unwrap(),
+                b"preserve legacy bytes"
+            );
+            assert_eq!(store.schema_version().unwrap(), 3);
+            assert!(store.query("SELECT req_body FROM runs").is_err());
+        }
+    }
+}
+
+#[test]
+fn process_writer() {
+    let Some(root) = std::env::var_os("LATTICE_TURSO_TEST_ROOT") else {
+        return;
+    };
+    let store = WorkspaceStore::open(std::path::Path::new(&root), config()).unwrap();
+    for _ in 0..10 {
+        store.record_run(&NewRun::default()).unwrap();
+    }
+}
+
+#[test]
+fn separate_process_writers_and_reader_share_the_database() {
+    let dir = tempfile::tempdir().unwrap();
+    let reader = WorkspaceStore::open(dir.path(), config()).unwrap();
+    let mut children: Vec<_> = (0..3)
+        .map(|_| {
+            std::process::Command::new(std::env::current_exe().unwrap())
+                .args(["--exact", "process_writer", "--nocapture"])
+                .env("LATTICE_TURSO_TEST_ROOT", dir.path())
+                .stdout(std::process::Stdio::piped())
+                .stderr(std::process::Stdio::piped())
+                .spawn()
+                .unwrap()
+        })
+        .collect();
+    for child in children.drain(..) {
+        let output = child.wait_with_output().unwrap();
+        assert!(
+            output.status.success(),
+            "{}\n{}",
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr)
+        );
+        assert!(reader.count_runs().unwrap() >= 10);
+    }
+    assert_eq!(reader.count_runs().unwrap(), 30);
 }

--- a/docs/CLUSTER-TRANSPORT.md
+++ b/docs/CLUSTER-TRANSPORT.md
@@ -1,0 +1,85 @@
+# Authenticated cluster requests
+
+Facet can use a project kubeconfig for verified client-certificate authentication.
+Set `FACET_KUBECONFIG` to one explicit kubeconfig file; optionally set
+`FACET_KUBE_CONTEXT` to a context name in that file. Otherwise its `current-context`
+is selected. Facet does not discover ambient `KUBECONFIG` or execute credential
+plugins.
+
+```sh
+export FACET_KUBECONFIG=/absolute/project/runtime/facet.kubeconfig
+export FACET_KUBE_CONTEXT=m1
+facet mcp
+```
+
+The same shared transport applies to CLI `request run`, replay, TUI execution and
+MCP `request_run`/`run_replay`. Ordinary Facet behavior is unchanged when the
+variable is absent. Canonical OpenCollection YAML holds URLs, methods and request
+bodies; certificate and private-key material stays in the runtime kubeconfig or
+referenced files. Do not place these credentials in Nix expressions or stores,
+collection YAML, command arguments, or Lattice fields.
+
+## Supported profile and enforcement
+
+This profile supports a kubeconfig `v1`/`Config` with a selected context, cluster
+and user; a CA bundle; and a client certificate/private key. Each material may be
+embedded as base64 `*-data` or referenced by a file path relative to the
+kubeconfig. Exactly one source per material is required. Missing/duplicate selected
+names, malformed input, and files over 4 MiB fail closed with credential-safe
+diagnostics.
+
+The configured server must be an HTTPS origin without userinfo, a path prefix,
+query or fragment. Its CA and hostname are verified. The final request URL,
+after substitutions, must have that exact origin. Same-origin redirects obey the
+request's limit; cross-origin or downgrade redirects fail before connecting to
+the destination. Non-default redirect settings preserve the client certificate
+and origin restrictions. The profile disables ambient HTTP proxies and TLS key
+logging.
+
+The profile rejects insecure TLS, TLS-name overrides, proxy settings, exec and
+auth-provider plugins, bearer/token-file/password authentication and impersonation.
+Other unsupported cluster/user fields are rejected rather than silently ignored.
+It also rejects explicit Authorization, Proxy-Authorization, Host and
+Impersonate-* request headers to avoid conflicting identity/routing. This is a
+bounded certificate profile, not a claim to implement every kubeconfig feature.
+Unset `FACET_KUBECONFIG` to use ordinary non-cluster Facet requests.
+
+Use a dedicated identity with only the necessary RBAC permissions in the intended
+namespace. Loading a kubeconfig does not itself grant permissions; h3s authorizes
+every API action. Dry runs continue to avoid loading credentials or sending requests.
+TLS/transport configuration failures are recorded as failed actions when recording
+is enabled. HTTP 403 is a real response; use `--expect`/MCP `expect` to have Facet
+report the rejected action as a tool failure while retaining its history.
+
+## Turso and session integration
+
+Build with `--features lattice-turso` and configure `[lattice] engine = "turso"`
+in the project machine configuration for both session commands and workspace
+recording. Use private `FACET_CONFIG_DIR` and `FACET_DATA_DIR`; keep workspace
+engine overrides consistent. See [Lattice engines](LATTICE-ENGINES.md).
+
+`session_start` returns an ID. The harness sets `FACET_SESSION` on the MCP process
+used for subsequent requests, and `FACET_ACTOR` identifies the actor. Restarting
+MCP with that same session environment preserves the lineage. The transport never
+adds credential material to the request model or to recorded headers/body metadata.
+
+## Tower acceptance probe
+
+`integration/tower/check-cluster-mcp.py` drives the real Facet MCP protocol against
+an existing h3s API. It requires explicit project tool, operator kubeconfig, PKI
+bundle, artifact-root and non-system namespace paths. Run it through the pinned
+Facet Nix shell, with remote builders disabled and job/core limits of two. The
+shell supplies OpenSSL for the operator-controlled, three-day test certificate.
+
+The probe issues an unprivileged test identity, installs a temporary ConfigMap-only
+Role and RoleBinding, then verifies create/read/delete, Secret and cross-namespace
+RBAC denials, Turso recording/indexing, session history, and MCP process reopen.
+The operator CA key is materialized only in a private temporary signing directory
+and removed immediately after issuance. The client credentials are removed at the
+end. Fixture cleanup checks ownership and uses UID preconditions; sanitized MCP
+transcripts, canonical YAML, Turso databases and a result manifest remain under a
+unique project artifact directory.
+
+This probe does not run containers, OMP, Herdr or a model. It supports the Facet
+integration checkpoint; the complete six-component workflow, HQL, runtime recovery
+and portability retain separate M1 acceptance requirements.

--- a/docs/FACET.md
+++ b/docs/FACET.md
@@ -240,45 +240,38 @@ one immediate transaction so concurrent first opens serialize.
 
 ### Engines
 
-The default engine is **rusqlite** (bundled SQLite). Two optional cargo
-features, both off by default, add engines without changing the on-disk
-file format:
+The default engine remains **rusqlite** (bundled SQLite). The optional
+`lattice-turso` feature now compiles the **actual Rust Turso engine**, pinned to
+`tursodatabase/turso` commit `87c7a8516511c3ad2745c25b1079ea5c90112692`.
+It replaces the old libSQL-only smoke feature. Both `WorkspaceStore` and
+`MachineStore` use the selected engine for their real application operations:
+recording, sessions, indexes, history, body metadata, SQL queries, and migrations.
+Compiling the feature alone does not change an installation's engine.
 
-| Feature | Engine | Notes |
+| Feature | Engine | Scope |
 | --- | --- | --- |
-| `lattice-turso` | Turso / libSQL (local mode) | Same file format as rusqlite (libSQL is a SQLite fork); flipping the flag requires no migration. Smoke: `crates/lattice/tests/turso.rs` (open/write/read a workspace store through libSQL). The smoke is libsql-only: rusqlite and libsql both bundle SQLite and cannot coexist in one binary (libsql's `sqlite3_config(SERIALIZED)` returns `SQLITE_MISUSE` after rusqlite initializes SQLite; `skip_safety_assert` is `unsafe` and the workspace forbids it). Verified still true 2026-09-06 (libsql 0.9.30). |
-| `lattice-duckdb` | DuckDB in-process (bundled) | **Apiary-only; never in lathe default members.** ATTACHes the SQLite lattice file for analytics. Smoke: `crates/lattice/tests/duckdb.rs`. Heavy native build. |
-| `lattice-hedron` | HedronDB knowledge-graph (`hedron-core`, bundled rusqlite) | **Apiary-only; never in lathe default members.** A **second data plane**, not a `lattice-turso` clone: Turso **retrieves** (same `lattice.db`, libSQL is a SQLite fork); HedronDB **records/reconciles** (separate-schema store — `nodes`/`edges`/`desired_states`/`events`, HQL — `hedron_core::Store::open` bootstraps its own schema and cannot read `lattice.db`). Engines are **beside, not instead** — no Turso cutover, no Facet SoT flip; read/search stays Turso/lattice. The smoke proves coexistence — `hedron-core` (rusqlite 0.40, bundled, aligned via the `facet-pin-align` proposal branch) and this crate's default engine (rusqlite 0.40, bundled) share one `libsqlite3-sys` and link/run in one binary. Smoke: `crates/lattice/tests/hedron.rs`. The Lattice→HedronDB projection (record/reconcile adapters) is a later slice; do not mix Warm `current_state` and Cool `causal_chain` in one API. |
+| `lattice-turso` | Rust Turso local driver | Explicit `[lattice] engine = "turso"`; real application storage, without libSQL or a silent SQLite fallback. |
+| `lattice-duckdb` | Bundled DuckDB | Existing optional analytics smoke against SQLite files. A heavy native build; not part of the default installation. |
+| `lattice-hedron` | HedronDB `hedron-core` | Separate knowledge-graph schema and authorization boundary. Existing coexistence smoke; intent/reconciliation integration remains separate work. |
 
-The primary analytics path is the **`duckdb` CLI** attaching the SQLite
-file externally (no Rust, no feature flag). Durable smoke:
-`scripts/duckdb-attach-demo.sh` (uses `duckdb` on `PATH` or `~/bin/duckdb`).
+For configuration, file safety, supported SQL, exact driver settings, tests and
+rollback, see [Lattice engines](LATTICE-ENGINES.md). SQLite files are not silently
+reopened with Turso. HedronDB never opens Lattice as its own Store, and canonical
+OpenCollection YAML remains independent of all database engines. Preserve the
+HedronDB distinction between Warm current state and Cool causal history.
 
-```text
+The external DuckDB analytics path remains available for SQLite stores:
+
+```sh
 duckdb -c "INSTALL sqlite; LOAD sqlite; \
   ATTACH '/path/to/.facet/lattice.db' AS lattice (TYPE SQLITE); \
   SELECT status, count(*) FROM lattice.runs GROUP BY status;"
 ```
 
-`INSTALL sqlite` downloads the `sqlite` extension on first use (network
-needed once). The in-process `lattice-duckdb` feature is a convenience
-for embedding the same ATTACH in Rust; it is not required for analytics.
-
-`lattice-hedron` is a **second data plane**, not a
-`lattice-turso` clone: Turso retrieves (reads the same `lattice.db`);
-HedronDB records/reconciles (a separate-schema knowledge graph —
-HQL, not SQL — that a future projection feeds from Lattice run history).
-Engines are **beside, not instead** — no Turso cutover, no Facet
-SoT flip; read/search stays Turso/lattice. It is apiary-only until
-the projection adapters and the upstream `hedron-core` pin alignment
-(rusqlite 0.40) land on hedrondb main. Do not mix Warm
-`current_state` and Cool `causal_chain` in one API. See
-`agents/backend/notes/2026-09-07-evaluate-hedrondb.md` for the evaluation.
-
-Feature-gated tests use `required-features` in `crates/lattice/Cargo.toml`,
-so a default `cargo test -p lattice` (features off) never pulls libsql,
-tokio, or duckdb. See `agents/backend/notes/2026-09-06-facet-engines.md`
-in the Lapis vault for the full runbook.
+`INSTALL sqlite` downloads an extension. Do not attach a live Turso database
+through SQLite/DuckDB; cross-engine access is not a supported conversion or
+concurrency mechanism. Historical engine evaluation notes describe the older
+libSQL smoke and do not establish compatibility of the Rust Turso backend.
 
 
 ## Commands

--- a/docs/FACET.md
+++ b/docs/FACET.md
@@ -276,6 +276,10 @@ libSQL smoke and do not establish compatibility of the Rust Turso backend.
 
 ## Commands
 
+For verified h3s client-certificate requests shared by CLI, replay, TUI and MCP,
+see [Cluster transport](CLUSTER-TRANSPORT.md). Configure credentials through an
+explicit project kubeconfig, separately from canonical collection YAML.
+
 ```text
 facet request run <path> <selector> [<probe request run flags>] [--no-record] [--tag <tag>]... [--expect <codes>] [--dry-run] [--inline-body-max <size>] [--json]
 facet history [<path>] [--limit <n>] [--request <selector>] [--status <code>] [--actor <name>] [--since <unix-ms>] [--session <id>|current] [--environment <name>] [--tag <tag>]... [--hash <sha256>] [--bodies] [--json]

--- a/docs/LATTICE-ENGINES.md
+++ b/docs/LATTICE-ENGINES.md
@@ -1,0 +1,151 @@
+# Lattice engines
+
+Lattice keeps run history beside canonical OpenCollection YAML, and machine
+sessions/indexes/preferences in a separate file. SQLite is the default. The
+`lattice-turso` feature selects the actual Rust Turso driver at runtime when
+`[lattice] engine = "turso"` is configured. Both stores and all their application
+operations use that engine. There is no libSQL dependency or SQLite execution
+fallback in the Turso branch.
+
+## Build and configure
+
+```sh
+cargo build -p facet-cli --features lattice-turso --locked
+```
+
+For a new project, choose private configuration and data directories. Put this in
+`$FACET_CONFIG_DIR/config.toml` (or the platform's normal Facet configuration
+file):
+
+```toml
+[lattice]
+engine = "turso"
+wal = true
+busy_timeout_ms = 5000
+```
+
+Set `FACET_DATA_DIR` to the project's machine-data directory and run Facet from
+the project workspace. Workspace `.facet/config.toml` overrides the machine file
+for workspace operations. Session commands intentionally use machine configuration
+only; keep the engine setting consistent in both files. A mismatched engine
+produces an explicit store error, which request recording reports in its existing
+`recorded`/`indexed` outcome. Verify these fields; HTTP success alone does not
+prove history was persisted.
+
+The workspace database remains `.facet/lattice.db`; the machine database remains
+`$FACET_DATA_DIR/lattice.db`. Existing library callers can set `LatticeConfig.engine`
+and inspect `WorkspaceStore::engine()` / `MachineStore::engine()`. A build without
+`lattice-turso` rejects a Turso selection rather than opening SQLite.
+
+## Driver and runtime configuration
+
+- Rust Turso source: `https://github.com/tursodatabase/turso`, commit
+  `87c7a8516511c3ad2745c25b1079ea5c90112692` (`0.8.0-pre.8`). The same commit
+  supplies the SQL parser used to authorize user queries. Cargo.lock pins the
+  resolved dependency set. This reviewed revision is used for M1's native engine
+  integration; it is not the former `libsql` package.
+- Default driver features are disabled: no FTS, optional network sync, or global
+  mimalloc allocator. Upstream still includes its sync support crates as ordinary
+  dependencies; the network sync feature is not enabled.
+- Local database mode, WAL required, experimental multiprocess WAL enabled, and
+  the configured busy timeout. The multiprocess flag is needed for independent
+  Facet CLI processes sharing history. It is an upstream experimental capability,
+  so thread and process contention tests are part of the compatibility contract.
+- The existing synchronous storage API uses `futures::executor::block_on` for
+  local driver operations. The driver polls its own I/O; no nested Tokio runtime
+  is constructed. As with SQLite, callers must keep storage I/O off the UI thread.
+- Each write transaction begins IMMEDIATE, commits explicitly, and attempts
+  rollback on error/drop. Migrations and run/blob registry inserts share the same
+  application code for both engines. Body files retain the existing hash/threshold
+  placement policy.
+
+## Existing files and rollback
+
+Every opened store has a sibling `lattice.db.engine` marker containing `sqlite`
+or `turso`. Legacy unmarked database files belong to SQLite. Selecting Turso for
+one is rejected before opening that database, and a marked Turso file is rejected
+by the SQLite path. Marker creation uses exclusive creation and sync; invalid or
+incomplete markers fail closed. Keep the marker with backups and restored files.
+Do not edit/delete it to force an engine switch.
+
+This implementation supports new Turso stores and numbered Lattice migrations
+within the same engine. It does not yet provide a cross-engine import/export
+command. Preserve existing SQLite history and select a separate workspace and
+machine-data directory when evaluating Turso. Merely sharing a SQLite-format
+header does not establish safe interchangeability, especially with active WAL.
+Unknown future schema versions are rejected before request-body hydration.
+
+Before upgrades, stop the project's Facet writers and preserve both database
+files, their markers, any WAL/SHM files, workspace identity and blob directory as
+one consistent backup. Keep the previous tested executable and configuration.
+Rollback restores that complete snapshot and its matching binary/configuration;
+it never changes only the engine setting on a live database. Remove only the
+explicit project installation/data paths when uninstalling. Credentials stay in
+approved runtime configuration, outside source, build artifacts and logs.
+
+## Read-only SQL
+
+`facet history --sql` opens a separate read-only connection to the selected
+workspace engine. The Turso path accepts one SELECT (including WITH, VALUES and
+compound selects), EXPLAIN SELECT or EXPLAIN QUERY PLAN SELECT. It rejects other
+statements, PRAGMA commands and multiple statements before preparation. This is
+a deliberately documented subset of the SQLite escape hatch. Invalid SQL remains
+a query error in the CLI contract; storage failures retain their driver errors.
+
+SQLite retains its statement-readonly check and now denies ATTACH/DETACH through
+the parsed authorizer, including comment-prefixed forms. User SQL cannot attach
+the machine database. Turso attachment and load-extension capabilities are not
+enabled. Neither engine's SQL escape hatch replaces the authorized HedronDB
+Store or HQL adapter.
+
+## Verification
+
+```sh
+cargo fmt --check
+cargo clippy --all-targets --all-features
+cargo test
+cargo test -p lattice --features lattice-turso --locked
+cargo test -p facet-cli --features lattice-turso --test facet_commands \
+  turso_records_real_http_requests_and_recalls_sessions_across_cli_processes --locked
+```
+
+Tests cover the existing SQLite contracts and actual Turso application recording,
+JSON tag filtering, inline/hashed bodies, v1 migration, future-schema rejection,
+transaction rollback, read-only queries, reopen, sessions/indexes/preferences,
+thread/process writers, and real HTTP recording/recall through separate Facet CLI
+processes. These do not establish the complete Hedronetes M1 workflow: NixOS
+integration, authenticated cluster actions, Herdr/OMP/Grok, HQL, system recovery,
+and distro portability have their own acceptance gates.
+
+## NixOS development environment
+
+`flake.nix` / `flake.lock` provide the native C toolchain, CMake, pkg-config and
+Nix's bindgen hook (including libclang and header search paths) needed by the
+actual Turso dependency. Nixpkgs is pinned to
+`c25784012c9982bca5b3e0de87e90bbdac8927d3`, rust-overlay to
+`ca7f624be3935a5bc46d2c240515491ab8675503`, and the Nix development compiler to
+Rust 1.98.1. The existing rustup toolchain and declared minimum remain 1.95;
+local checks exercise that minimum and NixOS checks exercise the newer compiler.
+This is a development shell, not yet a redistributable Facet Nix package.
+
+On Tower, use only the explicitly named project Lima guest and disable remote
+builders for every Nix invocation. Extract a clean `git archive` for the tested
+Facet commit; use that immutable source as the flake input. Build from a separate
+working copy so `target/` never enters Nix's input store:
+
+```sh
+nix develop path:/absolute/project/sources/facet-COMMIT \
+  --option builders '' --option max-jobs 2 --option cores 2 \
+  -c cargo test -p lattice --features lattice-turso --locked
+nix develop path:/absolute/project/sources/facet-COMMIT \
+  --option builders '' --option max-jobs 2 --option cores 2 \
+  -c cargo test -p facet-cli --features lattice-turso --test facet_commands \
+  turso_records_real_http_requests_and_recalls_sessions_across_cli_processes --locked
+```
+
+The shell limits Cargo to two jobs and disables debug information in dev/test
+builds to bound guest disk consumption. It does not change shared host tools or
+Nix configuration, and it must never dispatch to the protected `builder` lab.
+The feature-enabled CLI executable is `target/debug/facet`; an explicit
+project-local wrapper may enter this same pinned shell when launching it. Keep
+such a wrapper and its required store closure with the installation provenance.

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,49 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1788690626,
+        "narHash": "sha256-+v4I4LawmRD/mVxO7QIAerRrCkElp3YImzWkkUnvOTg=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "c25784012c9982bca5b3e0de87e90bbdac8927d3",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "c25784012c9982bca5b3e0de87e90bbdac8927d3",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs",
+        "rust-overlay": "rust-overlay"
+      }
+    },
+    "rust-overlay": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1788765185,
+        "narHash": "sha256-pp8lb5CrKjmscZbTK34HuCaq18zDU4Q6zlaD5dS+Hi4=",
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "rev": "ca7f624be3935a5bc46d2c240515491ab8675503",
+        "type": "github"
+      },
+      "original": {
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "rev": "ca7f624be3935a5bc46d2c240515491ab8675503",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,34 @@
+{
+  description = "Facet M1 development shell with the Rust Turso native build dependencies";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/c25784012c9982bca5b3e0de87e90bbdac8927d3";
+    rust-overlay = {
+      url = "github:oxalica/rust-overlay/ca7f624be3935a5bc46d2c240515491ab8675503";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+  };
+
+  outputs = { nixpkgs, rust-overlay, ... }:
+    let
+      systems = [ "aarch64-linux" "x86_64-linux" ];
+      forSystems = nixpkgs.lib.genAttrs systems;
+    in {
+      devShells = forSystems (system:
+        let
+          pkgs = import nixpkgs { inherit system; overlays = [ rust-overlay.overlays.default ]; };
+          rust = pkgs.rust-bin.stable."1.98.1".minimal.override {
+            extensions = [ "rustfmt" "clippy" ];
+          };
+        in {
+          default = pkgs.mkShell {
+            packages = [ rust pkgs.cmake pkgs.pkg-config pkgs.git pkgs.python3 ];
+            nativeBuildInputs = [ pkgs.rustPlatform.bindgenHook ];
+            CARGO_BUILD_JOBS = "2";
+            # Bound build space in the M1 guest; this is not a release profile.
+            CARGO_PROFILE_DEV_DEBUG = "0";
+            CARGO_PROFILE_TEST_DEBUG = "0";
+          };
+        });
+    };
+}

--- a/flake.nix
+++ b/flake.nix
@@ -22,7 +22,7 @@
           };
         in {
           default = pkgs.mkShell {
-            packages = [ rust pkgs.cmake pkgs.pkg-config pkgs.git pkgs.python3 ];
+            packages = [ rust pkgs.cmake pkgs.pkg-config pkgs.git pkgs.python3 pkgs.openssl ];
             nativeBuildInputs = [ pkgs.rustPlatform.bindgenHook ];
             CARGO_BUILD_JOBS = "2";
             # Bound build space in the M1 guest; this is not a release profile.

--- a/integration/tower/check-cluster-mcp.py
+++ b/integration/tower/check-cluster-mcp.py
@@ -1,0 +1,255 @@
+#!/usr/bin/env python3
+"""Exercise real h3s mTLS/RBAC through Facet MCP with Rust Turso history.
+
+Requires explicit project paths and an existing non-system namespace. Uses the
+operator's h3s CA bundle to issue a short-lived, unprivileged test identity. The
+CA key is copied only to a private temporary directory and always removed.
+Fixture RBAC/ConfigMap objects are removed with UID preconditions. Credentials
+are removed; sanitized transcripts, canonical YAML and Turso stores are retained.
+This does not run workloads or substitute for the complete M1 harness workflow.
+"""
+import argparse
+import base64
+import hashlib
+import json
+import os
+from pathlib import Path
+import selectors
+import shutil
+import subprocess
+import tempfile
+import uuid
+
+
+def require(condition, message):
+    if not condition:
+        raise RuntimeError(message)
+
+
+class Mcp:
+    def __init__(self, binary, env, root, transcript):
+        self.errors = (root / "mcp-stderr.log").open("a")
+        self.child = subprocess.Popen([str(binary), "mcp"], cwd=root, env=env,
+                                      stdin=subprocess.PIPE, stdout=subprocess.PIPE,
+                                      stderr=self.errors, text=True, bufsize=1)
+        self.selector = selectors.DefaultSelector()
+        self.selector.register(self.child.stdout, selectors.EVENT_READ)
+        self.next_id = 1
+        self.transcript = transcript
+        self.request("initialize", {"protocolVersion": "2025-06-18", "capabilities": {},
+                                     "clientInfo": {"name": "hedronetes-acceptance", "version": "1"}})
+        self.child.stdin.write(json.dumps({"jsonrpc": "2.0", "method": "notifications/initialized"}) + "\n")
+        self.child.stdin.flush()
+
+    def request(self, method, params):
+        message = {"jsonrpc": "2.0", "id": self.next_id, "method": method, "params": params}
+        self.next_id += 1
+        self.child.stdin.write(json.dumps(message) + "\n")
+        self.child.stdin.flush()
+        require(self.selector.select(20), "MCP response timed out")
+        response = json.loads(self.child.stdout.readline())
+        require(response.get("id") == message["id"], "MCP response ID differs")
+        self.transcript.write(json.dumps({"request": message, "response": response}) + "\n")
+        self.transcript.flush()
+        return response
+
+    def call(self, name, arguments, expected_error=False):
+        response = self.request("tools/call", {"name": name, "arguments": arguments})
+        result = response["result"]
+        require(bool(result.get("isError", False)) == expected_error, f"unexpected MCP error state for {name}")
+        document = result["structuredContent"]
+        require(json.loads(result["content"][0]["text"]) == document, "MCP text and structured result differ")
+        return document
+
+    def close(self):
+        try:
+            self.child.stdin.close()
+        except BrokenPipeError:
+            pass
+        try:
+            self.child.wait(timeout=5)
+        except subprocess.TimeoutExpired:
+            self.child.terminate()
+            self.child.wait(timeout=5)
+        self.selector.close()
+        self.child.stdout.close()
+        self.errors.close()
+        require(self.child.returncode == 0, "MCP did not exit cleanly")
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    for name in ["facet", "kubectl", "admin-kubeconfig", "pki-bundle", "root"]:
+        parser.add_argument("--" + name, type=Path, required=True)
+    parser.add_argument("--namespace", required=True)
+    args = parser.parse_args()
+    for path in [args.facet, args.kubectl, args.admin_kubeconfig, args.pki_bundle]:
+        require(path.is_absolute() and path.is_file(), "tool/credential paths must be existing absolute files")
+    require(args.root.is_absolute() and args.root.is_dir(), "root must be an existing project directory")
+    require(args.namespace not in {"default", "kube-system", "kube-public", "kube-node-lease"}
+            and args.namespace.replace("-", "").isalnum(), "use an explicit non-system project namespace")
+    os.umask(0o077)
+    root = Path(tempfile.mkdtemp(prefix="facet-mcp-", dir=args.root))
+    credentials = root / "credentials"
+    credentials.mkdir(mode=0o700)
+    prefix = "facet-mcp-" + uuid.uuid4().hex[:10]
+    api = f"/api/v1/namespaces/{args.namespace}"
+    rbac = f"/apis/rbac.authorization.k8s.io/v1/namespaces/{args.namespace}"
+    created = []
+    mcp = None
+    transcript = (root / "transcript.jsonl").open("w")
+    summary = {"run_id": prefix, "artifact_directory": str(root), "namespace": args.namespace,
+               "harness": "deterministic MCP client; no OMP/Herdr/model claim", "outcome": "failed"}
+
+    def kubectl(*argv, value=None):
+        result = subprocess.run([str(args.kubectl), "--kubeconfig", str(args.admin_kubeconfig),
+                                 "--request-timeout=15s", *argv], input=None if value is None else json.dumps(value),
+                                capture_output=True, text=True, timeout=20)
+        require(result.returncode == 0, f"kubectl {argv[0]} failed: {result.stderr.strip()}")
+        return json.loads(result.stdout)
+
+    def create(plural, kind, fields):
+        obj = kubectl("create", "--raw", f"{rbac}/{plural}", "-f", "-", value={
+            "apiVersion": "rbac.authorization.k8s.io/v1", "kind": kind,
+            "metadata": {"name": prefix, "namespace": args.namespace, "annotations": {"hedronetes.io/acceptance-run": prefix}}, **fields})
+        created.append((f"{rbac}/{plural}/{prefix}", obj["metadata"]["uid"]))
+
+    def openssl(*argv):
+        result = subprocess.run(["openssl", *map(str, argv)], capture_output=True, timeout=20)
+        require(result.returncode == 0, "OpenSSL test credential generation failed")
+
+    try:
+        kubectl("get", "--raw", f"/api/v1/namespaces/{args.namespace}")
+        admin = json.loads(args.admin_kubeconfig.read_text())
+        cluster = admin["clusters"][0]["cluster"]
+        endpoint = cluster["server"].rstrip("/")
+        bundle = json.loads(args.pki_bundle.read_text())
+        ca_pem = bundle["ca"]["certificate_pem"]
+        require(base64.b64decode(cluster["certificate-authority-data"]).decode() == ca_pem,
+                "operator kubeconfig and PKI bundle CA differ")
+        with tempfile.TemporaryDirectory(prefix="issuer-", dir=credentials) as issuer:
+            issuer = Path(issuer)
+            (issuer / "ca.pem").write_text(ca_pem)
+            (issuer / "ca.key").write_text(bundle["ca"]["private_key_pem"])
+            openssl("genpkey", "-algorithm", "EC", "-pkeyopt", "ec_paramgen_curve:P-256", "-out", credentials / "client.key")
+            openssl("req", "-new", "-key", credentials / "client.key", "-subj", f"/CN={prefix}", "-out", issuer / "client.csr")
+            (issuer / "extensions").write_text("basicConstraints=critical,CA:FALSE\nkeyUsage=critical,digitalSignature\nextendedKeyUsage=clientAuth\n")
+            openssl("x509", "-req", "-in", issuer / "client.csr", "-CA", issuer / "ca.pem", "-CAkey", issuer / "ca.key",
+                    "-set_serial", "0x" + uuid.uuid4().hex, "-days", "3", "-extfile", issuer / "extensions", "-out", credentials / "client.pem")
+        del bundle
+        encode = lambda value: base64.b64encode(value).decode()
+        config = {"apiVersion": "v1", "kind": "Config", "current-context": "m1",
+                  "clusters": [{"name": "cluster", "cluster": cluster}],
+                  "users": [{"name": "facet", "user": {"client-certificate-data": encode((credentials / "client.pem").read_bytes()),
+                                                          "client-key-data": encode((credentials / "client.key").read_bytes())}}],
+                  "contexts": [{"name": "m1", "context": {"cluster": "cluster", "user": "facet", "namespace": args.namespace}}]}
+        (credentials / "kubeconfig").write_text(json.dumps(config))
+        del config
+        create("roles", "Role", {"rules": [{"apiGroups": [""], "resources": ["configmaps"], "verbs": ["create", "get", "list", "delete"]}]})
+        create("rolebindings", "RoleBinding", {"roleRef": {"apiGroup": "rbac.authorization.k8s.io", "kind": "Role", "name": prefix},
+                                               "subjects": [{"apiGroup": "rbac.authorization.k8s.io", "kind": "User", "name": prefix}]})
+        for directory in [root / "config", root / "machine"]:
+            directory.mkdir()
+        (root / "config/config.toml").write_text('[lattice]\nengine = "turso"\n')
+        env = dict(os.environ, FACET_CONFIG_DIR=str(root / "config"), FACET_DATA_DIR=str(root / "machine"),
+                   FACET_KUBECONFIG=str(credentials / "kubeconfig"), FACET_KUBE_CONTEXT="m1", FACET_ACTOR=prefix)
+        for name in ["FACET_SESSION", "FACET_NO_RECORD", "HERDR_WORKSPACE_ID", "HERDR_TAB_ID", "HERDR_PANE_ID"]:
+            env.pop(name, None)
+        mcp = Mcp(args.facet, env, root, transcript)
+        session = mcp.call("session_start", {"actor": prefix, "meta": {"acceptanceRun": prefix}})["session"]["id"]
+        mcp.close()
+        mcp = None
+        env["FACET_SESSION"] = session
+        mcp = Mcp(args.facet, env, root, transcript)
+        listed = mcp.request("tools/list", {})["result"]["tools"]
+        require({"request_run", "history_list", "history_get"} <= {tool["name"] for tool in listed}, "required MCP tools missing")
+        items = []
+        def item(name, method, path, body=None):
+            http = {"method": method, "url": endpoint + path}
+            if body is not None:
+                http["body"] = {"type": "json", "data": json.dumps(body)}
+            items.append({"info": {"name": name, "type": "http", "seq": len(items) + 1}, "http": http})
+        item("create", "POST", api + "/configmaps", {"apiVersion": "v1", "kind": "ConfigMap", "metadata": {"name": prefix, "namespace": args.namespace}, "data": {"acceptanceRun": prefix}})
+        item("read", "GET", api + "/configmaps/" + prefix)
+        item("denied-secret", "GET", api + "/secrets")
+        item("denied-namespace", "GET", "/api/v1/namespaces/kube-system/configmaps")
+        workspace = root / "workspace.yml"
+        def save():
+            workspace.write_text(json.dumps({"opencollection": "1.0.0", "info": {"name": "h3s MCP acceptance"}, "bundled": True, "items": items}, indent=2))
+        save()
+        runs = []
+        def action(index, status, expected_error=False):
+            doc = mcp.call("request_run", {"path": str(workspace), "selector": f"items/{index}", "expect": [200, 201], "tag": [prefix]}, expected_error)
+            require(doc["response"]["status"] == status, "unexpected h3s HTTP status")
+            require(doc["lattice"]["recorded"] and doc["lattice"]["indexed"], "action did not persist in both stores")
+            runs.append(doc["lattice"]["runId"])
+            return json.loads(doc["response"]["body"]["content"])
+        obj = action(0, 201)
+        cm_path = api + "/configmaps/" + prefix
+        created.append((cm_path, obj["metadata"]["uid"]))
+        require(action(1, 200) == obj, "MCP read differs from create")
+        action(2, 403, True)
+        action(3, 403, True)
+        item("delete", "DELETE", cm_path, {"apiVersion": "v1", "kind": "DeleteOptions", "preconditions": {"uid": obj["metadata"]["uid"]}})
+        save()
+        action(4, 200)
+        created.remove((cm_path, obj["metadata"]["uid"]))
+        history = mcp.call("history_list", {"path": str(workspace), "session": session})["runs"]
+        require({run["id"] for run in history} == set(runs), "session history lost a run")
+        require(sum(run["status"] == 403 for run in history) == 2, "denials missing from history")
+        mcp.close(); mcp = None
+        mcp = Mcp(args.facet, env, root, transcript)
+        again = mcp.call("history_list", {"path": str(workspace), "session": session})["runs"]
+        require(again == history, "MCP process reopen changed history")
+        mcp.call("session_end", {"id": session})
+        mcp.close(); mcp = None
+        for db in [root / ".facet/lattice.db", root / "machine/lattice.db"]:
+            require(db.with_suffix(db.suffix + ".engine").read_text() == "turso\n", "wrong database engine marker")
+        summary.update(outcome="passed", session_id=session, run_ids=runs, configmap_uid=obj["metadata"]["uid"],
+                       workspace_sha256=hashlib.sha256(workspace.read_bytes()).hexdigest(),
+                       verified=["mTLS h3s ConfigMap create/read/delete through MCP", "namespace and Secret RBAC denials", "Turso action/session history", "MCP process reopen"])
+    finally:
+        cleanup_errors = []
+        if mcp is not None:
+            try:
+                mcp.close()
+            except Exception as error:
+                cleanup_errors.append(str(error))
+        # A server may commit before a response/recording failure. Discover only
+        # this run's names and verify their nonce before considering cleanup.
+        candidates = [api + "/configmaps/" + prefix, rbac + "/roles/" + prefix, rbac + "/rolebindings/" + prefix]
+        for candidate in candidates:
+            if any(path == candidate for path, _ in created):
+                continue
+            try:
+                result = subprocess.run([str(args.kubectl), "--kubeconfig", str(args.admin_kubeconfig),
+                                         "--request-timeout=15s", "get", "--raw", candidate],
+                                        capture_output=True, text=True, timeout=20)
+                if result.returncode == 0:
+                    obj = json.loads(result.stdout)
+                    owned = (obj.get("data", {}).get("acceptanceRun") == prefix if obj["kind"] == "ConfigMap"
+                             else obj["metadata"].get("annotations", {}).get("hedronetes.io/acceptance-run") == prefix)
+                    require(owned, "cleanup ownership mismatch")
+                    created.append((candidate, obj["metadata"]["uid"]))
+                elif "NotFound" not in result.stderr:
+                    cleanup_errors.append("cannot inspect possible fixture after operation failure")
+            except Exception as error:
+                cleanup_errors.append(str(error))
+        for path, uid in reversed(created):
+            try:
+                kubectl("delete", "--raw", path, "-f", "-", value={"apiVersion": "v1", "kind": "DeleteOptions", "preconditions": {"uid": uid}})
+            except Exception as error:
+                cleanup_errors.append(str(error))
+        shutil.rmtree(credentials)
+        transcript.close()
+        summary["cleanup_errors"] = cleanup_errors
+        summary["credentials_removed"] = True
+        if cleanup_errors:
+            summary["outcome"] = "failed"
+        (root / "result.json").write_text(json.dumps(summary, indent=2) + "\n")
+        print(json.dumps(summary, indent=2))
+        require(not cleanup_errors, "fixture cleanup failed")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/support/cluster_pki.rs
+++ b/tests/support/cluster_pki.rs
@@ -1,0 +1,55 @@
+//! Ephemeral test-only keys, shared by HTTP and kubeconfig adapter tests.
+use rcgen::{
+    BasicConstraints, CertificateParams, DnType, ExtendedKeyUsagePurpose, IsCa, Issuer, KeyPair,
+    KeyUsagePurpose,
+};
+
+pub struct Pki {
+    pub ca: String,
+    pub server_cert: String,
+    pub server_key: String,
+    pub client_cert: String,
+    pub client_key: String,
+}
+impl Pki {
+    pub fn new(names: &[&str]) -> Self {
+        let mut ca_params = CertificateParams::default();
+        ca_params
+            .distinguished_name
+            .push(DnType::CommonName, "test-cluster-ca");
+        ca_params.is_ca = IsCa::Ca(BasicConstraints::Constrained(0));
+        ca_params.key_usages = vec![KeyUsagePurpose::KeyCertSign, KeyUsagePurpose::CrlSign];
+        let ca_key = KeyPair::generate().unwrap();
+        let ca_cert = ca_params.self_signed(&ca_key).unwrap();
+        let issuer = Issuer::from_params(&ca_params, &ca_key);
+        let issue = |name: &str, names: Vec<String>, usage| {
+            let mut params = CertificateParams::new(names).unwrap();
+            params.distinguished_name.push(DnType::CommonName, name);
+            params.key_usages = vec![KeyUsagePurpose::DigitalSignature];
+            params.extended_key_usages = vec![usage];
+            let key = KeyPair::generate().unwrap();
+            let cert = params.signed_by(&key, &issuer).unwrap();
+            (cert.pem(), key.serialize_pem())
+        };
+        let (server_cert, server_key) = issue(
+            "test-server",
+            names.iter().map(|v| v.to_string()).collect(),
+            ExtendedKeyUsagePurpose::ServerAuth,
+        );
+        let (client_cert, client_key) = issue(
+            "facet-test",
+            Vec::new(),
+            ExtendedKeyUsagePurpose::ClientAuth,
+        );
+        Self {
+            ca: ca_cert.pem(),
+            server_cert,
+            server_key,
+            client_cert,
+            client_key,
+        }
+    }
+    pub fn client_pem(&self) -> String {
+        format!("{}\n{}", self.client_cert, self.client_key)
+    }
+}


### PR DESCRIPTION
Facet's application history previously stayed on SQLite even with its `lattice-turso` feature, and its HTTP client did not load Kubernetes client credentials. This change enables real, authenticated cluster actions through Facet MCP with recording and recall through the actual Rust Turso engine.

`FACET_KUBECONFIG` selects one explicit certificate-based profile shared by CLI, replay, TUI and MCP. The transport verifies the cluster CA and hostname, restricts final URLs and redirects to that HTTPS origin, and keeps credentials out of the request model/history/debug output. Unsupported kubeconfig authentication, insecure TLS, proxies, and conflicting identity/routing headers fail closed. Configuration failures are recorded as failed actions.

Lattice's optional Rust Turso backend uses the same workspace/machine storage code as SQLite. Explicit configuration selects it; engine markers reject accidental cross-engine opens. Migrations, bodies, sessions, indexes, transaction rollback and concurrent process access are tested. Turso is pinned to `87c7a8516511c3ad2745c25b1079ea5c90112692`, with experimental multiprocess WAL enabled. SQLite remains the default; cross-engine import/export is not yet implemented.

The pinned Nix shell supplies Rust 1.98.1, bindgen dependencies and OpenSSL. Documentation covers configuration, file protection, supported transport/SQL subsets and rollback. Existing formatting/lint issues were corrected narrowly for strict CI while preserving public Recording ownership and palette behavior.

Validation at c46d95a:
- Local Rust 1.95: formatting, strict full-feature Clippy, 356 default tests and 365 full-feature tests pass.
- NixOS ARM64 / Rust 1.98.1: mutual-TLS and kubeconfig tests pass; the feature-enabled CLI builds and its versioned project installation launches directly.
- Two real NixOS MCP-to-h3s runs, including the installed binary, create/read/delete a ConfigMap, verify Secret and cross-namespace RBAC denials, record/index all five actions in Turso, and recover history after MCP restart.
- Temporary Role/RoleBinding/ConfigMap objects and test credentials are removed; independent cleanup checks pass. Sanitized transcripts, YAML, stores, hashes and result manifests are retained.
- GitHub reports no workflow runs/checks for this repository at this observation; no hosted CI pass is claimed.

This remains a draft of the broader M1 integration work. The native Turso live-path check now passes, but OMP/Herdr/Grok, the full workload fixture, HQL, clean system reproduction and portability remain separate unfinished acceptance gates.
