### PR TITLE
ci: shorten Windows CARGO_HOME to dodge Turso MAX_PATH

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -65,6 +65,11 @@ jobs:
 
     steps:
       - uses: actions/checkout@v7
+      # Turso git checkout exceeds Windows MAX_PATH under default CARGO_HOME
+      - name: Shorten Cargo home
+        if: matrix.platform == 'windows-x64'
+        shell: bash
+        run: echo "CARGO_HOME=C:\c" >> "$GITHUB_ENV"
       - uses: dtolnay/rust-toolchain@master
         with:
           toolchain: 1.95.0


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Release [run 34514855780](https://github.com/VirtualMachinist/facet/actions/runs/34514855780) (`v0.5.7`): Validate and linux/mac CLI builds succeeded; **windows-x64 CLI failed** with `path too long` while cargo checked out the Turso git dependency under the default `CARGO_HOME`. Publish was skipped.

## Fix

In `.github/workflows/release.yml`, the windows-x64 Build CLI matrix cell now sets `CARGO_HOME=C:\c` via `GITHUB_ENV` **before** `rust-toolchain` and `cargo build`. Linux and macOS cells are unchanged.

One-line comment in the workflow explains why (Turso git checkout / Windows `MAX_PATH`).

## Constraints

- Smallest change: workflow only
- No version bump, no retag, no merge

## Test plan

- [ ] Confirm the windows-x64 step is gated on `matrix.platform == 'windows-x64'`
- [ ] Confirm `CARGO_HOME` is exported before `dtolnay/rust-toolchain` and `cargo build`
- [ ] Re-run the Release workflow on the next `v*` tag (or a workflow_dispatch / dry run if added later) and check windows-x64 CLI succeeds

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-44ce1f0a-918a-4079-a204-ef57f328773d?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-44ce1f0a-918a-4079-a204-ef57f328773d&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

