### PR TITLE
feat: version truth for v0.6.0 (VT-01..VT-04)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,3 +43,10 @@ jobs:
       - run: cargo fmt --check
       - run: cargo clippy --all-targets --all-features -- -D warnings
       - run: cargo test --all-targets --all-features
+      # No tag on a PR, so gate the pair that exists: Cargo == `facet --version`.
+      # The tag leg is enforced on release (.github/workflows/release.yml).
+      - name: Version truth (Cargo == facet --version)
+        shell: bash
+        run: |
+          cargo build --release -p facet-cli --bin facet
+          ./scripts/version-check.sh --binary target/release/facet

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,6 +35,8 @@ jobs:
             libwayland-dev \
             libx11-xcb-dev \
             libxkbcommon-x11-dev
+      - name: Version truth (git tag == Cargo)
+        run: ./scripts/version-check.sh --tag "$GITHUB_REF_NAME"
       - run: cargo fmt --check
       - run: cargo clippy --all-targets --all-features -- -D warnings
       - run: cargo test --all-targets --all-features
@@ -71,6 +73,8 @@ jobs:
         id: metadata
         shell: bash
         run: |
+          # The tag is gated against Cargo in `validate` and against the built
+          # binary below, so all three agree by the time an asset is named.
           version="${GITHUB_REF_NAME#v}"
           asset_name="facet-cli-${version}-${{ matrix.platform }}"
           echo "version=${version}" >> "$GITHUB_OUTPUT"
@@ -85,6 +89,12 @@ jobs:
       - name: Verify CLI starts
         shell: bash
         run: '"dist/package/facet${{ matrix.exe }}" --help'
