### PR TITLE
ci: drop Windows from Release (Linux + macOS only)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,11 +52,6 @@ jobs:
             target: aarch64-apple-darwin
             exe: ""
             archive: tar.gz
-          - platform: windows-x64
-            os: windows-latest
-            target: x86_64-pc-windows-msvc
-            exe: ".exe"
-            archive: zip
           - platform: linux-x64
             os: ubuntu-22.04
             target: x86_64-unknown-linux-gnu
@@ -65,11 +60,6 @@ jobs:
 
     steps:
       - uses: actions/checkout@v7
-      # Turso git checkout exceeds Windows MAX_PATH under default CARGO_HOME
-      - name: Shorten Cargo home
-        if: matrix.platform == 'windows-x64'
-        shell: bash
-        run: echo "CARGO_HOME=C:\c" >> "$GITHUB_ENV"
       - uses: dtolnay/rust-toolchain@master
         with:
           toolchain: 1.95.0


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Evan decided Windows is out of Release. It is not a dogfood target, and Turso's git checkout still hits `MAX_PATH` on Windows even after the shortened `CARGO_HOME` workaround.

This change:
- Removes the `windows-x64` matrix entry from `build-cli`
- Removes the now-dead "Shorten Cargo home" step
- Leaves `macos-arm64` and `linux-x64` unchanged
- Leaves validate + publish jobs unchanged
- Does not touch main CI (Windows was already dropped there)

Leave the broken `v0.5.7` tag alone. After this merges, a retag or `v0.5.8` rebuild can publish Linux + macOS assets only.

Do not merge this PR from the agent — Evan merges.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7d4f342d-4259-42bc-b665-3171b322438c?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7d4f342d-4259-42bc-b665-3171b322438c&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