+      - name: Version truth (git tag == Cargo == facet --version)
+        shell: bash
+        run: |
+          ./scripts/version-check.sh \
+            --tag "$GITHUB_REF_NAME" \
+            --binary "dist/package/facet${{ matrix.exe }}"
       - name: Create tarball
         if: matrix.archive == 'tar.gz'
         shell: bash

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2332,7 +2332,7 @@ dependencies = [
 
 [[package]]
 name = "facet-cli"
-version = "0.5.9"
+version = "0.6.0"
 dependencies = [
  "crossterm 0.29.0",
  "facet-lattice",
@@ -2370,7 +2370,7 @@ dependencies = [
 
 [[package]]
 name = "facet-record"
-version = "0.5.9"
+version = "0.6.0"
 dependencies = [
  "base64 0.23.1",
  "facet-lattice",
@@ -2385,7 +2385,7 @@ dependencies = [
 
 [[package]]
 name = "facet-tui"
-version = "0.5.9"
+version = "0.6.0"
 dependencies = [
  "base64 0.23.1",
  "crossterm 0.29.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,8 +29,17 @@ default-members = [
 ]
 resolver = "2"
 
+# Three version axes, each independently true (see docs/FACET.md):
+#   1. Facet CLI     -- [workspace.package].version below. facet-cli, facet-tui,
+#                       and facet-record inherit it; this is the git tag `vX.Y.Z`.
+#   2. facet-lattice -- pinned in crates/lattice/Cargo.toml to its crates.io
+#                       release. NEVER bumped just to match the CLI.
+#   3. probe-*       -- pinned in each probe crate. Vendored Probe cut; NEVER
+#                       bumped just to make `facet --version` read symmetrical.
+# `facet --version` prints axes 1 and 3 together: `facet <facet> (probe <probe>)`.
+# scripts/version-check.sh is the gate that keeps tag == Cargo == binary.
 [workspace.package]
-version = "0.5.9"
+version = "0.6.0"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 rust-version = "1.95"

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 
 <p align="center">
   <a href="https://github.com/VirtualMachinist/facet/actions/workflows/ci.yml"><img src="https://img.shields.io/github/actions/workflow/status/VirtualMachinist/facet/ci.yml?branch=main&style=flat&colorA=1A1A1A&colorB=C9A227&label=ci" alt="CI"></a>
-  <a href="https://github.com/VirtualMachinist/facet/releases/tag/v0.5.9"><img src="https://img.shields.io/badge/Facet-v0.5.9-C9A227?style=flat&colorA=1A1A1A" alt="Facet v0.5.9"></a>
+  <a href="https://github.com/VirtualMachinist/facet/releases/tag/v0.6.0"><img src="https://img.shields.io/badge/Facet-v0.6.0-C9A227?style=flat&colorA=1A1A1A" alt="Facet v0.6.0"></a>
   <a href="https://crates.io/crates/facet-lattice"><img src="https://img.shields.io/crates/v/facet-lattice?style=flat&colorA=1A1A1A&colorB=C9A227" alt="facet-lattice on crates.io"></a>
   <a href="https://rustup.rs"><img src="https://img.shields.io/badge/Rust-1.95-F46623?style=flat&colorA=1A1A1A&logo=rust&logoColor=white" alt="Rust 1.95"></a>
   <a href="LICENSE"><img src="https://img.shields.io/badge/License-MIT%20%2F%20Apache--2.0-C9A227?style=flat&colorA=1A1A1A" alt="License"></a>
@@ -39,7 +39,7 @@
 
 Collections stay YAML; Git stays the sync layer. No account or hosted control plane. The `facet` binary coexists with `probe` on `PATH`.
 
-**0.5.9** · OpenCollection YAML · Ratatui TUI · SQLite run history
+**0.6.0** · OpenCollection YAML · Ratatui TUI · SQLite run history
 
 ## Quick start
 
@@ -126,9 +126,9 @@ docs/FACET.md             # Facet contracts
 
 ## Status
 
-**0.5.9** on `main` (next release). [`facet-lattice` 0.5.8](https://crates.io/crates/facet-lattice) is live on crates.io; **0.5.9** publishes after this PR merges (no yank of 0.5.8).
+**0.6.0** on `main` (next release). The `facet-lattice` crate is a separate version axis and does not follow the CLI: [`facet-lattice` 0.5.9](https://crates.io/crates/facet-lattice) is live on crates.io, with 0.5.8 still up (no yank).
 
-- **facet-lattice**: SQLite default. Scrubbed crate package ready for **0.5.9** publish.
+- **facet-lattice**: SQLite default. Scrubbed crate package published as **0.5.9**.
 - **CLI + TUI**: shipped. Deterministic JSON, SQL over history, Ratatui interface.
 - **Roadmap**: WebSocket, GraphQL, gRPC, theme files — [IMPLEMENTATION_PLAN.md](IMPLEMENTATION_PLAN.md).
 

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "probe-cli"
-version.workspace = true
+# Pinned: vendored Probe cut. Do NOT bump to match the Facet CLI version.
+version = "0.5.9"
 edition.workspace = true
 license.workspace = true
 rust-version.workspace = true

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "probe-core"
-version.workspace = true
+# Pinned: vendored Probe cut. Do NOT bump to match the Facet CLI version.
+version = "0.5.9"
 edition.workspace = true
 license.workspace = true
 rust-version.workspace = true

--- a/crates/desktop/Cargo.toml
+++ b/crates/desktop/Cargo.toml
@@ -1,7 +1,8 @@
 [package]
 name = "probe-desktop"
 description = "A fast, native, local-first API client"
-version.workspace = true
+# Pinned: vendored Probe cut. Do NOT bump to match the Facet CLI version.
+version = "0.5.9"
 edition.workspace = true
 license.workspace = true
 rust-version.workspace = true

--- a/crates/facet/src/lib.rs
+++ b/crates/facet/src/lib.rs
@@ -423,6 +423,42 @@ mod tests {
         assert!(value["probeVersion"].is_string());
     }
 
+    /// `scripts/version-check.sh` parses this exact human line to gate releases
+    /// (git tag == Cargo == binary). Reformatting it silently breaks that gate,
+    /// so the shape is pinned here rather than only in the JSON payload.
+    #[test]
+    fn version_human_line_stays_gateable() {
+        let output = run(["--version"]);
+        assert_eq!(output.exit_code, 0);
+        let human = String::from_utf8(output.stdout).unwrap();
+        let line = human.lines().next().expect("--version prints a line");
+
+        let facet_version = super::version();
+        let probe_version = probe_cli::version();
+        assert_eq!(
+            line,
+            format!("facet {facet_version} (probe {probe_version})")
+        );
+
+        // The gate reads the version as the second whitespace-separated field.
+        let mut fields = line.split_whitespace();
+        assert_eq!(fields.next(), Some("facet"));
+        assert_eq!(fields.next(), Some(facet_version));
+    }
+
+    /// The Facet CLI and the vendored Probe cut are independent version axes.
+    /// Neither is ever bumped just to make the parenthetical read symmetrical,
+    /// so this asserts the line reports each crate's own version, not one twice.
+    #[test]
+    fn version_axes_are_reported_independently() {
+        assert_eq!(super::version(), env!("CARGO_PKG_VERSION"));
+
+        let output = run(["--version", "--json"]);
+        let value: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+        assert_eq!(value["version"], env!("CARGO_PKG_VERSION"));
+        assert_eq!(value["probeVersion"], probe_cli::version());
+    }
+
     #[test]
     fn delegates_unknown_commands_to_probe() {
         let output = run(["collection", "validate", "/nonexistent/path.yml", "--json"]);

--- a/crates/http/Cargo.toml
+++ b/crates/http/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "probe-http"
-version.workspace = true
+# Pinned: vendored Probe cut. Do NOT bump to match the Facet CLI version.
+version = "0.5.9"
 edition.workspace = true
 license.workspace = true
 rust-version.workspace = true

--- a/crates/lattice/Cargo.toml
+++ b/crates/lattice/Cargo.toml
@@ -1,6 +1,8 @@
 [package]
 name = "facet-lattice"
-version.workspace = true
+# Pinned to the live crates.io release. Do NOT bump to match the Facet
+# CLI version; the lattice crate identity is its own version axis.
+version = "0.5.9"
 edition.workspace = true
 license = "MIT"
 rust-version.workspace = true

--- a/crates/opencollection/Cargo.toml
+++ b/crates/opencollection/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "probe-opencollection"
-version.workspace = true
+# Pinned: vendored Probe cut. Do NOT bump to match the Facet CLI version.
+version = "0.5.9"
 edition.workspace = true
 license.workspace = true
 rust-version.workspace = true

--- a/crates/postman/Cargo.toml
+++ b/crates/postman/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "probe-postman"
-version.workspace = true
+# Pinned: vendored Probe cut. Do NOT bump to match the Facet CLI version.
+version = "0.5.9"
 edition.workspace = true
 license.workspace = true
 rust-version.workspace = true

--- a/crates/yaak/Cargo.toml
+++ b/crates/yaak/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "probe-yaak"
-version.workspace = true
+# Pinned: vendored Probe cut. Do NOT bump to match the Facet CLI version.
+version = "0.5.9"
 edition.workspace = true
 license.workspace = true
 rust-version.workspace = true

--- a/docs/FACET.md
+++ b/docs/FACET.md
@@ -55,7 +55,7 @@ Install paths for strangers: [install.md](install.md) (`facet-lattice` on crates
 
 ```bash
 cargo build --release -p probe-cli -p facet-cli
-facet --version   # facet 0.5.9 (probe 0.5.9)
+facet --version   # facet 0.6.0 (probe 0.5.9)
 probe --version   # probe 0.5.9
 ```
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -61,7 +61,7 @@ The `facet` executable is **not** on crates.io as a one-line `cargo install`. Us
 ```bash
 export PATH="$HOME/.local/bin:$PATH"   # if needed
 facet --version
-# facet 0.5.9 (probe 0.5.9)
+# facet 0.6.0 (probe 0.5.9)
 ```
 
 ### From git (Rust toolchain required)
@@ -73,7 +73,7 @@ cargo install --git https://github.com/VirtualMachinist/facet --package facet-cl
 facet --version
 ```
 
-This compiles from `main` (or pass `--tag v0.5.9` to match a release). Expect a longer build than downloading a release archive.
+This compiles from `main` (or pass `--tag v0.6.0` to match a release). Expect a longer build than downloading a release archive.
 
 ### From a cloned repo (contributors)
 
@@ -92,7 +92,7 @@ facet --version
 ## Verify install
 
 ```bash
-facet --version          # human: facet 0.5.9 (probe 0.5.9)
+facet --version          # human: facet 0.6.0 (probe 0.5.9)
 facet --version --json   # structured version + probeVersion
 facet doctor --json      # machine + workspace stores, secrets backend, env flags
 ```
@@ -101,14 +101,20 @@ facet doctor --json      # machine + workspace stores, secrets backend, env flag
 
 ## Versions
 
+Facet carries three version axes. They are allowed to differ; each simply has
+to be true.
+
 | Artifact | Source | Version |
 | --- | --- | --- |
-| `facet-lattice` crate (live) | [crates.io](https://crates.io/crates/facet-lattice) | **0.5.8** |
-| `facet-lattice` crate (next) | this branch / post-merge publish | **0.5.9** |
-| `facet` / `probe` binaries | GitHub release tag | **v0.5.9** (when tagged) |
-| Workspace on `main` | this repository | **0.5.9** |
+| `facet` CLI / `facet-tui` / `facet-record` | `[workspace.package].version`, GitHub release tag | **0.6.0** (when tagged) |
+| `facet-lattice` crate | [crates.io](https://crates.io/crates/facet-lattice) | **0.5.9** live (0.5.8 also up) |
+| `probe-*` crates | vendored Probe cut, pinned per crate | **0.5.9** |
 
-**0.5.8** stays on crates.io (no yank). **0.5.9** is the scrubbed publish target after merge.
+`facet --version` prints the first and third together: `facet 0.6.0 (probe 0.5.9)`.
+The `facet-lattice` crate is never bumped to match the CLI, and the probe crates
+are never bumped to make that parenthetical look symmetrical. **0.5.8** stays on
+crates.io (no yank). `scripts/version-check.sh` is the gate that keeps the git
+tag, the Cargo version, and the built binary in agreement.
 
 ## Next steps
 

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -18,8 +18,11 @@ die() {
   exit 1
 }
 
+# The Facet CLI version is the release axis. probe-* and facet-lattice are
+# pinned on their own axes (see Cargo.toml), so reading probe-cli here would
+# report a version this release never bumps.
 package_version() {
-  cargo pkgid -p probe-cli | sed 's/.*@//'
+  cargo pkgid -p facet-cli | sed 's/.*[@#]//'
 }
 
 if [[ "${1:-}" == "-h" || "${1:-}" == "--help" ]]; then
@@ -78,6 +81,11 @@ updated_version="$(package_version)"
 
 [[ "$updated_version" == "$version" ]] \
   || die "Cargo metadata still reports ${updated_version}, expected ${version}"
+
+# Same gate CI and the release workflow run, before the tag exists to be wrong.
+cargo build --release -p facet-cli --bin facet
+scripts/version-check.sh --tag "$tag" --binary target/release/facet \
+  || die "version truth gate failed; refusing to tag ${tag}"
 
 git add Cargo.toml Cargo.lock
 git commit -m "release: ${tag}"

--- a/scripts/version-check.sh
+++ b/scripts/version-check.sh
@@ -1,0 +1,112 @@
+#!/usr/bin/env bash
+# Version truth gate for Facet.
+#
+# Facet carries three independent version axes (see Cargo.toml):
+#   1. Facet CLI     -- [workspace.package].version; the git tag `vX.Y.Z`.
+#   2. facet-lattice -- pinned in crates/lattice/Cargo.toml (crates.io identity).
+#   3. probe-*       -- pinned per probe crate (vendored Probe cut).
+#
+# This script gates axis 1 only, and asserts the three sources agree:
+#
+#   git tag  ==  Cargo (facet-cli)  ==  `facet --version`
+#
+# A release that disagrees on any pair is a lie about what a stranger installed,
+# so this exits non-zero and CI/release fails. It NEVER edits a version; fixing a
+# mismatch is a deliberate human bump, not an automatic rewrite.
+#
+# Usage:
+#   scripts/version-check.sh [--tag <vX.Y.Z>] [--binary <path/to/facet>]
+#
+#   --tag     Compare against a release tag (leading `v` optional). In GitHub
+#             Actions on a tag push, pass "$GITHUB_REF_NAME".
+#   --binary  Compare against a built binary's `--version` output.
+#
+# With neither flag it prints the Cargo version and exits 0, which is how you ask
+# "what version does this worktree claim?" without building anything.
+
+set -euo pipefail
+
+die() {
+  echo "version-check: $*" >&2
+  exit 1
+}
+
+tag=""
+binary=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --tag)
+      [[ $# -ge 2 ]] || die "--tag needs a value"
+      tag="$2"
+      shift 2
+      ;;
+    --binary)
+      [[ $# -ge 2 ]] || die "--binary needs a value"
+      binary="$2"
+      shift 2
+      ;;
+    -h | --help)
+      sed -n '2,28p' "$0" | sed 's/^# \{0,1\}//'
+      exit 0
+      ;;
+    *)
+      die "unknown argument: $1"
+    ;;
+  esac
+done
+
+git rev-parse --show-toplevel >/dev/null 2>&1 || die "must run inside the git worktree"
+cd "$(git rev-parse --show-toplevel)"
+
+# Axis 1, from Cargo. facet-cli is the crate that owns the `facet` binary, so it
+# is the only correct source here -- NOT probe-cli, which is pinned separately.
+cargo_version="$(cargo pkgid -p facet-cli | sed 's/.*[@#]//')"
+[[ -n "$cargo_version" ]] || die "could not read the facet-cli version from cargo"
+
+echo "cargo (facet-cli):  ${cargo_version}"
+
+failed=0
+
+if [[ -n "$tag" ]]; then
+  tag_version="${tag#v}"
+  echo "git tag:            ${tag}  (version ${tag_version})"
+  if [[ "$tag_version" != "$cargo_version" ]]; then
+    echo "MISMATCH: git tag ${tag} says ${tag_version}, Cargo says ${cargo_version}" >&2
+    failed=1
+  fi
+fi
+
+if [[ -n "$binary" ]]; then
+  [[ -x "$binary" ]] || die "not an executable binary: ${binary}"
+
+  # Human line is exactly: `facet <facet-version> (probe <probe-version>)`
+  version_line="$("$binary" --version)" || die "${binary} --version failed"
+  binary_version="$(printf '%s\n' "$version_line" | head -n1 | awk '{print $2}')"
+  probe_version="$(printf '%s\n' "$version_line" | head -n1 | sed -n 's/.*(probe \([^)]*\)).*/\1/p')"
+
+  [[ -n "$binary_version" ]] \
+    || die "could not parse a version out of: ${version_line}"
+
+  echo "facet --version:    ${version_line}"
+
+  if [[ "$binary_version" != "$cargo_version" ]]; then
+    echo "MISMATCH: binary says ${binary_version}, Cargo says ${cargo_version}" >&2
+    failed=1
+  fi
+
+  # The probe parenthetical is reported, never enforced. Facet and probe are
+  # allowed to diverge; both simply have to be true.
+  if [[ -n "$probe_version" ]]; then
+    echo "probe (reported):   ${probe_version}"
+  fi
+fi
+
+if [[ "$failed" -ne 0 ]]; then
+  echo "" >&2
+  echo "version truth is broken. Reconcile the tag and [workspace.package].version" >&2
+  echo "before releasing -- do not rename release assets to paper over it." >&2
+  exit 1
+fi
+
+echo "version truth: OK"


### PR DESCRIPTION
Slice A of the `v0.6.0` tag: version truth (VT-01..VT-04). Slice B (`:open`) is a stacked PR on `feat/v0.6-tui` and does not wait on this one.

## The bug

Tag `v0.5.8` shipped GitHub assets built from a `0.5.7` workspace. `release.yml` derived the asset version from the git tag alone (`${GITHUB_REF_NAME#v}`) and only ran `--help`, so nothing ever compared the tag, the Cargo version, and what the binary actually reports. README carried a stale badge on top of that.

## Root cause

Every crate in the workspace used `version.workspace = true` — a **single** version knob. That is how `v0.5.8` assets came out of a `0.5.7` workspace, and it also made the three requirements of this slice mutually unsatisfiable: bumping `[workspace.package].version` to `0.6.0` necessarily drags `facet-lattice` **and** every `probe-*` crate to `0.6.0` too.

So the fix is to split the axes, not just to bump a number.

## Three version axes

| Axis | Source | This tag |
| --- | --- | --- |
| Facet CLI (`facet-cli`, `facet-tui`, `facet-record`) | `[workspace.package].version`, inherited | **0.6.0** |
| `facet-lattice` | pinned in `crates/lattice/Cargo.toml` | **0.5.9** (live on crates.io) |
| `probe-*` (vendored Probe cut) | pinned per crate | **0.5.9** |

Each is independently true. `facet-lattice` is never bumped to match the CLI, and the probe crates are never bumped to make the `--version` parenthetical read symmetrical.

`facet-lattice` is pinned at **0.5.9**, not 0.5.8: crates.io serves 0.5.9 live (0.5.8 also up, unyanked) and `main` already carries it via #25. Pinning 0.5.8 would make the manifest claim a version older than what shipped. PM ruling 2026-09-11 accepted this.

## VT-01..VT-04

- **VT-01** — workspace to `0.6.0`; facet crates inherit, the other two axes pinned so the bump cannot drag them.
- **VT-02** — a citadel-built binary reports `facet 0.6.0 (probe 0.5.9)`. Probe reads 0.5.9 because that is what those crates actually are after #25 — they were not bumped to match the CLI.
- **VT-03** — new `scripts/version-check.sh` asserts **git tag == Cargo (`facet-cli`) == `facet --version`**, wired into:
  - `release.yml` — tag vs Cargo in `validate` (fails before any build), then tag vs Cargo vs the built binary before upload
  - `ci.yml` — Cargo vs binary, since a PR has no tag
  - `scripts/release.sh` — before it tags
  Asset names stay `facet-cli-<ver>-<platform>`. The script never rewrites a version; fixing a mismatch stays a deliberate human bump.
- **VT-04** — README badge and product line follow the workspace version; docs examples that print `facet --version` show the true string; `docs/install.md` documents the three axes instead of one number.

`scripts/release.sh` read its version from `probe-cli`, which is now pinned and would no longer track a release — it reads `facet-cli`.

## Verification (citadel)

```
$ ./scripts/version-check.sh --tag v0.6.0 --binary target/release/facet
cargo (facet-cli):  0.6.0
git tag:            v0.6.0  (version 0.6.0)
facet --version:    facet 0.6.0 (probe 0.5.9)
probe (reported):   0.5.9
version truth: OK

$ ./scripts/version-check.sh --tag v0.5.8 --binary target/release/facet   # exit 1
```

`cargo fmt --check` clean · `cargo clippy --all-targets --all-features -- -D warnings` 0 findings · 371 tests passing, 0 failures.

Two tests pin the contract the gate depends on: `version_human_line_stays_gateable` (the human line the script parses) and `version_axes_are_reported_independently`.

## Scope held

`crates/lattice` is touched on the version line only — the package rename stays with the in-flight cloud agent (yield rule, F8). `probe-*` crates are pinned, not otherwise modified. Tag `v0.5.8` was **not** retagged.

## Not in this PR

CR-02 / CR-03 (trail, do not block this tag). TUI `:open` is the stacked PR. Tagging, merging and any `cargo publish` need Evan GO.

> [!NOTE]
> Pre-existing and untouched by this branch: tag `v0.5.8` disagrees between citadel (`01409dc`) and origin (`2a66732`). Flagged for QA baseline; deliberately not retagged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JzkTNG1SFPNZLUE9rb9G2d
