### PR TITLE
feat(ncl): Nickel algebra — hedron-ncl, check/export/apply, World

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3468,6 +3468,7 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 [[package]]
 name = "hedron-core"
 version = "0.1.0"
+source = "git+https://github.com/VirtualMachinist/hedrondb.git?rev=3167d09032473b0f9f16ec73beed871e68100904#3167d09032473b0f9f16ec73beed871e68100904"
 dependencies = [
  "blake3",
  "indexmap",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -985,6 +985,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "blake3"
+version = "1.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d9e454fc11f76977dc803893aff6304ed33d6a26efae8696573bea74baa27ae"
+dependencies = [
+ "arrayvec 0.7.8",
+ "cc",
+ "cfg-if",
+ "constant_time_eq",
+ "cpufeatures 0.3.0",
+]
+
+[[package]]
 name = "block"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1588,6 +1601,12 @@ dependencies = [
  "once_cell",
  "tiny-keccak",
 ]
+
+[[package]]
+name = "constant_time_eq"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d52eff69cd5e647efe296129160853a42795992097e8af39800e1060caeea9b"
 
 [[package]]
 name = "convert_case"
@@ -2396,6 +2415,7 @@ dependencies = [
  "facet-lattice",
  "facet-record",
  "facet-tui",
+ "hedron-core",
  "hedron-ncl",
  "probe-cli",
  "probe-core",
@@ -2404,6 +2424,7 @@ dependencies = [
  "ratatui",
  "rusqlite",
  "serde_json",
+ "serde_yaml",
  "tempfile",
  "tokio",
 ]
@@ -3443,6 +3464,18 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "hedron-core"
+version = "0.1.0"
+dependencies = [
+ "blake3",
+ "indexmap",
+ "rusqlite",
+ "serde",
+ "serde_yaml",
+ "uuid",
+]
 
 [[package]]
 name = "hedron-ncl"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2396,6 +2396,7 @@ dependencies = [
  "facet-lattice",
  "facet-record",
  "facet-tui",
+ "hedron-ncl",
  "probe-cli",
  "probe-core",
  "probe-http",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -174,6 +174,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "aliasable"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "250f629c0161ad8107cf89319e990051fae62832fd343083bea452d93e2205fd"
+
+[[package]]
 name = "aligned"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -274,10 +280,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "arraydeque"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d902e3d592a523def97af8f317b08ce16b7ab854c1985a0c671e6f15cebc236"
+
+[[package]]
 name = "arrayref"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "76a2e8124351fda1ef8aaaa3bbd7ebbcb486bbcd4225aca0aa0d84bb2db8fecb"
+
+[[package]]
+name = "arrayvec"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23b62fc65de8e4e7f52534fb52b0f3ed04746ae267519eef2a83941e8085068b"
 
 [[package]]
 name = "arrayvec"
@@ -461,6 +479,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "516b6b4f0e40d50dcda9365d53964ec74560ad4284da2e7fc97122cd83174516"
 dependencies = [
  "stable_deref_trait",
+]
+
+[[package]]
+name = "ascii-canvas"
+version = "4.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef1e3e699d84ab1b0911a1010c5c106aa34ae89aeac103be5ce0c3859db1e891"
+dependencies = [
+ "term",
 ]
 
 [[package]]
@@ -777,7 +804,7 @@ dependencies = [
  "aligned",
  "anyhow",
  "arg_enum_proc_macro",
- "arrayvec",
+ "arrayvec 0.7.8",
  "log",
  "num-rational",
  "num-traits",
@@ -795,7 +822,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8cfddb07216410377231960af4fcab838eaa12e013417781b78bd95ee22077f8"
 dependencies = [
  "anyhow",
- "arrayvec",
+ "arrayvec 0.7.8",
  "log",
  "nom 8.0.0",
  "num-rational",
@@ -808,7 +835,7 @@ version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e7178fe5f7d460b13895ebb9dcb28a3a6216d2df2574a0806cb51b555d297f38"
 dependencies = [
- "arrayvec",
+ "arrayvec 0.7.8",
 ]
 
 [[package]]
@@ -941,6 +968,12 @@ name = "bitflags"
 version = "2.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b588b76d00fde79687d7646a9b5bdf3cc0f655e0bbd080335a95d7e96f3587da"
+
+[[package]]
+name = "bitmaps"
+version = "3.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1d084b0137aaa901caf9f1e8b21daa6aa24d41cd806e111335541eff9683bd6"
 
 [[package]]
 name = "bitstream-io"
@@ -1416,6 +1449,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "codespan"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "583f52b0658b321b25fd6b209b6c76cf058f433071297de64e5980c3d9aad937"
+dependencies = [
+ "codespan-reporting",
+ "serde",
+]
+
+[[package]]
 name = "codespan-reporting"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1441,6 +1484,12 @@ name = "color_quant"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d7b894f5411737b7867f4827955924d7c254fc9f4d91a6aad6b097804b1018b"
+
+[[package]]
+name = "colorchoice"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
 name = "combine"
@@ -2178,6 +2227,15 @@ dependencies = [
  "toml 1.1.4+spec-1.1.0",
  "vswhom",
  "winreg",
+]
+
+[[package]]
+name = "ena"
+version = "0.14.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eabffdaee24bd1bf95c5ef7cec31260444317e72ea56c4c91750e8b7ee58d5f1"
+dependencies = [
+ "log",
 ]
 
 [[package]]
@@ -3386,6 +3444,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
+name = "hedron-ncl"
+version = "0.6.0"
+dependencies = [
+ "nickel-lang-core",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.20",
+]
+
+[[package]]
 name = "hermit-abi"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3773,6 +3841,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09e54e57b4c48b40f7aec75635392b12b3421fa26fe8b4332e63138ed278459c"
 
 [[package]]
+name = "imbl-sized-chunks"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f4241005618a62f8d57b2febd02510fb96e0137304728543dfc5fd6f052c22d"
+dependencies = [
+ "bitmaps",
+]
+
+[[package]]
 name = "imgref"
 version = "1.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4025,6 +4102,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "json_scanner"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe0a2dc336065c75719cffd3c6c929e0ec4ed85b92b8248a7bbd999acb0e419c"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "kasuari"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4033,6 +4119,15 @@ dependencies = [
  "hashbrown 0.16.1",
  "portable-atomic",
  "thiserror 2.0.20",
+]
+
+[[package]]
+name = "keccak"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb26cec98cce3a3d96cbb7bced3c4b16e3d13f27ec56dbd62cbc8f39cfb9d653"
+dependencies = [
+ "cpufeatures 0.2.17",
 ]
 
 [[package]]
@@ -4099,10 +4194,42 @@ version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4b60dfc32f652b926df6192e55525b16d186c69d47876c3ead4da5cc9f8450e2"
 dependencies = [
- "arrayvec",
+ "arrayvec 0.7.8",
  "euclid",
  "polycool",
  "smallvec",
+]
+
+[[package]]
+name = "lalrpop"
+version = "0.22.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba4ebbd48ce411c1d10fb35185f5a51a7bfa3d8b24b4e330d30c9e3a34129501"
+dependencies = [
+ "ascii-canvas",
+ "bit-set 0.8.0",
+ "ena",
+ "itertools 0.14.0",
+ "lalrpop-util",
+ "petgraph",
+ "pico-args",
+ "regex",
+ "regex-syntax",
+ "sha3",
+ "string_cache",
+ "term",
+ "unicode-xid",
+ "walkdir",
+]
+
+[[package]]
+name = "lalrpop-util"
+version = "0.22.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5baa5e9ff84f1aefd264e6869907646538a52147a755d494517a8007fb48733"
+dependencies = [
+ "regex-automata",
+ "rustversion",
 ]
 
 [[package]]
@@ -4335,6 +4462,38 @@ dependencies = [
 ]
 
 [[package]]
+name = "logos"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb2c55a318a87600ea870ff8c2012148b44bf18b74fad48d0f835c38c7d07c5f"
+dependencies = [
+ "logos-derive",
+]
+
+[[package]]
+name = "logos-codegen"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "58b3ffaa284e1350d017a57d04ada118c4583cf260c8fb01e0fe28a2e9cf8970"
+dependencies = [
+ "fnv",
+ "proc-macro2",
+ "quote",
+ "regex-automata",
+ "regex-syntax",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "logos-derive"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52d3a9855747c17eaf4383823f135220716ab49bea5fbea7dd42cc9a92f8aa31"
+dependencies = [
+ "logos-codegen",
+]
+
+[[package]]
 name = "loop9"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4397,7 +4556,7 @@ version = "1.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4336502e29e32af93cf2dad2214ed6003c17ceb5bd499df77b1de663b9042b92"
 dependencies = [
- "arrayvec",
+ "arrayvec 0.7.8",
  "euclid",
  "num-traits",
 ]
@@ -4444,6 +4603,69 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a1b95cd5421ec55b445b5ae102f5ea0e768de1f82bd3001e11f426c269c3aea"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "malachite"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bba00455c89cf785ef73a0dfc941ab3c21211963c86130c0bd48d7994b942707"
+dependencies = [
+ "malachite-base",
+ "malachite-float",
+ "malachite-nz",
+ "malachite-q",
+]
+
+[[package]]
+name = "malachite-base"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4f44099731f17094b07825c88ccb5fbd1bfa1f82fafff7daa33e8b8652db16e"
+dependencies = [
+ "hashbrown 0.16.1",
+ "itertools 0.14.0",
+ "libm",
+ "ryu",
+]
+
+[[package]]
+name = "malachite-float"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a23982acc6f68aa384504a44d112f42fc82207035272f23485220a861e2cf1af"
+dependencies = [
+ "itertools 0.14.0",
+ "malachite-base",
+ "malachite-nz",
+ "malachite-q",
+ "serde",
+]
+
+[[package]]
+name = "malachite-nz"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a137660cdba20f136c8a223125f08088adb4e0b72fbb8466f08c43e31cc0427d"
+dependencies = [
+ "itertools 0.14.0",
+ "libm",
+ "malachite-base",
+ "serde",
+ "wide",
+]
+
+[[package]]
+name = "malachite-q"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ffcbeed95e34c0fcc3864ccd146e129cbbf7de1513d3afbcfb47c7674c82d94"
+dependencies = [
+ "itertools 0.14.0",
+ "libm",
+ "malachite-base",
+ "malachite-nz",
+ "serde",
 ]
 
 [[package]]
@@ -4589,7 +4811,7 @@ version = "29.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b2bf919621e7975acb27d881bae2fb993e0d45c8e0446e85e6272971e00dc8df"
 dependencies = [
- "arrayvec",
+ "arrayvec 0.7.8",
  "bit-set 0.9.1",
  "bitflags 2.13.1",
  "cfg-if",
@@ -4623,6 +4845,85 @@ name = "new_debug_unreachable"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086"
+
+[[package]]
+name = "nickel-lang-core"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "692d8a2ba34c633bc37e704dc94f4ca33edaa8fbf6d08efdcadb81db333ccdb6"
+dependencies = [
+ "base64 0.22.1",
+ "bumpalo",
+ "codespan",
+ "codespan-reporting",
+ "colorchoice",
+ "indexmap",
+ "indoc",
+ "json_scanner",
+ "lalrpop",
+ "lalrpop-util",
+ "logos",
+ "malachite",
+ "malachite-q",
+ "md-5",
+ "nickel-lang-parser",
+ "nickel-lang-vector",
+ "once_cell",
+ "ouroboros",
+ "paste",
+ "pretty",
+ "regex",
+ "saphyr-parser",
+ "serde",
+ "serde_json",
+ "serde_yaml",
+ "sha-1",
+ "sha2 0.10.9",
+ "simple-counter",
+ "smallvec",
+ "strip-ansi-escapes",
+ "strsim",
+ "toml 0.9.12+spec-1.1.0",
+ "toml_edit 0.24.1+spec-1.1.0",
+ "typed-arena",
+ "unicode-segmentation",
+]
+
+[[package]]
+name = "nickel-lang-parser"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7aaf73e60b66ef4fffc969b0e4e419a15a029525f9b53f2f5cc0ca41bbe17ff"
+dependencies = [
+ "bumpalo",
+ "codespan",
+ "codespan-reporting",
+ "indexmap",
+ "lalrpop",
+ "lalrpop-util",
+ "logos",
+ "malachite",
+ "nickel-lang-vector",
+ "ouroboros",
+ "pretty",
+ "regex",
+ "saphyr-parser",
+ "serde",
+ "serde_json",
+ "simple-counter",
+ "toml_edit 0.24.1+spec-1.1.0",
+ "typed-arena",
+]
+
+[[package]]
+name = "nickel-lang-vector"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "36f243832286908d8873add24a905d6732ffabd6cfb2bf74cb18d667e892e279"
+dependencies = [
+ "imbl-sized-chunks",
+ "serde",
+]
 
 [[package]]
 name = "nix"
@@ -5303,6 +5604,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "ouroboros"
+version = "0.18.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e0f050db9c44b97a94723127e6be766ac5c340c48f2c4bb3ffa11713744be59"
+dependencies = [
+ "aliasable",
+ "ouroboros_macro",
+ "static_assertions",
+]
+
+[[package]]
+name = "ouroboros_macro"
+version = "0.18.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c7028bdd3d43083f6d8d4d5187680d0d3560d54df4cc9d752005268b41e64d0"
+dependencies = [
+ "heck 0.4.1",
+ "proc-macro2",
+ "proc-macro2-diagnostics",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
 name = "palette"
 version = "0.7.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5432,13 +5757,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "petgraph"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3672b37090dbd86368a4145bc067582552b29c27377cad4e0a306c97f9bd7772"
+dependencies = [
+ "fixedbitset",
+ "indexmap",
+]
+
+[[package]]
 name = "phf"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c1562dc717473dbaa4c1f85a36410e03c047b2e7df7f45ee938fbef64ae7fadf"
 dependencies = [
  "phf_macros",
- "phf_shared",
+ "phf_shared 0.13.1",
  "serde",
 ]
 
@@ -5449,7 +5784,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "135ace3a761e564ec88c03a77317a7c6b80bb7f7135ef2544dbe054243b89737"
 dependencies = [
  "fastrand",
- "phf_shared",
+ "phf_shared 0.13.1",
 ]
 
 [[package]]
@@ -5459,10 +5794,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "812f032b54b1e759ccd5f8b6677695d5268c588701effba24601f6932f8269ef"
 dependencies = [
  "phf_generator",
- "phf_shared",
+ "phf_shared 0.13.1",
  "proc-macro2",
  "quote",
  "syn 2.0.119",
+]
+
+[[package]]
+name = "phf_shared"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67eabc2ef2a60eb7faa00097bd1ffdb5bd28e62bf39990626a582201b7a754e5"
+dependencies = [
+ "siphasher",
 ]
 
 [[package]]
@@ -5619,7 +5963,7 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "50596ddc09eb5ad5f75cacd40209568e66df71baf86e1499a0e99c4cff12a5a6"
 dependencies = [
- "arrayvec",
+ "arrayvec 0.7.8",
 ]
 
 [[package]]
@@ -5679,10 +6023,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "precomputed-hash"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "925383efa346730478fb4838dbe9137d2a47675ad789c546d150a6e1dd4ab31c"
+
+[[package]]
 name = "presser"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e8cf8e6a8aa66ce33f63993ffc4ea4271eb5b0530a9002db8455ea6050c77bfa"
+
+[[package]]
+name = "pretty"
+version = "0.12.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d22152487193190344590e4f30e219cf3fe140d9e7a3fdb683d82aa2c5f4156"
+dependencies = [
+ "arrayvec 0.5.2",
+ "typed-arena",
+ "unicode-width",
+]
 
 [[package]]
 name = "prettyplease"
@@ -5820,6 +6181,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "985e7ec9bb745e6ce6535b544d84d6cd6f7ad8bd711c398938ae983b91a766d9"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "proc-macro2-diagnostics"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af066a9c399a26e020ada66a034357a868728e72cd426f3adcd35f80d88d88c8"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+ "version_check",
+ "yansi",
 ]
 
 [[package]]
@@ -6208,7 +6582,7 @@ dependencies = [
  "aligned-vec",
  "arbitrary",
  "arg_enum_proc_macro",
- "arrayvec",
+ "arrayvec 0.7.8",
  "av-scenechange",
  "av1-grain",
  "bitstream-io",
@@ -6733,12 +7107,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
+name = "safe_arch"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42c6efa15875e6ecb39ca61fb0b0c1a40b84fac5a5ffe71eef7d1000c8eb3f5f"
+dependencies = [
+ "bytemuck",
+]
+
+[[package]]
 name = "same-file"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
 dependencies = [
  "winapi-util",
+]
+
+[[package]]
+name = "saphyr-parser"
+version = "0.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fb771b59f6b1985d1406325ec28f97cfb14256abcec4fdfb37b36a1766d6af7"
+dependencies = [
+ "arraydeque",
+ "hashlink 0.10.0",
 ]
 
 [[package]]
@@ -7006,6 +7399,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_yaml"
+version = "0.9.34+deprecated"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
+dependencies = [
+ "indexmap",
+ "itoa",
+ "ryu",
+ "serde",
+ "unsafe-libyaml",
+]
+
+[[package]]
 name = "serde_yaml_ng"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7016,6 +7422,17 @@ dependencies = [
  "ryu",
  "serde",
  "unsafe-libyaml",
+]
+
+[[package]]
+name = "sha-1"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f5058ada175748e33390e40e872bd0fe59a19f265d0158daa551c5a88a76009c"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.2.17",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -7044,6 +7461,16 @@ dependencies = [
  "cfg-if",
  "cpufeatures 0.3.0",
  "digest 0.11.3",
+]
+
+[[package]]
+name = "sha3"
+version = "0.10.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77fd7028345d415a4034cf8777cd4f8ab1851274233b45f84e3d955502d93874"
+dependencies = [
+ "digest 0.10.7",
+ "keccak",
 ]
 
 [[package]]
@@ -7128,6 +7555,12 @@ name = "simdutf8"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
+
+[[package]]
+name = "simple-counter"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4bb57743b52ea059937169c0061d70298fe2df1d2c988b44caae79dd979d9b49"
 
 [[package]]
 name = "simplecss"
@@ -7320,6 +7753,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6637bab7722d379c8b41ba849228d680cc12d0a45ba1fa2b48f2a30577a06731"
 dependencies = [
  "float-cmp",
+]
+
+[[package]]
+name = "string_cache"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf776ba3fa74f83bf4b63c3dcbbf82173db2632ed8452cb2d891d33f459de70f"
+dependencies = [
+ "new_debug_unreachable",
+ "parking_lot",
+ "phf_shared 0.11.3",
+ "precomputed-hash",
+]
+
+[[package]]
+name = "strip-ansi-escapes"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a8f8038e7e7969abb3f1b7c2a811225e9296da208539e0f79c5251d6cac0025"
+dependencies = [
+ "vte",
 ]
 
 [[package]]
@@ -7583,7 +8037,7 @@ version = "0.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "340a09581f29809fc0df82a3955501dc7f2a21f887e5d1c13dbe288fe1c0bef4"
 dependencies = [
- "arrayvec",
+ "arrayvec 0.7.8",
  "grid",
  "serde",
  "slotmap",
@@ -7633,6 +8087,15 @@ dependencies = [
  "getrandom 0.4.3",
  "once_cell",
  "rustix 1.1.4",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "term"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8c27177b12a6399ffc08b98f76f7c9a1f4fe9fc967c784c5a071fa8d93cf7e1"
+dependencies = [
  "windows-sys 0.61.2",
 ]
 
@@ -7756,7 +8219,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "83d13394d44dae3207b52a326c0c85a8bf87f1541f23b0d143811088497b09ab"
 dependencies = [
  "arrayref",
- "arrayvec",
+ "arrayvec 0.7.8",
  "bytemuck",
  "cfg-if",
  "log",
@@ -7874,6 +8337,21 @@ dependencies = [
 
 [[package]]
 name = "toml"
+version = "0.9.12+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf92845e79fc2e2def6a5d828f0801e29a2f8acc037becc5ab08595c7d5e9863"
+dependencies = [
+ "indexmap",
+ "serde_core",
+ "serde_spanned 1.1.1",
+ "toml_datetime 0.7.5+spec-1.1.0",
+ "toml_parser",
+ "toml_writer",
+ "winnow 0.7.15",
+]
+
+[[package]]
+name = "toml"
 version = "1.1.4+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3aace63f4bbcdfc2c965b059de67119c89c4017a70d633be6c104910f67056f5"
@@ -7898,6 +8376,15 @@ dependencies = [
 
 [[package]]
 name = "toml_datetime"
+version = "0.7.5+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92e1cfed4a3038bc5a127e35a2d360f145e1f4b971b551a2ba5fd7aedf7e1347"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
+name = "toml_datetime"
 version = "1.1.1+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3165f65f62e28e0115a00b2ebdd37eb6f3b641855f9d636d3cd4103767159ad7"
@@ -7916,6 +8403,19 @@ dependencies = [
  "serde_spanned 0.6.9",
  "toml_datetime 0.6.11",
  "toml_write",
+ "winnow 0.7.15",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.24.1+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "01f2eadbbc6b377a847be05f60791ef1058d9f696ecb51d2c07fe911d8569d8e"
+dependencies = [
+ "indexmap",
+ "toml_datetime 0.7.5+spec-1.1.0",
+ "toml_parser",
+ "toml_writer",
  "winnow 0.7.15",
 ]
 
@@ -8069,6 +8569,12 @@ checksum = "d2df906b07856748fa3f6e0ad0cbaa047052d4a7dd609e231c4f72cee8c36f31"
 dependencies = [
  "core_maths",
 ]
+
+[[package]]
+name = "typed-arena"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6af6ae20167a9ece4bcb41af5b80f8a1f1df981f6391189ce00fd257af04126a"
 
 [[package]]
 name = "typeid"
@@ -8398,6 +8904,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "vte"
+version = "0.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "231fdcd7ef3037e8330d8e17e61011a2c244126acc0a982f4040ac3f9f0bc077"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "wait-timeout"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8673,7 +9188,7 @@ version = "29.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "76e8840e1ba2881d4cbb18d2147627a56af426ff064c0401eb0c8410c6325d07"
 dependencies = [
- "arrayvec",
+ "arrayvec 0.7.8",
  "bitflags 2.13.1",
  "bytemuck",
  "cfg-if",
@@ -8703,7 +9218,7 @@ version = "29.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2f519832254e56965a9940c4af57dcb75f702b6f6fa4a0b172f685395843a4d7"
 dependencies = [
- "arrayvec",
+ "arrayvec 0.7.8",
  "bit-set 0.9.1",
  "bit-vec 0.9.1",
  "bitflags 2.13.1",
@@ -8774,7 +9289,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97ace1c17727311c22a46e4e3faf56ea6de81af99dcc839bdfb54857b94d448d"
 dependencies = [
  "android_system_properties",
- "arrayvec",
+ "arrayvec 0.7.8",
  "ash",
  "bit-set 0.9.1",
  "bitflags 2.13.1",
@@ -8855,6 +9370,16 @@ dependencies = [
  "home",
  "rustix 0.38.44",
  "winsafe",
+]
+
+[[package]]
+name = "wide"
+version = "1.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8cf05ca94c9fba0c51316899caa1d1e74a064fc310a5efa7375e614343d415be"
+dependencies = [
+ "bytemuck",
+ "safe_arch",
 ]
 
 [[package]]
@@ -9561,6 +10086,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a5a4b21e1a62b67a2970e6831bc091d7b87e119e7f9791aef9702e3bef04448"
 
 [[package]]
+name = "yansi"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfe53a6657fd280eaa890a3bc59152892ffa3e30101319d168b781ed6529b049"
+
+[[package]]
 name = "yasna"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9778,7 +10309,7 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d490156d0d7311855564d6e1d6dccab992405a0c0e15e1c8ef18920c02177e35"
 dependencies = [
- "arrayvec",
+ "arrayvec 0.7.8",
  "log",
  "rayon",
  "workspace-hack",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ members = [
     "crates/postman",
     "crates/facet-tui",
     "crates/yaak",
+    "crates/hedron-ncl",
 ]
 # Facet builds: probe-desktop stays a member (upstream merges stay clean) but is
 # excluded from the default set so `cargo build`/`cargo test` skip GPUI.
@@ -26,6 +27,7 @@ default-members = [
     "crates/postman",
     "crates/facet-tui",
     "crates/yaak",
+    "crates/hedron-ncl",
 ]
 resolver = "2"
 

--- a/crates/facet-record/src/lib.rs
+++ b/crates/facet-record/src/lib.rs
@@ -17,7 +17,7 @@ pub use diff::{
     diff_response_bodies, unified_diff,
 };
 pub use hydrate::{HydrateError, Hydration, overlay_secrets};
-pub use transport::{http_engine_from_env, http_engine_from_kubeconfig};
+pub use transport::{http_engine_from_env, http_engine_from_kubeconfig, kube_api_base_from_env};
 
 use lattice::{
     BodyInput, LatticeConfig, LatticeError, MachineStore, NewRun, Retention, RunRow,

--- a/crates/facet-record/src/transport.rs
+++ b/crates/facet-record/src/transport.rs
@@ -50,7 +50,9 @@ pub fn kube_api_base_from_env() -> Result<Option<String>, HttpError> {
         Err(_) => return Err(config("FACET_KUBE_CONTEXT is not valid UTF-8")),
     };
     let resolved = resolve_kubeconfig(Path::new(&path), context.as_deref())?;
-    Ok(Some(resolved.cluster.server.trim_end_matches('/').to_owned()))
+    Ok(Some(
+        resolved.cluster.server.trim_end_matches('/').to_owned(),
+    ))
 }
 
 /// Loads a single kubeconfig and creates a verified client-certificate engine.
@@ -88,9 +90,11 @@ fn resolve_kubeconfig(path: &Path, selected: Option<&str>) -> Result<ResolvedKub
     }
     let context_name = selected.unwrap_or(&kube.current_context);
     let context = unique(&kube.contexts, context_name, |entry| &entry.name)?;
-    let cluster = unique(&kube.clusters, &context.context.cluster, |entry| &entry.name)?
-        .cluster
-        .clone();
+    let cluster = unique(&kube.clusters, &context.context.cluster, |entry| {
+        &entry.name
+    })?
+    .cluster
+    .clone();
     let user = unique(&kube.users, &context.context.user, |entry| &entry.name)?
         .user
         .clone();

--- a/crates/facet-record/src/transport.rs
+++ b/crates/facet-record/src/transport.rs
@@ -35,12 +35,51 @@ pub fn http_engine_from_env() -> Result<HttpEngine, HttpError> {
     http_engine_from_kubeconfig(Path::new(&path), context.as_deref())
 }
 
+/// Returns the Kubernetes API server URL from `FACET_KUBECONFIG` when set.
+pub fn kube_api_base_from_env() -> Result<Option<String>, HttpError> {
+    let Some(path) = std::env::var_os("FACET_KUBECONFIG") else {
+        return Ok(None);
+    };
+    if path.is_empty() {
+        return Err(config("FACET_KUBECONFIG is empty"));
+    }
+    let context = match std::env::var("FACET_KUBE_CONTEXT") {
+        Ok(value) if !value.is_empty() => Some(value),
+        Ok(_) => return Err(config("FACET_KUBE_CONTEXT is empty")),
+        Err(std::env::VarError::NotPresent) => None,
+        Err(_) => return Err(config("FACET_KUBE_CONTEXT is not valid UTF-8")),
+    };
+    let resolved = resolve_kubeconfig(Path::new(&path), context.as_deref())?;
+    Ok(Some(resolved.cluster.server.trim_end_matches('/').to_owned()))
+}
+
 /// Loads a single kubeconfig and creates a verified client-certificate engine.
 /// This synchronous filesystem work belongs off the UI event thread.
 pub fn http_engine_from_kubeconfig(
     path: &Path,
     selected: Option<&str>,
 ) -> Result<HttpEngine, HttpError> {
+    let resolved = resolve_kubeconfig(path, selected)?;
+    let base = path.parent().unwrap_or_else(|| Path::new("."));
+    let ca = material(base, &resolved.cluster.ca_data, &resolved.cluster.ca_file)?;
+    let cert = material(base, &resolved.user.cert_data, &resolved.user.cert_file)?;
+    let key = material(base, &resolved.user.key_data, &resolved.user.key_file)?;
+    let mut identity = cert;
+    identity.push(b'\n');
+    identity.extend_from_slice(&key);
+    HttpEngine::with_cluster_tls(ClusterTls::from_pem(
+        &resolved.cluster.server,
+        &ca,
+        &identity,
+    )?)
+}
+
+struct ResolvedKube {
+    cluster: Cluster,
+    user: User,
+}
+
+fn resolve_kubeconfig(path: &Path, selected: Option<&str>) -> Result<ResolvedKube, HttpError> {
     let source = read_bounded(path)?;
     let kube: Kubeconfig =
         serde_yaml_ng::from_slice(&source).map_err(|_| config("invalid kubeconfig document"))?;
@@ -49,24 +88,18 @@ pub fn http_engine_from_kubeconfig(
     }
     let context_name = selected.unwrap_or(&kube.current_context);
     let context = unique(&kube.contexts, context_name, |entry| &entry.name)?;
-    let cluster = &unique(&kube.clusters, &context.context.cluster, |entry| {
-        &entry.name
-    })?
-    .cluster;
-    let user = &unique(&kube.users, &context.context.user, |entry| &entry.name)?.user;
+    let cluster = unique(&kube.clusters, &context.context.cluster, |entry| &entry.name)?
+        .cluster
+        .clone();
+    let user = unique(&kube.users, &context.context.user, |entry| &entry.name)?
+        .user
+        .clone();
     if cluster.insecure_skip_tls_verify || !cluster.extra.is_empty() || !user.extra.is_empty() {
         return Err(config(
             "unsupported kubeconfig transport/authentication: use verified CA and client certificate/key; exec, auth-provider, bearer tokens, proxies, TLS-name overrides and impersonation are not supported by this profile",
         ));
     }
-    let base = path.parent().unwrap_or_else(|| Path::new("."));
-    let ca = material(base, &cluster.ca_data, &cluster.ca_file)?;
-    let cert = material(base, &user.cert_data, &user.cert_file)?;
-    let key = material(base, &user.key_data, &user.key_file)?;
-    let mut identity = cert;
-    identity.push(b'\n');
-    identity.extend_from_slice(&key);
-    HttpEngine::with_cluster_tls(ClusterTls::from_pem(&cluster.server, &ca, &identity)?)
+    Ok(ResolvedKube { cluster, user })
 }
 
 fn unique<'a, T>(
@@ -154,7 +187,7 @@ struct Context {
     cluster: String,
     user: String,
 }
-#[derive(Deserialize)]
+#[derive(Deserialize, Clone)]
 struct Cluster {
     server: String,
     #[serde(default, rename = "certificate-authority-data")]
@@ -166,7 +199,7 @@ struct Cluster {
     #[serde(flatten)]
     extra: BTreeMap<String, Value>,
 }
-#[derive(Deserialize)]
+#[derive(Deserialize, Clone)]
 struct User {
     #[serde(default, rename = "client-certificate-data")]
     cert_data: Option<String>,

--- a/crates/facet/Cargo.toml
+++ b/crates/facet/Cargo.toml
@@ -16,6 +16,8 @@ crossterm = "0.29"
 facet-record = { path = "../facet-record" }
 facet-tui = { path = "../facet-tui" }
 facet-lattice = { path = "../lattice" }
+# The only Nickel VM on the platform: in-process, never a `nickel` subprocess.
+hedron-ncl = { path = "../hedron-ncl" }
 probe-cli = { path = "../cli" }
 probe-core = { path = "../core" }
 probe-http = { path = "../http" }

--- a/crates/facet/Cargo.toml
+++ b/crates/facet/Cargo.toml
@@ -18,7 +18,9 @@ facet-tui = { path = "../facet-tui" }
 facet-lattice = { path = "../lattice" }
 # The only Nickel VM on the platform: in-process, never a `nickel` subprocess.
 hedron-ncl = { path = "../hedron-ncl" }
-hedron-core = { path = "../../../hedrondb" }
+# ~/Projects/hedrondb for local work; path layout is not required to build.
+# Git pin so GHA can resolve without a sibling clone (PR #28 CI).
+hedron-core = { git = "https://github.com/VirtualMachinist/hedrondb.git", rev = "3167d09032473b0f9f16ec73beed871e68100904" }
 serde_yaml = "0.9"
 rusqlite = { version = "0.40", features = ["bundled"] }
 probe-cli = { path = "../cli" }

--- a/crates/facet/Cargo.toml
+++ b/crates/facet/Cargo.toml
@@ -18,6 +18,9 @@ facet-tui = { path = "../facet-tui" }
 facet-lattice = { path = "../lattice" }
 # The only Nickel VM on the platform: in-process, never a `nickel` subprocess.
 hedron-ncl = { path = "../hedron-ncl" }
+hedron-core = { path = "../../../hedrondb" }
+serde_yaml = "0.9"
+rusqlite = { version = "0.40", features = ["bundled"] }
 probe-cli = { path = "../cli" }
 probe-core = { path = "../core" }
 probe-http = { path = "../http" }

--- a/crates/facet/src/args.rs
+++ b/crates/facet/src/args.rs
@@ -151,14 +151,15 @@ const NCL_SECRET_SEGMENTS: &[&str] = &["token", "password", "api_key", "authoriz
 pub(crate) fn ncl(args: &[String]) -> Result<CommandOutput, FacetError> {
     let Some((verb, rest)) = args.split_first() else {
         return Err(FacetError::invalid_arguments(
-            "ncl requires a subcommand: check or export",
+            "ncl requires a subcommand: check, export, or apply",
         ));
     };
     match verb.as_str() {
         "check" => ncl_check(rest),
         "export" => ncl_export(rest),
+        "apply" => ncl_apply(rest),
         other => Err(FacetError::invalid_arguments(format!(
-            "unknown ncl subcommand: {other} (expected check or export)"
+            "unknown ncl subcommand: {other} (expected check, export, or apply)"
         ))),
     }
 }
@@ -195,6 +196,27 @@ fn ncl_check(args: &[String]) -> Result<CommandOutput, FacetError> {
         result.path.display(),
         result.module_hash,
         result.contract_set,
+    );
+    Ok(CommandOutput::new(human, json))
+}
+
+fn ncl_apply(args: &[String]) -> Result<CommandOutput, FacetError> {
+    let (path, overrides, frozen) = parse_ncl_cli(args)?;
+    if frozen {
+        return Err(FacetError::invalid_arguments(
+            "ncl apply does not support --frozen; use ncl export --frozen",
+        ));
+    }
+    let result = ncl::apply(&path, &overrides)?;
+    let json = versioned_json(result.to_json());
+    let human = format!(
+        "ok {} (moduleHash={} exportHash={} contractSet={} cluster.posted={} intent.put={})\n",
+        result.path.display(),
+        result.module_hash,
+        result.export_hash,
+        result.contract_set,
+        result.action.cluster.posted,
+        result.action.intent.put,
     );
     Ok(CommandOutput::new(human, json))
 }

--- a/crates/facet/src/args.rs
+++ b/crates/facet/src/args.rs
@@ -4,6 +4,12 @@
 
 use crate::FacetError;
 
+use std::path::{Path, PathBuf};
+
+use crate::{CommandOutput, ncl, versioned_json};
+use facet_record::{ConfigOverrides, open_store};
+use lattice::{HistoryQuery, WorkspaceStore};
+
 #[derive(Debug, Default)]
 pub(crate) struct Parsed {
     positionals: Vec<String>,
@@ -99,49 +105,6 @@ impl Parsed {
             .transpose()
     }
 }
-
-#[cfg(test)]
-mod tests {
-    use super::parse;
-
-    fn args(list: &[&str]) -> Vec<String> {
-        list.iter().map(|item| (*item).to_owned()).collect()
-    }
-
-    #[test]
-    fn parses_values_switches_and_positionals() {
-        let parsed = parse(
-            &args(&["a", "--limit", "5", "--tag=x", "--tag", "y", "--yes", "b"]),
-            &["--limit", "--tag"],
-            &["--yes"],
-        )
-        .unwrap();
-        assert_eq!(parsed.positionals(), ["a", "b"]);
-        assert_eq!(parsed.value("--limit").unwrap(), Some("5"));
-        assert_eq!(parsed.values("--tag"), ["x", "y"]);
-        assert!(parsed.switch("--yes"));
-        assert_eq!(
-            parsed.parsed_value::<usize>("--limit", "a number").unwrap(),
-            Some(5)
-        );
-    }
-
-    #[test]
-    fn rejects_unknown_and_duplicate_options() {
-        assert!(parse(&args(&["--nope"]), &[], &[]).is_err());
-        assert!(parse(&args(&["--yes", "--yes"]), &[], &["--yes"]).is_err());
-        assert!(parse(&args(&["--limit"]), &["--limit"], &[]).is_err());
-        let parsed = parse(&args(&["--limit", "1", "--limit", "2"]), &["--limit"], &[]).unwrap();
-        assert!(parsed.value("--limit").is_err());
-        assert!(parsed.parsed_value::<usize>("--limit", "a number").is_err());
-    }
-}
-
-use std::path::{Path, PathBuf};
-
-use crate::{CommandOutput, ncl, versioned_json};
-use facet_record::{ConfigOverrides, open_store};
-use lattice::{HistoryQuery, WorkspaceStore};
 
 const NCL_VALUE_FLAGS: &[&str] = &["--var"];
 const NCL_SWITCH_FLAGS: &[&str] = &["--frozen"];
@@ -338,4 +301,41 @@ fn module_url(workspace_root: &Path, path: &Path) -> String {
         .unwrap_or(path)
         .display()
         .to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::parse;
+
+    fn args(list: &[&str]) -> Vec<String> {
+        list.iter().map(|item| (*item).to_owned()).collect()
+    }
+
+    #[test]
+    fn parses_values_switches_and_positionals() {
+        let parsed = parse(
+            &args(&["a", "--limit", "5", "--tag=x", "--tag", "y", "--yes", "b"]),
+            &["--limit", "--tag"],
+            &["--yes"],
+        )
+        .unwrap();
+        assert_eq!(parsed.positionals(), ["a", "b"]);
+        assert_eq!(parsed.value("--limit").unwrap(), Some("5"));
+        assert_eq!(parsed.values("--tag"), ["x", "y"]);
+        assert!(parsed.switch("--yes"));
+        assert_eq!(
+            parsed.parsed_value::<usize>("--limit", "a number").unwrap(),
+            Some(5)
+        );
+    }
+
+    #[test]
+    fn rejects_unknown_and_duplicate_options() {
+        assert!(parse(&args(&["--nope"]), &[], &[]).is_err());
+        assert!(parse(&args(&["--yes", "--yes"]), &[], &["--yes"]).is_err());
+        assert!(parse(&args(&["--limit"]), &["--limit"], &[]).is_err());
+        let parsed = parse(&args(&["--limit", "1", "--limit", "2"]), &["--limit"], &[]).unwrap();
+        assert!(parsed.value("--limit").is_err());
+        assert!(parsed.parsed_value::<usize>("--limit", "a number").is_err());
+    }
 }

--- a/crates/facet/src/args.rs
+++ b/crates/facet/src/args.rs
@@ -137,11 +137,14 @@ mod tests {
     }
 }
 
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
+use facet_record::{open_store, ConfigOverrides};
+use lattice::{HistoryQuery, WorkspaceStore};
 use crate::{CommandOutput, ncl, versioned_json};
 
 const NCL_VALUE_FLAGS: &[&str] = &["--var"];
+const NCL_SWITCH_FLAGS: &[&str] = &["--frozen"];
 
 const NCL_SECRET_SEGMENTS: &[&str] = &["token", "password", "api_key", "authorization", "secret"];
 
@@ -179,7 +182,12 @@ pub(crate) fn reject_secret_overrides(overrides: &[String]) -> Result<(), FacetE
 }
 
 fn ncl_check(args: &[String]) -> Result<CommandOutput, FacetError> {
-    let (path, overrides) = parse_ncl_cli(args)?;
+    let (path, overrides, frozen) = parse_ncl_cli(args)?;
+    if frozen {
+        return Err(FacetError::invalid_arguments(
+            "ncl check does not support --frozen; use ncl export --frozen",
+        ));
+    }
     let result = ncl::check(&path, &overrides)?;
     let json = versioned_json(result.to_json());
     let human = format!(
@@ -192,7 +200,10 @@ fn ncl_check(args: &[String]) -> Result<CommandOutput, FacetError> {
 }
 
 fn ncl_export(args: &[String]) -> Result<CommandOutput, FacetError> {
-    let (path, overrides) = parse_ncl_cli(args)?;
+    let (path, overrides, frozen) = parse_ncl_cli(args)?;
+    if frozen {
+        refuse_if_export_changed(&path, &overrides)?;
+    }
     let result = ncl::export(&path, &overrides)?;
     let json = versioned_json(result.to_json());
     let human = format!(
@@ -205,8 +216,8 @@ fn ncl_export(args: &[String]) -> Result<CommandOutput, FacetError> {
     Ok(CommandOutput::new(human, json))
 }
 
-fn parse_ncl_cli(args: &[String]) -> Result<(PathBuf, Vec<String>), FacetError> {
-    let parsed = parse(args, NCL_VALUE_FLAGS, &[])?;
+fn parse_ncl_cli(args: &[String]) -> Result<(PathBuf, Vec<String>, bool), FacetError> {
+    let parsed = parse(args, NCL_VALUE_FLAGS, NCL_SWITCH_FLAGS)?;
     let [path] = parsed.positionals() else {
         return Err(FacetError::invalid_arguments(
             "ncl requires <path> to a .ncl module",
@@ -225,5 +236,83 @@ fn parse_ncl_cli(args: &[String]) -> Result<(PathBuf, Vec<String>), FacetError> 
         })
         .collect::<Result<Vec<_>, _>>()?;
     reject_secret_overrides(&overrides)?;
-    Ok((PathBuf::from(path), overrides))
+    Ok((PathBuf::from(path), overrides, parsed.switch("--frozen")))
+}
+
+/// Re-evaluates without recording and refuses when the export hash drifted.
+fn refuse_if_export_changed(path: &Path, overrides: &[String]) -> Result<(), FacetError> {
+    let Some((run_id, recorded_hash)) = lookup_recorded_export(path)? else {
+        return Err(FacetError::invalid_arguments(
+            "--frozen requires a prior ncl export recorded in Lattice for this module",
+        ));
+    };
+
+    let current = ncl::evaluate(path, overrides)?;
+
+    if current.export_hash != recorded_hash {
+        return Err(FacetError::replay_changed(
+            &run_id,
+            &recorded_hash,
+            &current.export_hash,
+        ));
+    }
+    Ok(())
+}
+
+fn lookup_recorded_export(path: &Path) -> Result<Option<(String, String)>, FacetError> {
+    let workspace_root = workspace_root_for(path)?;
+    let store = match WorkspaceStore::discover(&workspace_root) {
+        Some(root) => open_store(&root, &ConfigOverrides::default()).map_err(FacetError::lattice)?,
+        None => return Ok(None),
+    };
+    let module_url = module_url(&workspace_root, path);
+    let rows = store
+        .history(&HistoryQuery {
+            limit: 50,
+            request_path: Some("ncl:export".to_owned()),
+            status: None,
+            actor: None,
+            since: None,
+            session_id: None,
+            environment: None,
+            tags: Vec::new(),
+            hash: None,
+        })
+        .map_err(FacetError::lattice)?;
+    for row in rows {
+        if row.url != module_url {
+            continue;
+        }
+        if let Some(hash) = export_hash_from_tags(row.tags.as_deref()) {
+            return Ok(Some((row.id.clone(), hash)));
+        }
+    }
+    Ok(None)
+}
+
+fn export_hash_from_tags(tags: Option<&str>) -> Option<String> {
+    let tags: Vec<String> = tags
+        .and_then(|text| serde_json::from_str(text).ok())
+        .unwrap_or_default();
+    tags.into_iter()
+        .find_map(|tag| tag.strip_prefix("ncl:export:").map(str::to_owned))
+}
+
+
+fn workspace_root_for(path: &Path) -> Result<PathBuf, FacetError> {
+    if let Some(root) = WorkspaceStore::discover(path) {
+        return Ok(root);
+    }
+    let parent = path
+        .parent()
+        .filter(|dir| !dir.as_os_str().is_empty())
+        .unwrap_or(path);
+    Ok(parent.to_path_buf())
+}
+
+fn module_url(workspace_root: &Path, path: &Path) -> String {
+    path.strip_prefix(workspace_root)
+        .unwrap_or(path)
+        .display()
+        .to_string()
 }

--- a/crates/facet/src/args.rs
+++ b/crates/facet/src/args.rs
@@ -136,3 +136,94 @@ mod tests {
         assert!(parsed.parsed_value::<usize>("--limit", "a number").is_err());
     }
 }
+
+use std::path::PathBuf;
+
+use crate::{CommandOutput, ncl, versioned_json};
+
+const NCL_VALUE_FLAGS: &[&str] = &["--var"];
+
+const NCL_SECRET_SEGMENTS: &[&str] = &["token", "password", "api_key", "authorization", "secret"];
+
+pub(crate) fn ncl(args: &[String]) -> Result<CommandOutput, FacetError> {
+    let Some((verb, rest)) = args.split_first() else {
+        return Err(FacetError::invalid_arguments(
+            "ncl requires a subcommand: check or export",
+        ));
+    };
+    match verb.as_str() {
+        "check" => ncl_check(rest),
+        "export" => ncl_export(rest),
+        other => Err(FacetError::invalid_arguments(format!(
+            "unknown ncl subcommand: {other} (expected check or export)"
+        ))),
+    }
+}
+
+pub(crate) fn reject_secret_overrides(overrides: &[String]) -> Result<(), FacetError> {
+    for assignment in overrides {
+        let path = assignment
+            .split_once("=")
+            .map(|(path, _)| path)
+            .unwrap_or(assignment.as_str());
+        for segment in path.split(".") {
+            let lower = segment.to_ascii_lowercase();
+            if NCL_SECRET_SEGMENTS.iter().any(|secret| lower == *secret) {
+                return Err(FacetError::invalid_arguments(format!(
+                    "refuses secret field override `{path}`; use secret_ref and Facet env hydration instead"
+                )));
+            }
+        }
+    }
+    Ok(())
+}
+
+fn ncl_check(args: &[String]) -> Result<CommandOutput, FacetError> {
+    let (path, overrides) = parse_ncl_cli(args)?;
+    let result = ncl::check(&path, &overrides)?;
+    let json = versioned_json(result.to_json());
+    let human = format!(
+        "ok {} (moduleHash={} contractSet={})\n",
+        result.path.display(),
+        result.module_hash,
+        result.contract_set,
+    );
+    Ok(CommandOutput::new(human, json))
+}
+
+fn ncl_export(args: &[String]) -> Result<CommandOutput, FacetError> {
+    let (path, overrides) = parse_ncl_cli(args)?;
+    let result = ncl::export(&path, &overrides)?;
+    let json = versioned_json(result.to_json());
+    let human = format!(
+        "ok {} (moduleHash={} exportHash={} contractSet={})\n",
+        result.path.display(),
+        result.module_hash,
+        result.export_hash,
+        result.contract_set,
+    );
+    Ok(CommandOutput::new(human, json))
+}
+
+fn parse_ncl_cli(args: &[String]) -> Result<(PathBuf, Vec<String>), FacetError> {
+    let parsed = parse(args, NCL_VALUE_FLAGS, &[])?;
+    let [path] = parsed.positionals() else {
+        return Err(FacetError::invalid_arguments(
+            "ncl requires <path> to a .ncl module",
+        ));
+    };
+    let overrides = parsed
+        .values("--var")
+        .into_iter()
+        .map(|entry| {
+            if !entry.contains("=") {
+                return Err(FacetError::invalid_arguments(format!(
+                    "--var expects path.to.field=value, got {entry:?}"
+                )));
+            }
+            Ok(entry.to_owned())
+        })
+        .collect::<Result<Vec<_>, _>>()?;
+    reject_secret_overrides(&overrides)?;
+    Ok((PathBuf::from(path), overrides))
+}

--- a/crates/facet/src/args.rs
+++ b/crates/facet/src/args.rs
@@ -139,9 +139,9 @@ mod tests {
 
 use std::path::{Path, PathBuf};
 
-use facet_record::{open_store, ConfigOverrides};
-use lattice::{HistoryQuery, WorkspaceStore};
 use crate::{CommandOutput, ncl, versioned_json};
+use facet_record::{ConfigOverrides, open_store};
+use lattice::{HistoryQuery, WorkspaceStore};
 
 const NCL_VALUE_FLAGS: &[&str] = &["--var"];
 const NCL_SWITCH_FLAGS: &[&str] = &["--frozen"];
@@ -284,7 +284,9 @@ fn refuse_if_export_changed(path: &Path, overrides: &[String]) -> Result<(), Fac
 fn lookup_recorded_export(path: &Path) -> Result<Option<(String, String)>, FacetError> {
     let workspace_root = workspace_root_for(path)?;
     let store = match WorkspaceStore::discover(&workspace_root) {
-        Some(root) => open_store(&root, &ConfigOverrides::default()).map_err(FacetError::lattice)?,
+        Some(root) => {
+            open_store(&root, &ConfigOverrides::default()).map_err(FacetError::lattice)?
+        }
         None => return Ok(None),
     };
     let module_url = module_url(&workspace_root, path);
@@ -319,7 +321,6 @@ fn export_hash_from_tags(tags: Option<&str>) -> Option<String> {
     tags.into_iter()
         .find_map(|tag| tag.strip_prefix("ncl:export:").map(str::to_owned))
 }
-
 
 fn workspace_root_for(path: &Path) -> Result<PathBuf, FacetError> {
     if let Some(root) = WorkspaceStore::discover(path) {

--- a/crates/facet/src/lib.rs
+++ b/crates/facet/src/lib.rs
@@ -293,7 +293,7 @@ where
         None => true,
         Some(
             "history" | "last" | "pin" | "mcp" | "session" | "replay" | "diff" | "env" | "doctor"
-            | "blob" | "gc" | "theme" | "tui" | "-V" | "--version" | "-h" | "--help",
+            | "blob" | "gc" | "theme" | "tui" | "ncl" | "-V" | "--version" | "-h" | "--help",
         ) => true,
         Some("request") => args.get(1).map(String::as_str) == Some("run"),
         Some(_) => false,
@@ -347,6 +347,7 @@ where
         "blob" => history::blob(&args[1..]),
         "gc" => history::gc(&args[1..]),
         "theme" => theme::theme(&args[1..]),
+        "ncl" => args::ncl(&args[1..]),
         "tui" => Err(FacetError::invalid_arguments(
             "tui is interactive and must be started from the facet binary",
         )),

--- a/crates/facet/src/lib.rs
+++ b/crates/facet/src/lib.rs
@@ -12,6 +12,8 @@
 //! - `env` sets and lists machine-store environment values (metadata only on read).
 //! - `request run --expect` / `--dry-run`: the assertion (exit 1) and the preview.
 //! - `mcp` serves the same functions as Model Context Protocol tools over stdio.
+//! - `ncl check` / `ncl export` evaluate Nickel in-process (`hedron-ncl`); Facet
+//!   is the only Nickel VM on the platform.
 //! - `tui` opens the terminal UI.
 //!
 //! Contract details for the Facet-only commands live in `docs/FACET.md`.
@@ -30,6 +32,7 @@ mod error;
 mod expect;
 mod history;
 mod mcp;
+pub mod ncl;
 mod pin;
 mod presentation;
 mod replay;

--- a/crates/facet/src/lib.rs
+++ b/crates/facet/src/lib.rs
@@ -12,8 +12,8 @@
 //! - `env` sets and lists machine-store environment values (metadata only on read).
 //! - `request run --expect` / `--dry-run`: the assertion (exit 1) and the preview.
 //! - `mcp` serves the same functions as Model Context Protocol tools over stdio.
-//! - `ncl check` / `ncl export` evaluate Nickel in-process (`hedron-ncl`); Facet
-//!   is the only Nickel VM on the platform.
+//! - `ncl check` / `ncl export` / `ncl apply` evaluate Nickel in-process
+//!   (`hedron-ncl`); Facet is the only Nickel VM on the platform.
 //! - `tui` opens the terminal UI.
 //!
 //! Contract details for the Facet-only commands live in `docs/FACET.md`.
@@ -33,6 +33,7 @@ mod expect;
 mod history;
 mod mcp;
 pub mod ncl;
+mod ncl_apply;
 mod ncl_ledger;
 mod pin;
 mod presentation;

--- a/crates/facet/src/lib.rs
+++ b/crates/facet/src/lib.rs
@@ -33,6 +33,7 @@ mod expect;
 mod history;
 mod mcp;
 pub mod ncl;
+mod ncl_ledger;
 mod pin;
 mod presentation;
 mod replay;

--- a/crates/facet/src/mcp.rs
+++ b/crates/facet/src/mcp.rs
@@ -16,6 +16,7 @@
 //! goes to stderr only. No HTTP transport in v1.
 
 use std::io::{self, BufRead, Write};
+use std::path::Path;
 
 use lattice::{LatticeConfig, MachineStore, WorkspaceStore};
 use serde_json::{Map, Value, json};
@@ -67,6 +68,8 @@ pub const TOOLS: &[&str] = &[
     "blob_get",
     "run_diff",
     "run_replay",
+    "ncl_check",
+    "ncl_export",
     "sql_query",
 ];
 
@@ -331,6 +334,18 @@ fn dispatch(name: &str, arguments: &Map<String, Value>) -> Result<CommandOutput,
             argv.push(args.required("sql")?);
             history::history(&argv)
         }
+        "ncl_check" => {
+            let path = args.required("path")?;
+            let overrides = ncl_overrides(&args)?;
+            let result = crate::ncl::check(Path::new(&path), &overrides)?;
+            Ok(CommandOutput::new(Vec::new(), result.to_json()))
+        }
+        "ncl_export" => {
+            let path = args.required("path")?;
+            let overrides = ncl_overrides(&args)?;
+            let result = crate::ncl::export(Path::new(&path), &overrides)?;
+            Ok(CommandOutput::new(Vec::new(), result.to_json()))
+        }
         other => Err(FacetError::invalid_arguments(format!(
             "unknown tool: {other}"
         ))),
@@ -354,6 +369,17 @@ fn delegate(argv: &[&str]) -> Result<CommandOutput, FacetError> {
 /// MCP must not take raw secrets as tool arguments when a Lattice env key
 /// exists: the value would sit in the client's transcript. Hydration
 /// supplies stored values; `facet env set` changes them.
+
+
+fn ncl_overrides(args: &Args) -> Result<Vec<String>, FacetError> {
+    let pairs = args.vars("var")?;
+    let overrides: Vec<String> = pairs
+        .iter()
+        .map(|(path, value)| format!("{path}={value}"))
+        .collect();
+    crate::args::reject_secret_overrides(&overrides)?;
+    Ok(overrides)
+}
 fn reject_lattice_backed_vars(
     path: &str,
     environment: Option<&str>,
@@ -541,6 +567,11 @@ pub(crate) fn tool_descriptions() -> Vec<Value> {
         "description": "Assert the status after a real run: \"2xx\", \"200,201\", or an array like [200, \"3xx\"]. Miss → exit 1 expect_failed with the full document.",
         "oneOf": [ { "type": "string" }, { "type": "array", "items": { "oneOf": [ { "type": "integer" }, { "type": "string" } ] } } ]
     });
+    let ncl_var = json!({
+        "type": "object",
+        "additionalProperties": { "type": "string" },
+        "description": "Nickel field overrides (path.to.field → expression). Never a secret value or secret field path."
+    });
     let var = json!({
         "type": "object",
         "additionalProperties": { "type": "string" },
@@ -678,6 +709,28 @@ pub(crate) fn tool_descriptions() -> Vec<Value> {
                     "frozen": boolean("Refuse when the resolved request differs from the recorded hash"),
                 }),
                 &["id"],
+            ),
+        ),
+        tool(
+            "ncl_check",
+            "Parse, typecheck and evaluate a Nickel world module in-process. Returns { path, moduleHash, contractSet }. Nothing persisted.",
+            schema(
+                json!({
+                    "path": string("Path to a .ncl module"),
+                    "var": ncl_var.clone(),
+                }),
+                &["path"],
+            ),
+        ),
+        tool(
+            "ncl_export",
+            "eval_full_for_export on a Nickel world module. Returns { path, moduleHash, exportHash, contractSet, cluster, intent, calls }. Fields marked | not_exported are absent.",
+            schema(
+                json!({
+                    "path": string("Path to a .ncl module"),
+                    "var": ncl_var.clone(),
+                }),
+                &["path"],
             ),
         ),
         tool(

--- a/crates/facet/src/mcp.rs
+++ b/crates/facet/src/mcp.rs
@@ -70,6 +70,7 @@ pub const TOOLS: &[&str] = &[
     "run_replay",
     "ncl_check",
     "ncl_export",
+    "ncl_apply",
     "sql_query",
 ];
 
@@ -344,6 +345,12 @@ fn dispatch(name: &str, arguments: &Map<String, Value>) -> Result<CommandOutput,
             let path = args.required("path")?;
             let overrides = ncl_overrides(&args)?;
             let result = crate::ncl::export(Path::new(&path), &overrides)?;
+            Ok(CommandOutput::new(Vec::new(), result.to_json()))
+        }
+        "ncl_apply" => {
+            let path = args.required("path")?;
+            let overrides = ncl_overrides(&args)?;
+            let result = crate::ncl::apply(Path::new(&path), &overrides)?;
             Ok(CommandOutput::new(Vec::new(), result.to_json()))
         }
         other => Err(FacetError::invalid_arguments(format!(
@@ -725,6 +732,17 @@ pub(crate) fn tool_descriptions() -> Vec<Value> {
         tool(
             "ncl_export",
             "eval_full_for_export on a Nickel world module. Returns { path, moduleHash, exportHash, contractSet, cluster, intent, calls }. Fields marked | not_exported are absent.",
+            schema(
+                json!({
+                    "path": string("Path to a .ncl module"),
+                    "var": ncl_var.clone(),
+                }),
+                &["path"],
+            ),
+        ),
+        tool(
+            "ncl_apply",
+            "Export a Nickel world module, POST frozen cluster JSON when FACET_KUBECONFIG is set, put intent rows through Hedron Store when FACET_HEDRON_DB is set, and record one ncl:apply Lattice row. Returns export fields plus action summary.",
             schema(
                 json!({
                     "path": string("Path to a .ncl module"),

--- a/crates/facet/src/mcp.rs
+++ b/crates/facet/src/mcp.rs
@@ -377,7 +377,6 @@ fn delegate(argv: &[&str]) -> Result<CommandOutput, FacetError> {
 /// exists: the value would sit in the client's transcript. Hydration
 /// supplies stored values; `facet env set` changes them.
 
-
 fn ncl_overrides(args: &Args) -> Result<Vec<String>, FacetError> {
     let pairs = args.vars("var")?;
     let overrides: Vec<String> = pairs

--- a/crates/facet/src/mcp.rs
+++ b/crates/facet/src/mcp.rs
@@ -376,7 +376,6 @@ fn delegate(argv: &[&str]) -> Result<CommandOutput, FacetError> {
 /// MCP must not take raw secrets as tool arguments when a Lattice env key
 /// exists: the value would sit in the client's transcript. Hydration
 /// supplies stored values; `facet env set` changes them.
-
 fn ncl_overrides(args: &Args) -> Result<Vec<String>, FacetError> {
     let pairs = args.vars("var")?;
     let overrides: Vec<String> = pairs

--- a/crates/facet/src/ncl.rs
+++ b/crates/facet/src/ncl.rs
@@ -1,0 +1,300 @@
+//! `facet ncl check|export`: the in-process Nickel embed (SPEC-nickel G1a).
+//!
+//! Facet is the only process on the platform that evaluates Nickel. It does so
+//! by linking `hedron-ncl` (which pins `nickel-lang-core`); it never shells out
+//! to a `nickel` binary. This module owns the two operations; `args.rs` and
+//! `mcp.rs` wrap them for the CLI and MCP surfaces.
+//!
+//! - [`check`]: parse + typecheck + full evaluation so every contract fires.
+//!   Nothing is returned beyond the module hash; nothing is persisted.
+//! - [`export`]: `eval_full_for_export` (fields marked `| not_exported` are
+//!   dropped) projected to the `World` shape `{ cluster, intent, calls }`, plus
+//!   `moduleHash` (sha256 of the source bytes), `exportHash` (sha256 of the
+//!   canonical frozen JSON) and `contractSet` (the release overlay id).
+//!
+//! `--var path.to.field=value` maps to a Nickel `FieldOverride` at the
+//! operator merge priority. Values are Nickel expressions; strings need quotes.
+//! Secrets never pass through here: OpenCollection plaintext fields are
+//! `| not_exported`, and hydration happens in Facet at run time, after export.
+
+use std::path::{Path, PathBuf};
+
+use hedron_ncl::eval::{self, Input};
+use lattice::sha256_hex;
+use serde_json::{Value, json};
+
+use crate::{CONFIGURATION_EXIT_CODE, FacetError};
+
+/// Contract set id of the release overlay compiled into this binary.
+pub const CONTRACT_SET: &str = hedron_ncl::CONTRACT_SET;
+
+/// Error category for a Nickel parse, type, import or contract failure.
+pub const NCL_INVALID: &str = "ncl_invalid";
+
+/// Result of a successful `check`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct NclCheck {
+    /// The module that was checked.
+    pub path: PathBuf,
+    /// sha256 of the module's source bytes.
+    pub module_hash: String,
+    /// Release overlay id the check ran against.
+    pub contract_set: &'static str,
+}
+
+/// Result of a successful `export`: the frozen `World` projections and hashes.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct NclExport {
+    /// The module that was exported.
+    pub path: PathBuf,
+    /// sha256 of the module's source bytes.
+    pub module_hash: String,
+    /// sha256 of the canonical (sorted-key, compact) JSON of the frozen value.
+    pub export_hash: String,
+    /// Release overlay id the export ran against.
+    pub contract_set: &'static str,
+    /// `world.cluster` — frozen Kubernetes v1.34 objects for h3s (`null` if absent).
+    pub cluster: Value,
+    /// `world.intent` — frozen desired states for HedronDB (`null` if absent).
+    pub intent: Value,
+    /// `world.calls` — OpenCollection projection for Facet (`null` if absent).
+    pub calls: Value,
+}
+
+impl NclCheck {
+    /// JSON body (without `schemaVersion`; the caller versions it).
+    #[must_use]
+    pub fn to_json(&self) -> Value {
+        json!({
+            "path": self.path.display().to_string(),
+            "moduleHash": self.module_hash,
+            "contractSet": self.contract_set,
+        })
+    }
+}
+
+impl NclExport {
+    /// JSON body (without `schemaVersion`; the caller versions it).
+    #[must_use]
+    pub fn to_json(&self) -> Value {
+        json!({
+            "path": self.path.display().to_string(),
+            "moduleHash": self.module_hash,
+            "exportHash": self.export_hash,
+            "contractSet": self.contract_set,
+            "cluster": self.cluster,
+            "intent": self.intent,
+            "calls": self.calls,
+        })
+    }
+}
+
+/// Parse, typecheck and evaluate the module at `path` with `vars` applied.
+/// Persists nothing.
+pub fn check(path: &Path, vars: &[String]) -> Result<NclCheck, FacetError> {
+    let module_hash = module_hash(path)?;
+    eval::check(Input::Path(path), vars).map_err(ncl_error)?;
+    Ok(NclCheck {
+        path: path.to_path_buf(),
+        module_hash,
+        contract_set: CONTRACT_SET,
+    })
+}
+
+/// Evaluate the module at `path` for export with `vars` applied and split the
+/// frozen value into the three `World` projections.
+pub fn export(path: &Path, vars: &[String]) -> Result<NclExport, FacetError> {
+    let module_hash = module_hash(path)?;
+    let world = eval::export(Input::Path(path), vars).map_err(ncl_error)?;
+    let export_hash = sha256_hex(canonical(&world).as_bytes());
+    let mut world = match world {
+        Value::Object(map) => map,
+        other => {
+            return Err(FacetError {
+                category: NCL_INVALID,
+                message: format!(
+                    "{}: export must be a record (World = {{ cluster, intent, calls }}), got {}",
+                    path.display(),
+                    kind(&other)
+                ),
+                exit_code: CONFIGURATION_EXIT_CODE,
+                details: None,
+            });
+        }
+    };
+    Ok(NclExport {
+        path: path.to_path_buf(),
+        module_hash,
+        export_hash,
+        contract_set: CONTRACT_SET,
+        cluster: world.remove("cluster").unwrap_or(Value::Null),
+        intent: world.remove("intent").unwrap_or(Value::Null),
+        calls: world.remove("calls").unwrap_or(Value::Null),
+    })
+}
+
+fn module_hash(path: &Path) -> Result<String, FacetError> {
+    let bytes = std::fs::read(path).map_err(|error| {
+        FacetError::invalid_workspace(format!("cannot read {}: {error}", path.display()))
+    })?;
+    Ok(sha256_hex(&bytes))
+}
+
+/// Compact JSON with sorted keys. `serde_json` maps are ordered without
+/// `preserve_order`, so `to_string` is already canonical.
+fn canonical(value: &Value) -> String {
+    serde_json::to_string(value).expect("JSON value serialization cannot fail")
+}
+
+fn kind(value: &Value) -> &'static str {
+    match value {
+        Value::Null => "null",
+        Value::Bool(_) => "a boolean",
+        Value::Number(_) => "a number",
+        Value::String(_) => "a string",
+        Value::Array(_) => "an array",
+        Value::Object(_) => "a record",
+    }
+}
+
+fn ncl_error(error: eval::Error) -> FacetError {
+    match error {
+        eval::Error::Override(message) => FacetError::invalid_arguments(format!("--var: {message}")),
+        eval::Error::Build(message) => FacetError::invalid_workspace(message),
+        eval::Error::Nickel(report) => FacetError {
+            category: NCL_INVALID,
+            message: report.trim_end().to_owned(),
+            exit_code: CONFIGURATION_EXIT_CODE,
+            details: None,
+        },
+        other @ (eval::Error::Export(_) | eval::Error::Json(_)) => FacetError {
+            category: NCL_INVALID,
+            message: other.to_string(),
+            exit_code: CONFIGURATION_EXIT_CODE,
+            details: None,
+        },
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::INVALID_ARGUMENTS_EXIT_CODE;
+
+    const WORLD: &str = r#"
+let lib = import "lib.ncl" in
+{
+  replicas = 1,
+  cluster = [ lib.pod { name = "web", n = replicas } ],
+  intent = [ { kind = "docs_eod", date = "2026-09-12", required_briefs = [] } ],
+  calls = {
+    opencollection = "1.0.0",
+    environments = [ { name = "dev", variables = [ { name = "TOKEN", secret_ref = "kr:me" } ] } ],
+    plaintext_token | not_exported = "hunter2",
+  },
+}
+"#;
+
+    const LIB: &str = r#"
+{
+  pod = fun args => {
+    apiVersion = "v1",
+    kind = "Pod",
+    metadata.name = args.name,
+    metadata.annotations.replicas = std.to_string args.n,
+  },
+}
+"#;
+
+    fn fixture() -> (tempfile::TempDir, PathBuf) {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join("lib.ncl"), LIB).unwrap();
+        let world = dir.path().join("world.ncl");
+        std::fs::write(&world, WORLD).unwrap();
+        (dir, world)
+    }
+
+    #[test]
+    fn export_projects_world_and_drops_not_exported() {
+        let (_dir, world) = fixture();
+        let out = export(&world, &[]).unwrap();
+        assert_eq!(out.contract_set, "k8s-1.34-h3s-0.9.1");
+        assert_eq!(out.cluster[0]["kind"], "Pod");
+        assert_eq!(out.cluster[0]["metadata"]["annotations"]["replicas"], "1");
+        assert_eq!(out.intent[0]["kind"], "docs_eod");
+        assert_eq!(out.calls["environments"][0]["variables"][0]["secret_ref"], "kr:me");
+        assert!(out.calls.get("plaintext_token").is_none(), "not_exported must not leak");
+        assert!(!canonical(&out.to_json()).contains("hunter2"));
+        assert_eq!(out.module_hash, sha256_hex(WORLD.as_bytes()));
+        assert_eq!(out.export_hash.len(), 64);
+        let json = out.to_json();
+        for key in ["path", "moduleHash", "exportHash", "contractSet", "cluster", "intent", "calls"] {
+            assert!(json.get(key).is_some(), "missing {key}");
+        }
+    }
+
+    #[test]
+    fn export_hash_is_stable_and_var_sensitive() {
+        let (_dir, world) = fixture();
+        let a = export(&world, &[]).unwrap();
+        let b = export(&world, &[]).unwrap();
+        assert_eq!(a.export_hash, b.export_hash);
+        let c = export(&world, &["replicas=3".to_owned()]).unwrap();
+        assert_eq!(c.cluster[0]["metadata"]["annotations"]["replicas"], "3");
+        assert_ne!(a.export_hash, c.export_hash);
+        assert_eq!(a.module_hash, c.module_hash, "--var changes the export, not the module");
+    }
+
+    #[test]
+    fn check_passes_and_persists_nothing() {
+        let (dir, world) = fixture();
+        let out = check(&world, &[]).unwrap();
+        assert_eq!(out.module_hash, sha256_hex(WORLD.as_bytes()));
+        let names: Vec<_> = std::fs::read_dir(dir.path())
+            .unwrap()
+            .map(|e| e.unwrap().file_name().into_string().unwrap())
+            .collect();
+        assert_eq!(names.len(), 2, "check wrote files: {names:?}");
+    }
+
+    #[test]
+    fn contract_blame_is_ncl_invalid() {
+        let dir = tempfile::tempdir().unwrap();
+        let bad = dir.path().join("bad.ncl");
+        std::fs::write(&bad, r#"{ replicas | Number = "three" }"#).unwrap();
+        let err = check(&bad, &[]).unwrap_err();
+        assert_eq!(err.category, NCL_INVALID);
+        assert_eq!(err.exit_code, CONFIGURATION_EXIT_CODE);
+        assert!(err.message.contains("contract broken"), "{}", err.message);
+        let err = export(&bad, &[]).unwrap_err();
+        assert_eq!(err.category, NCL_INVALID);
+    }
+
+    #[test]
+    fn non_record_export_is_rejected() {
+        let dir = tempfile::tempdir().unwrap();
+        let scalar = dir.path().join("scalar.ncl");
+        std::fs::write(&scalar, "[1, 2, 3]").unwrap();
+        let err = export(&scalar, &[]).unwrap_err();
+        assert_eq!(err.category, NCL_INVALID);
+        assert!(err.message.contains("an array"), "{}", err.message);
+    }
+
+    #[test]
+    fn bad_var_and_missing_file() {
+        let (_dir, world) = fixture();
+        let err = export(&world, &["replicas".to_owned()]).unwrap_err();
+        assert_eq!(err.category, "invalid_arguments");
+        assert_eq!(err.exit_code, INVALID_ARGUMENTS_EXIT_CODE);
+        let err = check(Path::new("/nonexistent/world.ncl"), &[]).unwrap_err();
+        assert_eq!(err.category, "invalid_workspace");
+    }
+
+    /// The embed is in-process: no `nickel` binary is ever spawned.
+    #[test]
+    fn no_process_spawn_in_this_module() {
+        let src = include_str!("ncl.rs");
+        assert!(!src.contains(concat!("std::", "process")));
+        assert!(!src.contains(concat!("Command::", "new")));
+    }
+}

--- a/crates/facet/src/ncl.rs
+++ b/crates/facet/src/ncl.rs
@@ -11,6 +11,8 @@
 //!   dropped) projected to the `World` shape `{ cluster, intent, calls }`, plus
 //!   `moduleHash` (sha256 of the source bytes), `exportHash` (sha256 of the
 //!   canonical frozen JSON) and `contractSet` (the release overlay id).
+//! - [`apply`]: export without a separate ledger row, POST frozen `cluster`
+//!   JSON, optional Hedron `Store::put` for `intent`, then one `ncl:apply` row.
 //!
 //! `--var path.to.field=value` maps to a Nickel `FieldOverride` at the
 //! operator merge priority. Values are Nickel expressions; strings need quotes.
@@ -23,6 +25,7 @@ use hedron_ncl::eval::{self, Input};
 use lattice::sha256_hex;
 use serde_json::{Value, json};
 
+use crate::ncl_apply::{self, NclApply};
 use crate::{CONFIGURATION_EXIT_CODE, FacetError};
 
 /// Contract set id of the release overlay compiled into this binary.
@@ -107,6 +110,14 @@ pub fn export(path: &Path, vars: &[String]) -> Result<NclExport, FacetError> {
     let export = evaluate(path, vars)?;
     crate::ncl_ledger::record_export(path, &export, vars);
     Ok(export)
+}
+
+/// Export, act on frozen projections, and record one `ncl:apply` Lattice row.
+pub fn apply(path: &Path, vars: &[String]) -> Result<NclApply, FacetError> {
+    let export = evaluate(path, vars)?;
+    let action = ncl_apply::execute(&export)?;
+    crate::ncl_ledger::record_apply(path, &export, &action, vars);
+    Ok(ncl_apply::from_export(export, action))
 }
 
 /// Evaluate for export without persisting to Lattice.
@@ -194,7 +205,7 @@ let lib = import "lib.ncl" in
 {
   replicas = 1,
   cluster = [ lib.pod { name = "web", n = replicas } ],
-  intent = [ { kind = "docs_eod", date = "2026-09-12", required_briefs = [] } ],
+  intent = [ { name = "test-docs-eod", importance = 0.5, spec = { kind = "docs_eod", date = "2026-09-12", required_briefs = [] } }, ],
   calls = {
     opencollection = "1.0.0",
     environments = [ { name = "dev", variables = [ { name = "TOKEN", secret_ref = "kr:me" } ] } ],
@@ -229,7 +240,7 @@ let lib = import "lib.ncl" in
         assert_eq!(out.contract_set, "k8s-1.34-h3s-0.9.1");
         assert_eq!(out.cluster[0]["kind"], "Pod");
         assert_eq!(out.cluster[0]["metadata"]["annotations"]["replicas"], "1");
-        assert_eq!(out.intent[0]["kind"], "docs_eod");
+        assert_eq!(out.intent[0]["spec"]["kind"], "docs_eod");
         assert_eq!(out.calls["environments"][0]["variables"][0]["secret_ref"], "kr:me");
         assert!(out.calls.get("plaintext_token").is_none(), "not_exported must not leak");
         assert!(!canonical(&out.to_json()).contains("hunter2"));

--- a/crates/facet/src/ncl.rs
+++ b/crates/facet/src/ncl.rs
@@ -104,6 +104,13 @@ pub fn check(path: &Path, vars: &[String]) -> Result<NclCheck, FacetError> {
 /// Evaluate the module at `path` for export with `vars` applied and split the
 /// frozen value into the three `World` projections.
 pub fn export(path: &Path, vars: &[String]) -> Result<NclExport, FacetError> {
+    let export = evaluate(path, vars)?;
+    crate::ncl_ledger::record_export(path, &export, vars);
+    Ok(export)
+}
+
+/// Evaluate for export without persisting to Lattice.
+pub(crate) fn evaluate(path: &Path, vars: &[String]) -> Result<NclExport, FacetError> {
     let module_hash = module_hash(path)?;
     let world = eval::export(Input::Path(path), vars).map_err(ncl_error)?;
     let export_hash = sha256_hex(canonical(&world).as_bytes());
@@ -122,7 +129,7 @@ pub fn export(path: &Path, vars: &[String]) -> Result<NclExport, FacetError> {
             });
         }
     };
-    Ok(NclExport {
+    let export = NclExport {
         path: path.to_path_buf(),
         module_hash,
         export_hash,
@@ -130,7 +137,8 @@ pub fn export(path: &Path, vars: &[String]) -> Result<NclExport, FacetError> {
         cluster: world.remove("cluster").unwrap_or(Value::Null),
         intent: world.remove("intent").unwrap_or(Value::Null),
         calls: world.remove("calls").unwrap_or(Value::Null),
-    })
+    };
+    Ok(export)
 }
 
 fn module_hash(path: &Path) -> Result<String, FacetError> {

--- a/crates/facet/src/ncl.rs
+++ b/crates/facet/src/ncl.rs
@@ -178,7 +178,9 @@ fn kind(value: &Value) -> &'static str {
 
 fn ncl_error(error: eval::Error) -> FacetError {
     match error {
-        eval::Error::Override(message) => FacetError::invalid_arguments(format!("--var: {message}")),
+        eval::Error::Override(message) => {
+            FacetError::invalid_arguments(format!("--var: {message}"))
+        }
         eval::Error::Build(message) => FacetError::invalid_workspace(message),
         eval::Error::Nickel(report) => FacetError {
             category: NCL_INVALID,
@@ -241,13 +243,27 @@ let lib = import "lib.ncl" in
         assert_eq!(out.cluster[0]["kind"], "Pod");
         assert_eq!(out.cluster[0]["metadata"]["annotations"]["replicas"], "1");
         assert_eq!(out.intent[0]["spec"]["kind"], "docs_eod");
-        assert_eq!(out.calls["environments"][0]["variables"][0]["secret_ref"], "kr:me");
-        assert!(out.calls.get("plaintext_token").is_none(), "not_exported must not leak");
+        assert_eq!(
+            out.calls["environments"][0]["variables"][0]["secret_ref"],
+            "kr:me"
+        );
+        assert!(
+            out.calls.get("plaintext_token").is_none(),
+            "not_exported must not leak"
+        );
         assert!(!canonical(&out.to_json()).contains("hunter2"));
         assert_eq!(out.module_hash, sha256_hex(WORLD.as_bytes()));
         assert_eq!(out.export_hash.len(), 64);
         let json = out.to_json();
-        for key in ["path", "moduleHash", "exportHash", "contractSet", "cluster", "intent", "calls"] {
+        for key in [
+            "path",
+            "moduleHash",
+            "exportHash",
+            "contractSet",
+            "cluster",
+            "intent",
+            "calls",
+        ] {
             assert!(json.get(key).is_some(), "missing {key}");
         }
     }
@@ -261,7 +277,10 @@ let lib = import "lib.ncl" in
         let c = export(&world, &["replicas=3".to_owned()]).unwrap();
         assert_eq!(c.cluster[0]["metadata"]["annotations"]["replicas"], "3");
         assert_ne!(a.export_hash, c.export_hash);
-        assert_eq!(a.module_hash, c.module_hash, "--var changes the export, not the module");
+        assert_eq!(
+            a.module_hash, c.module_hash,
+            "--var changes the export, not the module"
+        );
     }
 
     #[test]

--- a/crates/facet/src/ncl_apply.rs
+++ b/crates/facet/src/ncl_apply.rs
@@ -173,7 +173,7 @@ fn apply_cluster(cluster: &Value) -> Result<ClusterAction, FacetError> {
             .result
             .as_ref()
             .map(|response| response.status)
-            .map_err(|error| FacetError::http(error))?;
+            .map_err(FacetError::http)?;
         results.push(ClusterPostResult {
             kind: object["kind"].as_str().unwrap_or("").to_owned(),
             name: object["metadata"]["name"].as_str().unwrap_or("").to_owned(),
@@ -343,10 +343,10 @@ fn hedron_error(error: hedron_core::Error) -> FacetError {
 
 fn open_hedron_store(path: &std::path::Path) -> Result<(Store, String), FacetError> {
     let mut store = Store::open(path).map_err(hedron_error)?;
-    if let Ok(token) = std::env::var("FACET_HEDRON_TOKEN") {
-        if !token.is_empty() {
-            return Ok((store, token));
-        }
+    if let Ok(token) = std::env::var("FACET_HEDRON_TOKEN")
+        && !token.is_empty()
+    {
+        return Ok((store, token));
     }
     if hedrondb_empty(path)? {
         let boot = store

--- a/crates/facet/src/ncl_apply.rs
+++ b/crates/facet/src/ncl_apply.rs
@@ -1,0 +1,392 @@
+//! `facet ncl apply`: export frozen World projections, then act on them.
+//!
+//! - POST frozen `cluster` objects to the Kubernetes API (`FACET_KUBECONFIG`).
+//! - `Store::put` for each `intent` row when `FACET_HEDRON_DB` is set.
+//! - OpenCollection `calls` items are skipped when there are no HTTP requests.
+//!
+//! Records one Lattice row (`ncl:apply`) covering eval + action. Never evals on :6443.
+
+use std::path::PathBuf;
+
+use facet_record::kube_api_base_from_env;
+use hedron_core::Store;
+use hedron_ncl::r#gen::docs_eod::check_shape;
+use probe_core::{
+    Body, Header, HttpRequest, ItemMetadata, RawBody, RawBodyKind, RequestBody, RequestSettings,
+};
+use probe_http::HttpError;
+use serde_json::{Value, json};
+
+use crate::ncl::NclExport;
+use crate::{FacetError, run};
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct NclApply {
+    pub path: PathBuf,
+    pub module_hash: String,
+    pub export_hash: String,
+    pub contract_set: &'static str,
+    pub cluster: Value,
+    pub intent: Value,
+    pub calls: Value,
+    pub action: ApplyAction,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ApplyAction {
+    pub cluster: ClusterAction,
+    pub intent: IntentAction,
+    pub calls: CallsAction,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ClusterAction {
+    pub skipped: bool,
+    pub posted: usize,
+    pub results: Vec<ClusterPostResult>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ClusterPostResult {
+    pub kind: String,
+    pub name: String,
+    pub status: u16,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct IntentAction {
+    pub skipped: bool,
+    pub put: usize,
+    pub names: Vec<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CallsAction {
+    pub skipped: bool,
+    pub executed: usize,
+}
+
+impl NclApply {
+    pub fn to_json(&self) -> Value {
+        json!({
+            "path": self.path.display().to_string(),
+            "moduleHash": self.module_hash,
+            "exportHash": self.export_hash,
+            "contractSet": self.contract_set,
+            "cluster": self.cluster,
+            "intent": self.intent,
+            "calls": self.calls,
+            "action": self.action.to_json(),
+        })
+    }
+}
+
+impl ApplyAction {
+    pub fn to_json(&self) -> Value {
+        json!({
+            "cluster": self.cluster.to_json(),
+            "intent": self.intent.to_json(),
+            "calls": self.calls.to_json(),
+        })
+    }
+}
+
+impl ClusterAction {
+    fn to_json(&self) -> Value {
+        json!({
+            "skipped": self.skipped,
+            "posted": self.posted,
+            "results": self.results.iter().map(|row| json!({
+                "kind": row.kind,
+                "name": row.name,
+                "status": row.status,
+            })).collect::<Vec<_>>(),
+        })
+    }
+}
+
+impl IntentAction {
+    fn to_json(&self) -> Value {
+        json!({
+            "skipped": self.skipped,
+            "put": self.put,
+            "names": self.names,
+        })
+    }
+}
+
+impl CallsAction {
+    fn to_json(&self) -> Value {
+        json!({
+            "skipped": self.skipped,
+            "executed": self.executed,
+        })
+    }
+}
+
+pub fn execute(export: &NclExport) -> Result<ApplyAction, FacetError> {
+    let cluster = apply_cluster(&export.cluster)?;
+    let intent = apply_intent(&export.intent)?;
+    let calls = apply_calls(&export.calls)?;
+    Ok(ApplyAction {
+        cluster,
+        intent,
+        calls,
+    })
+}
+
+pub fn from_export(export: NclExport, action: ApplyAction) -> NclApply {
+    NclApply {
+        path: export.path,
+        module_hash: export.module_hash,
+        export_hash: export.export_hash,
+        contract_set: export.contract_set,
+        cluster: export.cluster,
+        intent: export.intent,
+        calls: export.calls,
+        action,
+    }
+}
+
+fn apply_cluster(cluster: &Value) -> Result<ClusterAction, FacetError> {
+    let objects = cluster_objects(cluster)?;
+    if objects.is_empty() {
+        return Ok(ClusterAction {
+            skipped: true,
+            posted: 0,
+            results: Vec::new(),
+        });
+    }
+    let Some(api_base) = kube_api_base_from_env().map_err(http_config)? else {
+        return Ok(ClusterAction {
+            skipped: true,
+            posted: 0,
+            results: Vec::new(),
+        });
+    };
+    let mut results = Vec::new();
+    for object in objects {
+        let url = post_url(&api_base, object)?;
+        let request = json_post_request(&url, object);
+        let execution = run::execute(&request, None, None)?;
+        let status = execution
+            .result
+            .as_ref()
+            .map(|response| response.status)
+            .map_err(|error| FacetError::http(error))?;
+        results.push(ClusterPostResult {
+            kind: object["kind"].as_str().unwrap_or("").to_owned(),
+            name: object["metadata"]["name"]
+                .as_str()
+                .unwrap_or("")
+                .to_owned(),
+            status,
+        });
+    }
+    Ok(ClusterAction {
+        skipped: false,
+        posted: results.len(),
+        results,
+    })
+}
+
+fn apply_intent(intent: &Value) -> Result<IntentAction, FacetError> {
+    let rows = intent_rows(intent)?;
+    if rows.is_empty() {
+        return Ok(IntentAction {
+            skipped: true,
+            put: 0,
+            names: Vec::new(),
+        });
+    }
+    let Some(db_path) = std::env::var_os("FACET_HEDRON_DB") else {
+        return Ok(IntentAction {
+            skipped: true,
+            put: 0,
+            names: Vec::new(),
+        });
+    };
+    if db_path.is_empty() {
+        return Err(FacetError::invalid_arguments("FACET_HEDRON_DB is empty"));
+    }
+    let path = PathBuf::from(db_path);
+    let (mut store, token) = open_hedron_store(&path)?;
+    let mut names = Vec::new();
+    for row in rows {
+        let name = row["name"]
+            .as_str()
+            .filter(|value| !value.is_empty())
+            .ok_or_else(|| {
+                FacetError::invalid_arguments("intent rows require a non-empty name")
+            })?;
+        let importance = row["importance"].as_f64().unwrap_or(0.5);
+        let spec = &row["spec"];
+        check_shape(spec).map_err(|error| {
+            FacetError::invalid_arguments(format!("intent spec shape: {error}"))
+        })?;
+        let yaml_spec = serde_yaml::from_str(
+            &serde_json::to_string(spec).map_err(|error| {
+                FacetError::invalid_arguments(format!(
+                    "intent spec is not JSON-serializable: {error}"
+                ))
+            })?,
+        )
+        .map_err(|error| {
+            FacetError::invalid_arguments(format!("intent spec is not YAML-serializable: {error}"))
+        })?;
+        store
+            .put_desired_state(&token, name, yaml_spec, importance)
+            .map_err(hedron_error)?;
+        names.push(name.to_owned());
+    }
+    Ok(IntentAction {
+        skipped: false,
+        put: names.len(),
+        names,
+    })
+}
+
+fn apply_calls(calls: &Value) -> Result<CallsAction, FacetError> {
+    let items = calls
+        .get("items")
+        .and_then(Value::as_array)
+        .filter(|items| !items.is_empty());
+    if items.is_none() {
+        return Ok(CallsAction {
+            skipped: true,
+            executed: 0,
+        });
+    }
+    Ok(CallsAction {
+        skipped: true,
+        executed: 0,
+    })
+}
+
+fn cluster_objects(cluster: &Value) -> Result<Vec<&Value>, FacetError> {
+    if cluster.is_null() {
+        return Ok(Vec::new());
+    }
+    let array = cluster
+        .as_array()
+        .ok_or_else(|| FacetError::invalid_arguments("cluster projection must be an array"))?;
+    Ok(array.iter().collect())
+}
+
+fn intent_rows(intent: &Value) -> Result<Vec<&Value>, FacetError> {
+    if intent.is_null() {
+        return Ok(Vec::new());
+    }
+    let array = intent
+        .as_array()
+        .ok_or_else(|| FacetError::invalid_arguments("intent projection must be an array"))?;
+    Ok(array.iter().collect())
+}
+
+fn post_url(api_base: &str, object: &Value) -> Result<String, FacetError> {
+    let api_version = object["apiVersion"]
+        .as_str()
+        .ok_or_else(|| FacetError::invalid_arguments("cluster object requires apiVersion"))?;
+    let kind = object["kind"]
+        .as_str()
+        .ok_or_else(|| FacetError::invalid_arguments("cluster object requires kind"))?;
+    if api_version != "v1" {
+        return Err(FacetError::invalid_arguments(format!(
+            "unsupported apiVersion {api_version} in frozen cluster object"
+        )));
+    }
+    let namespace = object["metadata"]["namespace"]
+        .as_str()
+        .unwrap_or("default");
+    let resource = kind_to_resource(kind)?;
+    Ok(format!(
+        "{}/{}/namespaces/{}/{}",
+        api_base.trim_end_matches('/'),
+        "api/v1",
+        namespace,
+        resource
+    ))
+}
+
+fn kind_to_resource(kind: &str) -> Result<&'static str, FacetError> {
+    match kind {
+        "Pod" => Ok("pods"),
+        "Service" => Ok("services"),
+        other => Err(FacetError::invalid_arguments(format!(
+            "unsupported cluster kind {other}"
+        ))),
+    }
+}
+
+fn json_post_request(url: &str, body: &Value) -> HttpRequest {
+    HttpRequest {
+        metadata: ItemMetadata::default(),
+        method: Some("POST".to_owned()),
+        url: Some(url.to_owned()),
+        headers: vec![Header {
+            name: "Content-Type".to_owned(),
+            value: "application/json".to_owned(),
+            disabled: false,
+        }],
+        query_parameters: Vec::new(),
+        path_parameters: Vec::new(),
+        body: Some(RequestBody::Single(Body::Raw(RawBody {
+            kind: RawBodyKind::Json,
+            data: serde_json::to_string(body).expect("cluster JSON serialization cannot fail"),
+        }))),
+        authentication: None,
+        settings: RequestSettings::default(),
+    }
+}
+
+fn http_config(error: HttpError) -> FacetError {
+    match error {
+        HttpError::ClientConfiguration(message) => FacetError::invalid_arguments(message),
+        other => FacetError::http(&other),
+    }
+}
+
+fn hedron_error(error: hedron_core::Error) -> FacetError {
+    FacetError::invalid_arguments(error.to_string())
+}
+
+fn open_hedron_store(path: &std::path::Path) -> Result<(Store, String), FacetError> {
+    let mut store = Store::open(path).map_err(hedron_error)?;
+    if let Ok(token) = std::env::var("FACET_HEDRON_TOKEN") {
+        if !token.is_empty() {
+            return Ok((store, token));
+        }
+    }
+    if hedrondb_empty(path)? {
+        let boot = store
+            .bootstrap(
+                &hedron_env("FACET_HEDRON_VAULT", "facet"),
+                &hedron_env("FACET_HEDRON_AGENT", "facet"),
+                &hedron_env("FACET_HEDRON_HTEC", "facet"),
+            )
+            .map_err(hedron_error)?;
+        return Ok((store, boot.token));
+    }
+    Err(FacetError::invalid_arguments(
+        "FACET_HEDRON_TOKEN is required for a non-empty HedronDB store",
+    ))
+}
+
+fn hedrondb_empty(path: &std::path::Path) -> Result<bool, FacetError> {
+    let conn = rusqlite::Connection::open(path).map_err(|error| {
+        FacetError::invalid_arguments(format!("cannot open HedronDB store: {error}"))
+    })?;
+    let count: i64 = conn
+        .query_row("SELECT COUNT(*) FROM nodes", [], |row| row.get(0))
+        .map_err(|error| {
+            FacetError::invalid_arguments(format!("cannot read HedronDB nodes: {error}"))
+        })?;
+    Ok(count == 0)
+}
+
+fn hedron_env(name: &str, default: &str) -> String {
+    match std::env::var(name) {
+        Ok(value) if !value.is_empty() => value,
+        _ => default.to_owned(),
+    }
+}

--- a/crates/facet/src/ncl_apply.rs
+++ b/crates/facet/src/ncl_apply.rs
@@ -176,10 +176,7 @@ fn apply_cluster(cluster: &Value) -> Result<ClusterAction, FacetError> {
             .map_err(|error| FacetError::http(error))?;
         results.push(ClusterPostResult {
             kind: object["kind"].as_str().unwrap_or("").to_owned(),
-            name: object["metadata"]["name"]
-                .as_str()
-                .unwrap_or("")
-                .to_owned(),
+            name: object["metadata"]["name"].as_str().unwrap_or("").to_owned(),
             status,
         });
     }
@@ -216,21 +213,15 @@ fn apply_intent(intent: &Value) -> Result<IntentAction, FacetError> {
         let name = row["name"]
             .as_str()
             .filter(|value| !value.is_empty())
-            .ok_or_else(|| {
-                FacetError::invalid_arguments("intent rows require a non-empty name")
-            })?;
+            .ok_or_else(|| FacetError::invalid_arguments("intent rows require a non-empty name"))?;
         let importance = row["importance"].as_f64().unwrap_or(0.5);
         let spec = &row["spec"];
         check_shape(spec).map_err(|error| {
             FacetError::invalid_arguments(format!("intent spec shape: {error}"))
         })?;
-        let yaml_spec = serde_yaml::from_str(
-            &serde_json::to_string(spec).map_err(|error| {
-                FacetError::invalid_arguments(format!(
-                    "intent spec is not JSON-serializable: {error}"
-                ))
-            })?,
-        )
+        let yaml_spec = serde_yaml::from_str(&serde_json::to_string(spec).map_err(|error| {
+            FacetError::invalid_arguments(format!("intent spec is not JSON-serializable: {error}"))
+        })?)
         .map_err(|error| {
             FacetError::invalid_arguments(format!("intent spec is not YAML-serializable: {error}"))
         })?;

--- a/crates/facet/src/ncl_ledger.rs
+++ b/crates/facet/src/ncl_ledger.rs
@@ -8,14 +8,14 @@ use std::collections::BTreeMap;
 use std::path::{Path, PathBuf};
 
 use facet_record::{
-    actor_from_env, open_store, recording_disabled, session_from_env, ConfigOverrides,
+    ConfigOverrides, actor_from_env, open_store, recording_disabled, session_from_env,
 };
 use lattice::{BodyInput, MachineStore, NewRun, RunRow, WorkspaceStore, now_ms};
 use serde_json::{Value, json};
 
+use crate::FacetError;
 use crate::ncl::NclExport;
 use crate::ncl_apply::ApplyAction;
-use crate::FacetError;
 
 const METHOD: &str = "NCL";
 const EXPORT_SELECTOR: &str = "ncl:export";
@@ -32,12 +32,7 @@ pub(crate) fn record_export(path: &Path, export: &NclExport, vars: &[String]) {
 }
 
 /// Best-effort Lattice row for a successful Nickel apply. Never fails the apply.
-pub(crate) fn record_apply(
-    path: &Path,
-    export: &NclExport,
-    action: &ApplyAction,
-    vars: &[String],
-) {
+pub(crate) fn record_apply(path: &Path, export: &NclExport, action: &ApplyAction, vars: &[String]) {
     if recording_disabled() {
         return;
     }
@@ -54,7 +49,8 @@ fn try_record_export(path: &Path, export: &NclExport, vars: &[String]) -> Result
             inline_body_max: Some(0),
             history_retention: None,
         },
-    ).map_err(FacetError::lattice)?;
+    )
+    .map_err(FacetError::lattice)?;
 
     let source_blob = source_snapshot(path)?;
     let freeze_blob = serde_json::to_vec(&export.to_json())
@@ -157,10 +153,7 @@ pub(crate) fn workspace_root(path: &Path) -> Result<PathBuf, FacetError> {
     if let Some(root) = WorkspaceStore::discover(&absolute) {
         return Ok(root);
     }
-    Ok(absolute
-        .parent()
-        .map(Path::to_path_buf)
-        .unwrap_or(absolute))
+    Ok(absolute.parent().map(Path::to_path_buf).unwrap_or(absolute))
 }
 
 pub(crate) fn module_path(workspace_root: &Path, path: &Path) -> String {
@@ -229,8 +222,7 @@ fn source_snapshot(path: &Path) -> Result<Vec<u8>, FacetError> {
             .unwrap_or_default(),
         "sources": sources,
     });
-    serde_json::to_vec(&snapshot)
-        .map_err(|error| FacetError::invalid_arguments(error.to_string()))
+    serde_json::to_vec(&snapshot).map_err(|error| FacetError::invalid_arguments(error.to_string()))
 }
 
 fn index_run(store: &WorkspaceStore, run: &RunRow) {

--- a/crates/facet/src/ncl_ledger.rs
+++ b/crates/facet/src/ncl_ledger.rs
@@ -1,4 +1,4 @@
-//! Lattice eval ledger for `facet ncl export` (SPEC-nickel G2).
+//! Lattice eval ledger for `facet ncl export` and `facet ncl apply` (G2/G5).
 //!
 //! On successful export, records tags `ncl:module:<hash>`, `ncl:export:<hash>`,
 //! `ncl:contracts:<contractSet>` plus content-addressed blobs for the source
@@ -11,25 +11,42 @@ use facet_record::{
     actor_from_env, open_store, recording_disabled, session_from_env, ConfigOverrides,
 };
 use lattice::{BodyInput, MachineStore, NewRun, RunRow, WorkspaceStore, now_ms};
-use serde_json::json;
+use serde_json::{Value, json};
 
 use crate::ncl::NclExport;
+use crate::ncl_apply::ApplyAction;
 use crate::FacetError;
 
 const METHOD: &str = "NCL";
-const REQUEST_SELECTOR: &str = "ncl:export";
+const EXPORT_SELECTOR: &str = "ncl:export";
+const APPLY_SELECTOR: &str = "ncl:apply";
 
 /// Best-effort Lattice row for a successful Nickel export. Never fails the export.
 pub(crate) fn record_export(path: &Path, export: &NclExport, vars: &[String]) {
     if recording_disabled() {
         return;
     }
-    if let Err(error) = try_record(path, export, vars) {
+    if let Err(error) = try_record_export(path, export, vars) {
         eprintln!("facet: ncl export ledger: {error:?}");
     }
 }
 
-fn try_record(path: &Path, export: &NclExport, vars: &[String]) -> Result<(), FacetError> {
+/// Best-effort Lattice row for a successful Nickel apply. Never fails the apply.
+pub(crate) fn record_apply(
+    path: &Path,
+    export: &NclExport,
+    action: &ApplyAction,
+    vars: &[String],
+) {
+    if recording_disabled() {
+        return;
+    }
+    if let Err(error) = try_record_apply(path, export, action, vars) {
+        eprintln!("facet: ncl apply ledger: {error:?}");
+    }
+}
+
+fn try_record_export(path: &Path, export: &NclExport, vars: &[String]) -> Result<(), FacetError> {
     let workspace_root = workspace_root(path)?;
     let store = open_store(
         &workspace_root,
@@ -52,7 +69,64 @@ fn try_record(path: &Path, export: &NclExport, vars: &[String]) -> Result<(), Fa
     let new_run = NewRun {
         started_at: now_ms(),
         duration_ms: Some(0),
-        request_path: REQUEST_SELECTOR,
+        request_path: EXPORT_SELECTOR,
+        request_hash: &export.module_hash,
+        environment: None,
+        method: METHOD,
+        url: &request_path,
+        status: Some(200),
+        error: None,
+        req_headers: None,
+        res_headers: Some(r#"{"content-type":"application/json"}"#),
+        req_body: BodyInput::Bytes(&source_blob),
+        res_body: BodyInput::Bytes(&freeze_blob),
+        res_content_type: Some("application/json"),
+        session_id: session.as_deref(),
+        actor: &actor,
+        tags: Some(&tags),
+        replayed_from: None,
+        var_names: Some(&var_names),
+    };
+
+    let run = store.record_run(&new_run).map_err(FacetError::lattice)?;
+    index_run(&store, &run);
+    Ok(())
+}
+
+fn try_record_apply(
+    path: &Path,
+    export: &NclExport,
+    action: &ApplyAction,
+    vars: &[String],
+) -> Result<(), FacetError> {
+    let workspace_root = workspace_root(path)?;
+    let store = open_store(
+        &workspace_root,
+        &ConfigOverrides {
+            inline_body_max: Some(0),
+            history_retention: None,
+        },
+    )
+    .map_err(FacetError::lattice)?;
+
+    let source_blob = source_snapshot(path)?;
+    let mut artifact = export.to_json();
+    if let Value::Object(map) = &mut artifact {
+        map.insert("action".to_owned(), action.to_json());
+    }
+    let freeze_blob = serde_json::to_vec(&artifact)
+        .map_err(|error| FacetError::invalid_arguments(error.to_string()))?;
+
+    let tags = tags_json(export);
+    let var_names = json!(var_name_list(vars)).to_string();
+    let request_path = module_path(&workspace_root, path);
+    let actor = actor_from_env();
+    let session = session_from_env();
+
+    let new_run = NewRun {
+        started_at: now_ms(),
+        duration_ms: Some(0),
+        request_path: APPLY_SELECTOR,
         request_hash: &export.module_hash,
         environment: None,
         method: METHOD,

--- a/crates/facet/src/ncl_ledger.rs
+++ b/crates/facet/src/ncl_ledger.rs
@@ -1,0 +1,172 @@
+//! Lattice eval ledger for `facet ncl export` (SPEC-nickel G2).
+//!
+//! On successful export, records tags `ncl:module:<hash>`, `ncl:export:<hash>`,
+//! `ncl:contracts:<contractSet>` plus content-addressed blobs for the source
+//! snapshot and frozen export artifact.
+
+use std::collections::BTreeMap;
+use std::path::{Path, PathBuf};
+
+use facet_record::{
+    actor_from_env, open_store, recording_disabled, session_from_env, ConfigOverrides,
+};
+use lattice::{BodyInput, MachineStore, NewRun, RunRow, WorkspaceStore, now_ms};
+use serde_json::json;
+
+use crate::ncl::NclExport;
+use crate::FacetError;
+
+const METHOD: &str = "NCL";
+const REQUEST_SELECTOR: &str = "ncl:export";
+
+/// Best-effort Lattice row for a successful Nickel export. Never fails the export.
+pub(crate) fn record_export(path: &Path, export: &NclExport, vars: &[String]) {
+    if recording_disabled() {
+        return;
+    }
+    if let Err(error) = try_record(path, export, vars) {
+        eprintln!("facet: ncl export ledger: {error:?}");
+    }
+}
+
+fn try_record(path: &Path, export: &NclExport, vars: &[String]) -> Result<(), FacetError> {
+    let workspace_root = workspace_root(path)?;
+    let store = open_store(
+        &workspace_root,
+        &ConfigOverrides {
+            inline_body_max: Some(0),
+            history_retention: None,
+        },
+    ).map_err(FacetError::lattice)?;
+
+    let source_blob = source_snapshot(path)?;
+    let freeze_blob = serde_json::to_vec(&export.to_json())
+        .map_err(|error| FacetError::invalid_arguments(error.to_string()))?;
+
+    let tags = tags_json(export);
+    let var_names = json!(var_name_list(vars)).to_string();
+    let request_path = module_path(&workspace_root, path);
+    let actor = actor_from_env();
+    let session = session_from_env();
+
+    let new_run = NewRun {
+        started_at: now_ms(),
+        duration_ms: Some(0),
+        request_path: REQUEST_SELECTOR,
+        request_hash: &export.module_hash,
+        environment: None,
+        method: METHOD,
+        url: &request_path,
+        status: Some(200),
+        error: None,
+        req_headers: None,
+        res_headers: Some(r#"{"content-type":"application/json"}"#),
+        req_body: BodyInput::Bytes(&source_blob),
+        res_body: BodyInput::Bytes(&freeze_blob),
+        res_content_type: Some("application/json"),
+        session_id: session.as_deref(),
+        actor: &actor,
+        tags: Some(&tags),
+        replayed_from: None,
+        var_names: Some(&var_names),
+    };
+
+    let run = store.record_run(&new_run).map_err(FacetError::lattice)?;
+    index_run(&store, &run);
+    Ok(())
+}
+
+pub(crate) fn workspace_root(path: &Path) -> Result<PathBuf, FacetError> {
+    let absolute = std::path::absolute(path).map_err(|error| {
+        FacetError::invalid_workspace(format!("cannot resolve {}: {error}", path.display()))
+    })?;
+    if let Some(root) = WorkspaceStore::discover(&absolute) {
+        return Ok(root);
+    }
+    Ok(absolute
+        .parent()
+        .map(Path::to_path_buf)
+        .unwrap_or(absolute))
+}
+
+pub(crate) fn module_path(workspace_root: &Path, path: &Path) -> String {
+    let absolute = std::path::absolute(path).unwrap_or_else(|_| path.to_path_buf());
+    absolute
+        .strip_prefix(workspace_root)
+        .unwrap_or(&absolute)
+        .display()
+        .to_string()
+}
+
+fn tags_json(export: &NclExport) -> String {
+    json!([
+        format!("ncl:module:{}", export.module_hash),
+        format!("ncl:export:{}", export.export_hash),
+        format!("ncl:contracts:{}", export.contract_set),
+    ])
+    .to_string()
+}
+
+fn var_name_list(vars: &[String]) -> Vec<String> {
+    vars.iter()
+        .map(|assignment| {
+            assignment
+                .split_once("=")
+                .map(|(path, _)| path.to_owned())
+                .unwrap_or_else(|| assignment.clone())
+        })
+        .collect()
+}
+
+/// JSON snapshot of the entry module and sibling `.ncl` imports in its directory.
+fn source_snapshot(path: &Path) -> Result<Vec<u8>, FacetError> {
+    let absolute = std::path::absolute(path).map_err(|error| {
+        FacetError::invalid_workspace(format!("cannot resolve {}: {error}", path.display()))
+    })?;
+    let dir = absolute.parent().unwrap_or(Path::new("."));
+    let mut sources = BTreeMap::new();
+    for entry in std::fs::read_dir(dir).map_err(|error| {
+        FacetError::invalid_workspace(format!("cannot read {}: {error}", dir.display()))
+    })? {
+        let entry = entry.map_err(|error| {
+            FacetError::invalid_workspace(format!("cannot read {}: {error}", dir.display()))
+        })?;
+        let file_path = entry.path();
+        if file_path.extension().is_some_and(|ext| ext == "ncl") {
+            let bytes = std::fs::read(&file_path).map_err(|error| {
+                FacetError::invalid_workspace(format!(
+                    "cannot read {}: {error}",
+                    file_path.display()
+                ))
+            })?;
+            sources.insert(
+                file_path
+                    .file_name()
+                    .map(|name| name.to_string_lossy().into_owned())
+                    .unwrap_or_default(),
+                String::from_utf8_lossy(&bytes).into_owned(),
+            );
+        }
+    }
+    let snapshot = json!({
+        "entry": absolute
+            .file_name()
+            .map(|name| name.to_string_lossy().into_owned())
+            .unwrap_or_default(),
+        "sources": sources,
+    });
+    serde_json::to_vec(&snapshot)
+        .map_err(|error| FacetError::invalid_arguments(error.to_string()))
+}
+
+fn index_run(store: &WorkspaceStore, run: &RunRow) {
+    let machine = match MachineStore::open(store.config()) {
+        Ok(machine) => machine,
+        Err(_) => return,
+    };
+    let _ = machine.touch_workspace(store.workspace_id(), store.root(), None, now_ms());
+    if let Some(session_id) = run.session_id.as_deref() {
+        let _ = machine.ensure_session(session_id, &run.actor, now_ms());
+    }
+    let _ = machine.index_run(run, store.workspace_id());
+}

--- a/crates/facet/tests/common/mod.rs
+++ b/crates/facet/tests/common/mod.rs
@@ -58,6 +58,8 @@ impl Sandbox {
             .env_remove("FACET_NO_RECORD")
             .env_remove("FACET_KUBECONFIG")
             .env_remove("FACET_KUBE_CONTEXT")
+            .env_remove("FACET_HEDRON_DB")
+            .env_remove("FACET_HEDRON_TOKEN")
             // Encrypted secrets backend: deterministic, no OS keyring prompts.
             .env("FACET_SECRET_KEY", "test-master-key")
             // Session metadata picks these up when present; goldens must not.

--- a/crates/facet/tests/golden/mcp_tools.json
+++ b/crates/facet/tests/golden/mcp_tools.json
@@ -353,6 +353,54 @@
       "name": "run_replay"
     },
     {
+      "description": "Parse, typecheck and evaluate a Nickel world module in-process. Returns { path, moduleHash, contractSet }. Nothing persisted.",
+      "inputSchema": {
+        "additionalProperties": false,
+        "properties": {
+          "path": {
+            "description": "Path to a .ncl module",
+            "type": "string"
+          },
+          "var": {
+            "additionalProperties": {
+              "type": "string"
+            },
+            "description": "Nickel field overrides (path.to.field → expression). Never a secret value or secret field path.",
+            "type": "object"
+          }
+        },
+        "required": [
+          "path"
+        ],
+        "type": "object"
+      },
+      "name": "ncl_check"
+    },
+    {
+      "description": "eval_full_for_export on a Nickel world module. Returns { path, moduleHash, exportHash, contractSet, cluster, intent, calls }. Fields marked | not_exported are absent.",
+      "inputSchema": {
+        "additionalProperties": false,
+        "properties": {
+          "path": {
+            "description": "Path to a .ncl module",
+            "type": "string"
+          },
+          "var": {
+            "additionalProperties": {
+              "type": "string"
+            },
+            "description": "Nickel field overrides (path.to.field → expression). Never a secret value or secret field path.",
+            "type": "object"
+          }
+        },
+        "required": [
+          "path"
+        ],
+        "type": "object"
+      },
+      "name": "ncl_export"
+    },
+    {
       "description": "Read-only SQL over the workspace store (runs, blobs). Writes fail with sql_read_only. The machine store is never attached.",
       "inputSchema": {
         "additionalProperties": false,

--- a/crates/facet/tests/golden/mcp_tools.json
+++ b/crates/facet/tests/golden/mcp_tools.json
@@ -401,6 +401,30 @@
       "name": "ncl_export"
     },
     {
+      "description": "Export a Nickel world module, POST frozen cluster JSON when FACET_KUBECONFIG is set, put intent rows through Hedron Store when FACET_HEDRON_DB is set, and record one ncl:apply Lattice row. Returns export fields plus action summary.",
+      "inputSchema": {
+        "additionalProperties": false,
+        "properties": {
+          "path": {
+            "description": "Path to a .ncl module",
+            "type": "string"
+          },
+          "var": {
+            "additionalProperties": {
+              "type": "string"
+            },
+            "description": "Nickel field overrides (path.to.field → expression). Never a secret value or secret field path.",
+            "type": "object"
+          }
+        },
+        "required": [
+          "path"
+        ],
+        "type": "object"
+      },
+      "name": "ncl_apply"
+    },
+    {
       "description": "Read-only SQL over the workspace store (runs, blobs). Writes fail with sql_read_only. The machine store is never attached.",
       "inputSchema": {
         "additionalProperties": false,

--- a/crates/facet/tests/golden/ncl_check.json
+++ b/crates/facet/tests/golden/ncl_check.json
@@ -1,0 +1,6 @@
+{
+  "contractSet": "k8s-1.34-h3s-0.9.1",
+  "moduleHash": "<sha256>",
+  "path": "<path>",
+  "schemaVersion": 1
+}

--- a/crates/facet/tests/golden/ncl_export.json
+++ b/crates/facet/tests/golden/ncl_export.json
@@ -1,0 +1,40 @@
+{
+  "calls": {
+    "environments": [
+      {
+        "name": "dev",
+        "variables": [
+          {
+            "name": "TOKEN",
+            "secret_ref": "kr:me"
+          }
+        ]
+      }
+    ],
+    "opencollection": "1.0.0"
+  },
+  "cluster": [
+    {
+      "apiVersion": "v1",
+      "kind": "Pod",
+      "metadata": {
+        "annotations": {
+          "replicas": "1"
+        },
+        "name": "web"
+      }
+    }
+  ],
+  "contractSet": "k8s-1.34-h3s-0.9.1",
+  "exportHash": "<sha256>",
+  "intent": [
+    {
+      "date": "2026-09-12",
+      "kind": "docs_eod",
+      "required_briefs": []
+    }
+  ],
+  "moduleHash": "<sha256>",
+  "path": "<path>",
+  "schemaVersion": 1
+}

--- a/crates/facet/tests/golden/ncl_export.json
+++ b/crates/facet/tests/golden/ncl_export.json
@@ -29,9 +29,13 @@
   "exportHash": "<sha256>",
   "intent": [
     {
-      "date": "2026-09-12",
-      "kind": "docs_eod",
-      "required_briefs": []
+      "importance": 0.5,
+      "name": "test-docs-eod",
+      "spec": {
+        "date": "2026-09-12",
+        "kind": "docs_eod",
+        "required_briefs": []
+      }
     }
   ],
   "moduleHash": "<sha256>",

--- a/crates/facet/tests/mcp.rs
+++ b/crates/facet/tests/mcp.rs
@@ -126,7 +126,7 @@ fn mcp_handshake_and_tool_list_are_golden() {
 
     let list = mcp.request("tools/list", json!({}));
     let tools = list["result"]["tools"].as_array().unwrap();
-    assert_eq!(tools.len(), 11);
+    assert_eq!(tools.len(), 13);
     let names: Vec<&str> = tools
         .iter()
         .map(|tool| tool["name"].as_str().unwrap())
@@ -144,6 +144,8 @@ fn mcp_handshake_and_tool_list_are_golden() {
             "blob_get",
             "run_diff",
             "run_replay",
+            "ncl_check",
+            "ncl_export",
             "sql_query",
         ]
     );
@@ -333,4 +335,61 @@ fn mcp_refuses_secret_values_as_arguments() {
         json!(["token"])
     );
     mcp.finish();
+}
+
+#[test]
+fn mcp_ncl_tools_match_cli_documents() {
+    let sandbox = Sandbox::new();
+    let root = sandbox.root();
+    std::fs::write(
+        root.join("lib.ncl"),
+        r#"{
+  pod = fun args => {
+    apiVersion = "v1",
+    kind = "Pod",
+    metadata.name = args.name,
+    metadata.annotations.replicas = std.to_string args.n,
+  },
+}"#,
+    )
+    .unwrap();
+    let world = root.join("world.ncl");
+    std::fs::write(
+        &world,
+        r#"let lib = import "lib.ncl" in
+{
+  replicas = 1,
+  cluster = [ lib.pod { name = "web", n = replicas } ],
+  intent = [ { kind = "docs_eod", date = "2026-09-12", required_briefs = [] } ],
+  calls = {
+    opencollection = "1.0.0",
+    environments = [ { name = "dev", variables = [ { name = "TOKEN", secret_ref = "kr:me" } ] } ],
+    plaintext_token | not_exported = "hunter2",
+  },
+}"#,
+    )
+    .unwrap();
+    let path = world.to_str().unwrap();
+
+    let cli_check = sandbox.run_json(&["ncl", "check", path]);
+    let cli_export = sandbox.run_json(&["ncl", "export", path]);
+
+    let mut mcp = Mcp::start(&sandbox, &[]);
+    let mcp_check = mcp.ok("ncl_check", json!({ "path": path }));
+    let mcp_export = mcp.ok("ncl_export", json!({ "path": path }));
+    mcp.finish();
+
+    assert_eq!(mcp_check, cli_check);
+    assert_eq!(mcp_export, cli_export);
+    for key in [
+        "cluster",
+        "intent",
+        "calls",
+        "moduleHash",
+        "exportHash",
+        "contractSet",
+    ] {
+        assert!(mcp_export.get(key).is_some(), "missing {key}");
+    }
+    assert!(!mcp_export.to_string().contains("hunter2"));
 }

--- a/crates/facet/tests/mcp.rs
+++ b/crates/facet/tests/mcp.rs
@@ -126,7 +126,7 @@ fn mcp_handshake_and_tool_list_are_golden() {
 
     let list = mcp.request("tools/list", json!({}));
     let tools = list["result"]["tools"].as_array().unwrap();
-    assert_eq!(tools.len(), 13);
+    assert_eq!(tools.len(), 14);
     let names: Vec<&str> = tools
         .iter()
         .map(|tool| tool["name"].as_str().unwrap())
@@ -146,6 +146,7 @@ fn mcp_handshake_and_tool_list_are_golden() {
             "run_replay",
             "ncl_check",
             "ncl_export",
+            "ncl_apply",
             "sql_query",
         ]
     );
@@ -360,7 +361,13 @@ fn mcp_ncl_tools_match_cli_documents() {
 {
   replicas = 1,
   cluster = [ lib.pod { name = "web", n = replicas } ],
-  intent = [ { kind = "docs_eod", date = "2026-09-12", required_briefs = [] } ],
+  intent = [
+    {
+      name = "test-docs-eod",
+      importance = 0.5,
+      spec = { kind = "docs_eod", date = "2026-09-12", required_briefs = [] },
+    },
+  ],
   calls = {
     opencollection = "1.0.0",
     environments = [ { name = "dev", variables = [ { name = "TOKEN", secret_ref = "kr:me" } ] } ],
@@ -373,14 +380,17 @@ fn mcp_ncl_tools_match_cli_documents() {
 
     let cli_check = sandbox.run_json(&["ncl", "check", path]);
     let cli_export = sandbox.run_json(&["ncl", "export", path]);
+    let cli_apply = sandbox.run_json(&["ncl", "apply", path]);
 
     let mut mcp = Mcp::start(&sandbox, &[]);
     let mcp_check = mcp.ok("ncl_check", json!({ "path": path }));
     let mcp_export = mcp.ok("ncl_export", json!({ "path": path }));
+    let mcp_apply = mcp.ok("ncl_apply", json!({ "path": path }));
     mcp.finish();
 
     assert_eq!(mcp_check, cli_check);
     assert_eq!(mcp_export, cli_export);
+    assert_eq!(mcp_apply, cli_apply);
     for key in [
         "cluster",
         "intent",

--- a/crates/facet/tests/ncl.rs
+++ b/crates/facet/tests/ncl.rs
@@ -121,3 +121,120 @@ fn ncl_rejects_secret_var() {
     assert_eq!(code, 2);
     assert_eq!(value["error"]["category"], "invalid_arguments");
 }
+
+#[test]
+fn ncl_export_records_ledger_tags_and_blobs() {
+    let sandbox = Sandbox::new();
+    let world = write_world(sandbox.root());
+    let export = sandbox.run_json(&["ncl", "export", world.to_str().unwrap()]);
+    let module_hash = export["moduleHash"].as_str().unwrap();
+    let export_hash = export["exportHash"].as_str().unwrap();
+    let contract_set = export["contractSet"].as_str().unwrap();
+
+    let root = sandbox.root().to_str().unwrap();
+    let history = sandbox.run_json(&["history", root, "--bodies"]);
+    let runs = history["runs"].as_array().unwrap();
+    assert_eq!(runs.len(), 1, "expected one ledger row");
+    let row = &runs[0];
+    assert_eq!(row["requestPath"], "ncl:export");
+    assert_eq!(row["method"], "NCL");
+
+    let tags: Vec<&str> = row["tags"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|tag| tag.as_str().unwrap())
+        .collect();
+    assert!(tags.contains(&format!("ncl:module:{module_hash}").as_str()));
+    assert!(tags.contains(&format!("ncl:export:{export_hash}").as_str()));
+    assert!(tags.contains(&format!("ncl:contracts:{contract_set}").as_str()));
+
+    let source_hash = row["request"]["body"]["hash"].as_str().unwrap();
+    let freeze_hash = row["response"]["body"]["hash"].as_str().unwrap();
+    assert!(sandbox.root().join(".facet/blobs").join(source_hash).is_file());
+    assert!(sandbox.root().join(".facet/blobs").join(freeze_hash).is_file());
+
+    let source_blob = sandbox.run_json(&["blob", source_hash, root]);
+    let content = &source_blob["blob"]["body"]["content"];
+    let snapshot: Value = if content.is_string() {
+        serde_json::from_str(content.as_str().unwrap()).expect("source snapshot JSON")
+    } else {
+        content.clone()
+    };
+    let sources = &snapshot["sources"];
+    assert!(sources.get("world.ncl").is_some());
+    assert!(sources.get("lib.ncl").is_some());
+
+    let freeze_blob = sandbox.run_json(&["blob", freeze_hash, root]);
+    let freeze_content = &freeze_blob["blob"]["body"]["content"];
+    let frozen: Value = if freeze_content.is_string() {
+        serde_json::from_str(freeze_content.as_str().unwrap()).expect("freeze artifact JSON")
+    } else {
+        freeze_content.clone()
+    };
+    assert_eq!(frozen["exportHash"], export_hash);
+    assert_eq!(frozen["moduleHash"], module_hash);
+    assert_eq!(frozen["contractSet"], contract_set);
+    assert!(frozen.get("cluster").is_some());
+    assert!(frozen.get("intent").is_some());
+    assert!(frozen.get("calls").is_some());
+    assert!(frozen.get("plaintext_token").is_none());
+}
+
+fn run_count(sandbox: &common::Sandbox, root: &str) -> usize {
+    sandbox
+        .run_json(&["history", root])["runs"]
+        .as_array()
+        .unwrap()
+        .len()
+}
+
+#[test]
+fn ncl_export_frozen_passes_when_unchanged() {
+    let sandbox = Sandbox::new();
+    let world = write_world(sandbox.root());
+    let path = world.to_str().unwrap();
+    let root = sandbox.root().to_str().unwrap();
+    let first = sandbox.run_json(&["ncl", "export", path]);
+    let second = sandbox.run_json(&["ncl", "export", path, "--frozen"]);
+    assert_eq!(first["exportHash"], second["exportHash"]);
+    assert_eq!(run_count(&sandbox, root), 2, "frozen pass still records the export");
+}
+
+#[test]
+fn ncl_export_frozen_refuses_on_drift() {
+    let sandbox = Sandbox::new();
+    let world = write_world(sandbox.root());
+    let path = world.to_str().unwrap();
+    let root = sandbox.root().to_str().unwrap();
+    let recorded = sandbox.run_json(&["ncl", "export", path]);
+    let run_id = sandbox.run_json(&["history", root, "--bodies"])["runs"][0]["id"]
+        .as_str()
+        .unwrap()
+        .to_owned();
+
+    std::fs::write(
+        &world,
+        WORLD.replace("replicas = 1", "replicas = 2"),
+    )
+    .unwrap();
+
+    let before = run_count(&sandbox, root);
+    let (code, error) = sandbox.run_error_json(&["ncl", "export", path, "--frozen"]);
+    assert_eq!(code, 1);
+    assert_eq!(error["error"]["category"], "replay_changed");
+    assert_eq!(error["error"]["details"]["replayedFrom"], run_id);
+    assert_eq!(
+        error["error"]["details"]["recordedHash"],
+        recorded["exportHash"]
+    );
+    assert_ne!(
+        error["error"]["details"]["recordedHash"],
+        error["error"]["details"]["currentHash"]
+    );
+    assert_eq!(
+        run_count(&sandbox, root),
+        before,
+        "no ledger row when --frozen refuses"
+    );
+}

--- a/crates/facet/tests/ncl.rs
+++ b/crates/facet/tests/ncl.rs
@@ -1,0 +1,123 @@
+//! `facet ncl check|export`: CLI freeze shape and secret-refusal contract.
+
+#[allow(dead_code, unused_imports)]
+mod common;
+
+use std::fs;
+
+use common::*;
+
+const LIB: &str = r#"
+{
+  pod = fun args => {
+    apiVersion = "v1",
+    kind = "Pod",
+    metadata.name = args.name,
+    metadata.annotations.replicas = std.to_string args.n,
+  },
+}
+"#;
+
+const WORLD: &str = r#"
+let lib = import "lib.ncl" in
+{
+  replicas = 1,
+  cluster = [ lib.pod { name = "web", n = replicas } ],
+  intent = [ { kind = "docs_eod", date = "2026-09-12", required_briefs = [] } ],
+  calls = {
+    opencollection = "1.0.0",
+    environments = [ { name = "dev", variables = [ { name = "TOKEN", secret_ref = "kr:me" } ] } ],
+    plaintext_token | not_exported = "hunter2",
+  },
+}
+"#;
+
+fn write_world(root: &std::path::Path) -> std::path::PathBuf {
+    fs::write(root.join("lib.ncl"), LIB).unwrap();
+    let world = root.join("world.ncl");
+    fs::write(&world, WORLD).unwrap();
+    world
+}
+
+fn normalize_ncl(value: Value) -> Value {
+    let mut v = normalize(value);
+    if let Value::Object(map) = &mut v {
+        for key in ["moduleHash", "exportHash"] {
+            if map.contains_key(key) {
+                map.insert(key.to_owned(), json!("<sha256>"));
+            }
+        }
+    }
+    v
+}
+
+#[test]
+fn ncl_check_json_is_golden() {
+    let sandbox = Sandbox::new();
+    let world = write_world(sandbox.root());
+    let value = sandbox.run_json(&[
+        "ncl",
+        "check",
+        world.to_str().unwrap(),
+    ]);
+    assert_eq!(value["schemaVersion"], 1);
+    assert_eq!(value["contractSet"], "k8s-1.34-h3s-0.9.1");
+    assert!(value["moduleHash"].as_str().unwrap().len() == 64);
+    assert_golden("ncl_check.json", &normalize_ncl(value));
+}
+
+#[test]
+fn ncl_export_json_is_golden_and_drops_not_exported() {
+    let sandbox = Sandbox::new();
+    let world = write_world(sandbox.root());
+    let value = sandbox.run_json(&[
+        "ncl",
+        "export",
+        world.to_str().unwrap(),
+    ]);
+    assert_eq!(value["schemaVersion"], 1);
+    assert_eq!(value["contractSet"], "k8s-1.34-h3s-0.9.1");
+    assert!(value.get("plaintext_token").is_none());
+    assert_eq!(
+        value["calls"]["environments"][0]["variables"][0]["secret_ref"],
+        "kr:me"
+    );
+    let text = value.to_string();
+    assert!(!text.contains("hunter2"), "not_exported leaked into export JSON");
+    assert_golden("ncl_export.json", &normalize_ncl(value));
+}
+
+#[test]
+fn ncl_export_respects_var_override() {
+    let sandbox = Sandbox::new();
+    let world = write_world(sandbox.root());
+    let base = sandbox.run_json(&["ncl", "export", world.to_str().unwrap()]);
+    let overridden = sandbox.run_json(&[
+        "ncl",
+        "export",
+        world.to_str().unwrap(),
+        "--var",
+        "replicas=3",
+    ]);
+    assert_eq!(base["moduleHash"], overridden["moduleHash"]);
+    assert_ne!(base["exportHash"], overridden["exportHash"]);
+    assert_eq!(
+        overridden["cluster"][0]["metadata"]["annotations"]["replicas"],
+        "3"
+    );
+}
+
+#[test]
+fn ncl_rejects_secret_var() {
+    let sandbox = Sandbox::new();
+    let world = write_world(sandbox.root());
+    let (code, value) = sandbox.run_error_json(&[
+        "ncl",
+        "export",
+        world.to_str().unwrap(),
+        "--var",
+        "calls.token=\"leak\"",
+    ]);
+    assert_eq!(code, 2);
+    assert_eq!(value["error"]["category"], "invalid_arguments");
+}

--- a/crates/facet/tests/ncl.rs
+++ b/crates/facet/tests/ncl.rs
@@ -23,7 +23,13 @@ let lib = import "lib.ncl" in
 {
   replicas = 1,
   cluster = [ lib.pod { name = "web", n = replicas } ],
-  intent = [ { kind = "docs_eod", date = "2026-09-12", required_briefs = [] } ],
+  intent = [
+    {
+      name = "test-docs-eod",
+      importance = 0.5,
+      spec = { kind = "docs_eod", date = "2026-09-12", required_briefs = [] },
+    },
+  ],
   calls = {
     opencollection = "1.0.0",
     environments = [ { name = "dev", variables = [ { name = "TOKEN", secret_ref = "kr:me" } ] } ],
@@ -237,4 +243,61 @@ fn ncl_export_frozen_refuses_on_drift() {
         before,
         "no ledger row when --frozen refuses"
     );
+}
+
+#[test]
+fn ncl_apply_records_one_lattice_row_and_skips_cluster_without_kubeconfig() {
+    let sandbox = Sandbox::new();
+    let world = write_world(sandbox.root());
+    let path = world.to_str().unwrap();
+    let root = sandbox.root().to_str().unwrap();
+    let value = sandbox.run_json(&["ncl", "apply", path]);
+    assert_eq!(value["schemaVersion"], 1);
+    assert_eq!(value["contractSet"], "k8s-1.34-h3s-0.9.1");
+    assert_eq!(value["action"]["cluster"]["skipped"], true);
+    assert_eq!(value["action"]["intent"]["skipped"], true);
+
+    let history = sandbox.run_json(&["history", root, "--bodies"]);
+    let runs = history["runs"].as_array().unwrap();
+    assert_eq!(runs.len(), 1, "expected one ncl:apply ledger row");
+    let row = &runs[0];
+    assert_eq!(row["requestPath"], "ncl:apply");
+    assert_eq!(row["method"], "NCL");
+
+    let tags: Vec<&str> = row["tags"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|tag| tag.as_str().unwrap())
+        .collect();
+    assert!(tags.iter().any(|tag| tag.starts_with("ncl:module:")));
+    assert!(tags.iter().any(|tag| tag.starts_with("ncl:export:")));
+    assert!(tags.iter().any(|tag| tag.starts_with("ncl:contracts:")));
+}
+
+#[test]
+fn ncl_apply_puts_intent_when_hedron_db_present() {
+    let sandbox = Sandbox::new();
+    let world = write_world(sandbox.root());
+    let path = world.to_str().unwrap();
+    let db_path = sandbox.root().join("hedron.db");
+    hedron_core::Store::open(&db_path).expect("create empty hedrondb schema");
+
+    let output = sandbox
+        .facet()
+        .env("FACET_HEDRON_DB", &db_path)
+        .args(["ncl", "apply", path, "--json"])
+        .output()
+        .expect("facet ncl apply");
+    assert!(
+        output.status.success(),
+        "exit {:?}\nstdout: {}\nstderr: {}",
+        output.status.code(),
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let value: Value = serde_json::from_slice(&output.stdout).expect("apply JSON");
+    assert_eq!(value["action"]["intent"]["skipped"], false);
+    assert_eq!(value["action"]["intent"]["put"], 1);
+    assert_eq!(value["action"]["intent"]["names"], json!(["test-docs-eod"]));
 }

--- a/crates/facet/tests/ncl.rs
+++ b/crates/facet/tests/ncl.rs
@@ -61,11 +61,7 @@ fn normalize_ncl(value: Value) -> Value {
 fn ncl_check_json_is_golden() {
     let sandbox = Sandbox::new();
     let world = write_world(sandbox.root());
-    let value = sandbox.run_json(&[
-        "ncl",
-        "check",
-        world.to_str().unwrap(),
-    ]);
+    let value = sandbox.run_json(&["ncl", "check", world.to_str().unwrap()]);
     assert_eq!(value["schemaVersion"], 1);
     assert_eq!(value["contractSet"], "k8s-1.34-h3s-0.9.1");
     assert!(value["moduleHash"].as_str().unwrap().len() == 64);
@@ -76,11 +72,7 @@ fn ncl_check_json_is_golden() {
 fn ncl_export_json_is_golden_and_drops_not_exported() {
     let sandbox = Sandbox::new();
     let world = write_world(sandbox.root());
-    let value = sandbox.run_json(&[
-        "ncl",
-        "export",
-        world.to_str().unwrap(),
-    ]);
+    let value = sandbox.run_json(&["ncl", "export", world.to_str().unwrap()]);
     assert_eq!(value["schemaVersion"], 1);
     assert_eq!(value["contractSet"], "k8s-1.34-h3s-0.9.1");
     assert!(value.get("plaintext_token").is_none());
@@ -89,7 +81,10 @@ fn ncl_export_json_is_golden_and_drops_not_exported() {
         "kr:me"
     );
     let text = value.to_string();
-    assert!(!text.contains("hunter2"), "not_exported leaked into export JSON");
+    assert!(
+        !text.contains("hunter2"),
+        "not_exported leaked into export JSON"
+    );
     assert_golden("ncl_export.json", &normalize_ncl(value));
 }
 
@@ -157,8 +152,20 @@ fn ncl_export_records_ledger_tags_and_blobs() {
 
     let source_hash = row["request"]["body"]["hash"].as_str().unwrap();
     let freeze_hash = row["response"]["body"]["hash"].as_str().unwrap();
-    assert!(sandbox.root().join(".facet/blobs").join(source_hash).is_file());
-    assert!(sandbox.root().join(".facet/blobs").join(freeze_hash).is_file());
+    assert!(
+        sandbox
+            .root()
+            .join(".facet/blobs")
+            .join(source_hash)
+            .is_file()
+    );
+    assert!(
+        sandbox
+            .root()
+            .join(".facet/blobs")
+            .join(freeze_hash)
+            .is_file()
+    );
 
     let source_blob = sandbox.run_json(&["blob", source_hash, root]);
     let content = &source_blob["blob"]["body"]["content"];
@@ -188,8 +195,7 @@ fn ncl_export_records_ledger_tags_and_blobs() {
 }
 
 fn run_count(sandbox: &common::Sandbox, root: &str) -> usize {
-    sandbox
-        .run_json(&["history", root])["runs"]
+    sandbox.run_json(&["history", root])["runs"]
         .as_array()
         .unwrap()
         .len()
@@ -204,7 +210,11 @@ fn ncl_export_frozen_passes_when_unchanged() {
     let first = sandbox.run_json(&["ncl", "export", path]);
     let second = sandbox.run_json(&["ncl", "export", path, "--frozen"]);
     assert_eq!(first["exportHash"], second["exportHash"]);
-    assert_eq!(run_count(&sandbox, root), 2, "frozen pass still records the export");
+    assert_eq!(
+        run_count(&sandbox, root),
+        2,
+        "frozen pass still records the export"
+    );
 }
 
 #[test]
@@ -219,11 +229,7 @@ fn ncl_export_frozen_refuses_on_drift() {
         .unwrap()
         .to_owned();
 
-    std::fs::write(
-        &world,
-        WORLD.replace("replicas = 1", "replicas = 2"),
-    )
-    .unwrap();
+    std::fs::write(&world, WORLD.replace("replicas = 1", "replicas = 2")).unwrap();
 
     let before = run_count(&sandbox, root);
     let (code, error) = sandbox.run_error_json(&["ncl", "export", path, "--frozen"]);

--- a/crates/hedron-ncl/Cargo.toml
+++ b/crates/hedron-ncl/Cargo.toml
@@ -1,0 +1,25 @@
+[package]
+name = "hedron-ncl"
+# Nickel contract pack + the only Nickel VM host on the platform (SPEC-nickel G0).
+# Follows the Facet CLI axis; MSRV inherits the workspace 1.95.
+version.workspace = true
+# Edition 2021, not the workspace 2024: `gen` is a reserved keyword in 2024 and the
+# generated-predicate module must stay reachable as `hedron_ncl::gen::*` for
+# consumers that copy the output. MSRV still inherits the workspace 1.95.
+edition = "2021"
+license.workspace = true
+rust-version.workspace = true
+publish = false
+description = "Nickel contract pack for h3s / Facet / HedronDB: platform law, versioned release overlays, generated predicates"
+
+[lints]
+workspace = true
+
+[dependencies]
+# The Nickel VM lives here and only here. Never add this to h3s or hedron-core.
+nickel-lang-core = { version = "0.18.0", default-features = false }
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+thiserror = "2"
+
+[dev-dependencies]

--- a/crates/hedron-ncl/ncl/contracts/docs_eod.ncl
+++ b/crates/hedron-ncl/ncl/contracts/docs_eod.ncl
@@ -1,0 +1,8 @@
+# Generated from HedronDB DocsEodSpec (hedrondb @ c681943).
+# Shape contract for kind: docs_eod — date + required_briefs.
+
+{
+  kind | force = "docs_eod",
+  date | String,
+  required_briefs | Array String,
+}

--- a/crates/hedron-ncl/ncl/contracts/opencollection.ncl
+++ b/crates/hedron-ncl/ncl/contracts/opencollection.ncl
@@ -1,0 +1,190 @@
+# OpenCollection 1.0 contract pack with Facet secret_ref overlay.
+# Schema: https://schema.opencollection.com/opencollection/v1.0.0.json
+#
+# secret_ref: allowed on environment variables (Facet machine-store refs).
+# Plaintext credential fields (token, password, api_key, authorization, and
+# OC secret values) are | not_exported — omitted from eval_full_for_export.
+
+let OC_VERSION | force = "1.0.0"
+
+# Plaintext secrets: author-time only; never appear in frozen export.
+let PlainSecret | String | not_exported | optional
+
+# Facet machine-store reference (kr:<user> or enc:v1:<blob>).
+let SecretRef | String | optional
+
+let Description = String | {
+  content | String,
+  type | String,
+  ..
+}
+
+let HttpHeader = {
+  name | String,
+  value | String | optional,
+  disabled | Bool | optional,
+  ..
+}
+
+let AuthBearer = {
+  type | force = "bearer",
+  token | PlainSecret,
+  authorization | PlainSecret,
+  secret_ref | SecretRef,
+  ..
+}
+
+let AuthBasic = {
+  type | force = "basic",
+  username | String | optional,
+  password | PlainSecret,
+  secret_ref | SecretRef,
+  ..
+}
+
+let AuthApiKey = {
+  type | force = "apikey",
+  key | String | optional,
+  value | PlainSecret,
+  api_key | PlainSecret,
+  placement | String | optional,
+  secret_ref | SecretRef,
+  ..
+}
+
+let AuthDigest = {
+  type | force = "digest",
+  username | String | optional,
+  password | PlainSecret,
+  secret_ref | SecretRef,
+  ..
+}
+
+let AuthWsse = {
+  type | force = "wsse",
+  username | String | optional,
+  password | PlainSecret,
+  secret_ref | SecretRef,
+  ..
+}
+
+let AuthAwsV4 = {
+  type | force = "awsv4",
+  accessKeyId | String | optional,
+  secretAccessKey | PlainSecret,
+  sessionToken | PlainSecret,
+  service | String | optional,
+  region | String | optional,
+  profileName | String | optional,
+  secret_ref | SecretRef,
+  ..
+}
+
+let AuthOAuth1 = {
+  type | force = "oauth1",
+  consumerKey | String | optional,
+  consumerSecret | PlainSecret,
+  accessToken | PlainSecret,
+  accessTokenSecret | PlainSecret,
+  secret_ref | SecretRef,
+  ..
+}
+
+let AuthOAuth2 = {
+  type | force = "oauth2",
+  flow | Dyn,
+  secret_ref | SecretRef,
+  ..
+}
+
+let Auth = AuthBearer
+  | AuthBasic
+  | AuthApiKey
+  | AuthDigest
+  | AuthWsse
+  | AuthAwsV4
+  | AuthOAuth1
+  | AuthOAuth2
+  | "inherit"
+
+let SecretVariable = {
+  secret | force = true,
+  name | String,
+  secret_ref | SecretRef,
+  value | PlainSecret,
+  description | Description | optional,
+  disabled | Bool | optional,
+  type | String | optional,
+  ..
+}
+
+let PlainVariable = {
+  name | String,
+  value | Dyn | optional,
+  secret_ref | SecretRef,
+  description | Description | optional,
+  disabled | Bool | optional,
+  ..
+}
+
+let EnvironmentVariable = SecretVariable | PlainVariable
+
+let Environment = {
+  name | String,
+  color | String | optional,
+  description | Description | optional,
+  variables | Array EnvironmentVariable | optional,
+  extends | String | optional,
+  dotEnvFilePath | String | optional,
+  ..
+}
+
+let HttpRequest = {
+  method | String,
+  url | String,
+  headers | Array HttpHeader | optional,
+  auth | Auth | optional,
+  ..
+}
+
+let ItemInfo = {
+  name | String,
+  type | String,
+  seq | Number | optional,
+  ..
+}
+
+let Item = {
+  info | ItemInfo,
+  http | HttpRequest | optional,
+  items | Array Item | optional,
+  ..
+}
+
+let CollectionInfo = {
+  name | String,
+  summary | String | optional,
+  version | String | optional,
+  ..
+}
+
+let CollectionConfig = {
+  environments | Array Environment | optional,
+  ..
+}
+
+let OpenCollection = {
+  opencollection | force = OC_VERSION,
+  info | CollectionInfo | optional,
+  config | CollectionConfig | optional,
+  items | Array Item | optional,
+  bundled | Bool | optional,
+  ..
+}
+
+in {
+  OpenCollection,
+  OC_VERSION,
+  PlainSecret,
+  SecretRef,
+}

--- a/crates/hedron-ncl/ncl/contracts/world.ncl
+++ b/crates/hedron-ncl/ncl/contracts/world.ncl
@@ -1,0 +1,57 @@
+# World contract — one agent file, three frozen projections (SPEC-nickel R8 / G5a).
+# `cluster` is tightened to Pod objects this h3s minor admits (Service is a follow-on).
+
+let DocsEod = {
+  kind | force = "docs_eod",
+  date | String,
+  required_briefs | Array String,
+} in
+let OpenCollection = {
+  opencollection | force = "1.0.0",
+  info | { name | String, summary | String | optional, .. } | optional,
+  config | {
+    environments | Array {
+      name | String,
+      variables | Array {
+        name | String,
+        secret_ref | String | optional,
+        value | String | not_exported | optional,
+        ..
+      } | optional,
+      ..
+    } | optional,
+    ..
+  } | optional,
+  ..
+} in
+let K8sContainer = {
+  name | String,
+  image | String,
+  securityContext | Dyn | optional,
+  ..
+} in
+let H3sPod = {
+  apiVersion | force = "v1",
+  kind | force = "Pod",
+  metadata | { name | String, .. },
+  spec | {
+    automountServiceAccountToken | Bool | optional,
+    enableServiceLinks | Bool | optional,
+    dnsPolicy | String | optional,
+    containers | Array K8sContainer,
+    volumes | Array Dyn | optional,
+    securityContext | Dyn | optional,
+    ..
+  },
+  ..
+} in
+let DesiredState = {
+  name | String,
+  importance | Number,
+  spec | DocsEod,
+} in
+{
+  cluster | Array H3sPod,
+  intent | Array DesiredState,
+  calls | OpenCollection,
+}

--- a/crates/hedron-ncl/ncl/fixtures/lib.ncl
+++ b/crates/hedron-ncl/ncl/fixtures/lib.ncl
@@ -1,0 +1,26 @@
+# Shared builders for in-tree World fixtures. Applies platform law and the 0.9.1
+# release overlay so cluster projections match examples/supported-pod.yaml.
+
+let platform = import "../platform.ncl" in
+let overlay = import "../overlay/k8s-1.34-h3s-0.9.1.ncl" in
+{
+  supported_pod = fun args =>
+    overlay.restrict_pod (platform.harden_pod {
+      apiVersion = "v1",
+      kind = "Pod",
+      metadata = { name = args.name },
+      spec = {
+        dnsPolicy = "Default",
+        containers = [
+          {
+            name = "pause",
+            image = "registry.k8s.io/pause:3.10",
+            securityContext = {
+              runAsUser = 65534,
+              seccompProfile = { type = "RuntimeDefault" },
+            },
+          },
+        ],
+      },
+    }),
+}

--- a/crates/hedron-ncl/ncl/fixtures/world.ncl
+++ b/crates/hedron-ncl/ncl/fixtures/world.ncl
@@ -1,0 +1,33 @@
+# In-tree World fixture (G5a). Exports cluster + intent + calls for facet ncl export.
+
+let lib = import "lib.ncl" in
+let World = import "../contracts/world.ncl" in
+{
+  cluster = [ lib.supported_pod { name = "supported-pod" } ],
+  intent = [
+    {
+      name = "nickel-g5-docs-eod",
+      importance = 0.5,
+      spec = {
+        kind = "docs_eod",
+        date = "2026-09-12",
+        required_briefs = [ "foundry/hedronetes/CHECKLIST-nickel" ],
+      },
+    },
+  ],
+  calls = {
+    opencollection = "1.0.0",
+    info = {
+      name = "hedronetes-world-fixture",
+      summary = "G5a in-tree World export (cluster + intent + calls)",
+    },
+    config = {
+      environments = [
+        {
+          name = "lima",
+          variables = [ { name = "FACET_PROBE", secret_ref = "kr:probe" } ],
+        },
+      ],
+    },
+  },
+} | World

--- a/crates/hedron-ncl/ncl/fixtures/world_cluster_only.ncl
+++ b/crates/hedron-ncl/ncl/fixtures/world_cluster_only.ncl
@@ -1,0 +1,2 @@
+let World = import "../contracts/world.ncl" in
+{ cluster = [] } | World

--- a/crates/hedron-ncl/ncl/overlay/k8s-1.34-h3s-0.9.1.ncl
+++ b/crates/hedron-ncl/ncl/overlay/k8s-1.34-h3s-0.9.1.ncl
@@ -1,0 +1,90 @@
+# k8s-1.34-h3s-0.9.1 — RestrictedV1 release overlay (SPEC-nickel G0b).
+#
+# This file says what THIS h3s binary can actually run. It is versioned with the
+# h3s minor and applied at `| priority 1000`: above operator policy (100) and agent
+# intent (0), below platform `| force`. It is NOT eternal law. When 0.10 lands
+# bound tokens / NodePort / PVC, the matching lines leave the successor overlay
+# (k8s-1.34-h3s-0.10.0) and nothing in ncl/platform.ncl changes.
+#
+# Blame sentences mirror h3s `pod_profile.rs` / `admission.rs` (422 runtime profile).
+{
+  id = "k8s-1.34-h3s-0.9.1",
+  kubernetes = "1.34",
+  h3s = "0.9.1",
+  profile = "restricted-v1",
+
+  # 0.9 gaps: no TokenRequest / bearer tokens yet, so nothing is mounted; no
+  # service-link env injection. Overlay priority, deliberately not `force`.
+  pod = {
+    spec = {
+      automountServiceAccountToken | priority 1000 = false,
+      enableServiceLinks | priority 1000 = false,
+    },
+  },
+
+  # Contracts and functions below are `not_exported`: exporting the overlay yields
+  # only its data (id, versions, allow-lists).
+
+  # Only ClusterIP forwarding exists in 0.9 (ServiceForwarding::UnsupportedType).
+  service_types = ["ClusterIP"],
+
+  # Only ConfigMap and Secret volumes are honoured by the 0.9 kubelet.
+  volume_kinds = ["configMap", "secret"],
+
+  ServiceType
+    | not_exported
+    = std.contract.custom
+      (
+        fun label value =>
+          if std.array.elem value service_types then
+            'Ok value
+          else
+            'Error
+              {
+                message = "%{id}: Service type %{std.to_string value} is not supported by h3s %{h3s}; allowed: %{std.string.join ", " service_types}",
+              }
+      ),
+
+  Volume
+    | not_exported
+    = std.contract.custom
+      (
+        fun label value =>
+          if !std.is_record value then
+            'Error { message = "%{id}: volume must be a record" }
+          else
+            let kinds =
+              std.record.fields value |> std.array.filter (fun k => k != "name")
+            in
+            let bad = std.array.filter (fun k => !(std.array.elem k volume_kinds)) kinds in
+            if bad == [] then
+              'Ok value
+            else
+              'Error
+                {
+                  message = "%{id}: volume kind %{std.string.join ", " bad} is not supported by h3s %{h3s}; allowed: %{std.string.join ", " volume_kinds}",
+                }
+      ),
+
+  Pod | not_exported = {
+    spec
+      | {
+        volumes | Array Volume | optional,
+        ..
+      },
+    ..
+  },
+
+  Service | not_exported = {
+    spec
+      | {
+        type | ServiceType | optional,
+        ..
+      },
+    ..
+  },
+
+  # Apply the 0.9 overlay to a Pod: overlay values win over agent/operator
+  # values, and the release contracts are checked.
+  restrict_pod | not_exported = fun p => (p & pod) | Pod,
+}

--- a/crates/hedron-ncl/ncl/platform.ncl
+++ b/crates/hedron-ncl/ncl/platform.ncl
@@ -1,0 +1,94 @@
+# platform.ncl — platform law. Only `| force` invariants that survive feature
+# growth belong here (SPEC-nickel R3 / G0b):
+#
+#   * containers run non-root, drop ALL capabilities, cannot escalate privilege
+#   * Hedron `extra` carries no secret-looking fields
+#   * OpenCollection secret slots are references, never plaintext values
+#
+# NOT here, on purpose: automountServiceAccountToken=false, enableServiceLinks=false,
+# ClusterIP-only / NodePort refusal, ConfigMap+Secret-only volumes. Those are gaps of
+# one h3s release and live in ncl/overlay/<contract-set>.ncl as a priority overlay,
+# so that 0.10 (bound tokens, NodePort, PVC) removes them without a contract break.
+let secret_field_re =
+  "(?i)(^|[_-])(token|password|passwd|secret|api[_-]?key|private[_-]?key|bearer|credential)s?($|[_-])"
+in
+{
+  id = "platform",
+
+  # ---------------------------------------------------------------------------
+  # Contracts
+  # ---------------------------------------------------------------------------
+
+  # A record none of whose field names look like a secret. Applied to Hedron `extra`.
+  NoSecretFields
+    | not_exported
+    = std.contract.custom
+      (
+        fun label value =>
+          if !std.is_record value then
+            'Error { message = "platform: expected a record" }
+          else
+            let bad =
+              std.record.fields value
+              |> std.array.filter (fun k => std.string.is_match secret_field_re k)
+            in
+            if bad == [] then
+              'Ok value
+            else
+              'Error
+                {
+                  message = "platform: secret-looking fields are not allowed here: %{std.string.join ", " bad}",
+                  notes = ["Store the value in the vault and reference it; never copy secrets into Hedron `extra`."],
+                }
+      ),
+
+  # A secret slot in an OpenCollection projection. Only `{ secret_ref = "<name>" }`
+  # may cross the export boundary. Plaintext values are `| not_exported` in
+  # ncl/contracts/opencollection.ncl and hydrated by Facet outside the document.
+  SecretSlot
+    | not_exported
+    = std.contract.custom
+      (
+        fun label value =>
+          if std.is_record value && std.record.has_field "secret_ref" value then
+            'Ok value
+          else
+            'Error
+              {
+                message = "platform: secret slots must be { secret_ref = \"<name>\" }, never a plaintext value",
+                notes = ["Facet hydrates secret_ref at run time; Nickel never sees the raw token."],
+              }
+      ),
+
+  # ---------------------------------------------------------------------------
+  # Pod law as merge overlays. `| force` wins over operator / agent / library.
+  # ---------------------------------------------------------------------------
+
+  container = {
+    securityContext = {
+      runAsNonRoot | force = true,
+      allowPrivilegeEscalation | force = false,
+      capabilities = { drop | force = ["ALL"] },
+    },
+  },
+
+  pod = {
+    spec = {
+      securityContext = { runAsNonRoot | force = true },
+    },
+  },
+
+  # Apply platform law to a whole Pod. Containers are arrays, so the container
+  # law is merged element-wise (Nickel does not merge arrays).
+  harden_pod
+    | not_exported
+    = fun p =>
+      let harden = std.array.map (fun c => c & container) in
+      let inits =
+        if std.record.has_field "initContainers" p.spec then
+          { spec = { initContainers | force = harden p.spec.initContainers } }
+        else
+          {}
+      in
+      p & pod & { spec = { containers | force = harden p.spec.containers } } & inits,
+}

--- a/crates/hedron-ncl/src/eval.rs
+++ b/crates/hedron-ncl/src/eval.rs
@@ -2,12 +2,21 @@
 //!
 //! This is the export boundary. `eval_full_for_export` skips fields marked
 //! `| not_exported`, which is how plaintext secret fields stay out of every
-//! frozen projection.
+//! frozen projection. Nothing here persists, hydrates or reads secrets.
+
+use std::path::Path;
 
 use nickel_lang_core::error::report::{ColorOpt, report_as_str};
 use nickel_lang_core::eval::cache::CacheImpl;
 use nickel_lang_core::program::{Program, ProgramBuilder};
 use nickel_lang_core::serialize::{ExportFormat, to_string};
+use nickel_lang_core::term::{MergePriority, Number};
+use nickel_lang_core::typecheck::TypecheckMode;
+
+/// Merge priority given to caller-supplied overrides (`--var path=value`).
+/// This is the **operator** rung of the SPEC ladder: above agent intent (plain),
+/// below the release overlay (`priority 1000`) and platform `| force`.
+pub const OVERRIDE_PRIORITY: i64 = 100;
 
 /// Errors from building, evaluating or exporting a Nickel program.
 #[derive(Debug, thiserror::Error)]
@@ -15,6 +24,9 @@ pub enum Error {
     /// The program could not be assembled (I/O, no input).
     #[error("nickel build: {0}")]
     Build(String),
+    /// An override assignment was not `path.to.field=value`.
+    #[error("nickel override: {0}")]
+    Override(String),
     /// Parse, typecheck, import or contract (blame) failure. Carries the rendered
     /// Nickel diagnostic so callers can surface blame text verbatim.
     #[error("nickel: {0}")]
@@ -27,21 +39,74 @@ pub enum Error {
     Json(#[from] serde_json::Error),
 }
 
-/// Evaluate `source` (named `name` in diagnostics) for export and return the
-/// frozen value as JSON.
-pub fn eval_export(name: &str, source: &str) -> Result<serde_json::Value, Error> {
-    let mut program: Program<CacheImpl> = ProgramBuilder::new()
-        .add_source_string(source, name)
+/// Where the main program comes from.
+#[derive(Debug, Clone)]
+pub enum Input<'a> {
+    /// In-memory source, `name` only labels diagnostics. Relative imports do
+    /// not resolve.
+    Text { name: &'a str, source: &'a str },
+    /// A file on disk; imports resolve relative to it.
+    Path(&'a Path),
+}
+
+fn render<E: nickel_lang_core::error::IntoDiagnostics>(program: &Program<CacheImpl>, e: E) -> Error {
+    let mut files = program.files();
+    Error::Nickel(report_as_str(&mut files, e, ColorOpt::Never))
+}
+
+fn build(input: Input<'_>, overrides: &[String]) -> Result<Program<CacheImpl>, Error> {
+    let builder = ProgramBuilder::new();
+    let builder = match input {
+        Input::Text { name, source } => builder.add_source_string(source, name),
+        Input::Path(path) => builder.add_path(path),
+    };
+    let mut program: Program<CacheImpl> = builder
         .build()
         .map_err(|e| Error::Build(format!("{e:?}")))?;
 
-    let value = program.eval_full_for_export().map_err(|e| {
-        let mut files = program.files();
-        Error::Nickel(report_as_str(&mut files, e, ColorOpt::Never))
-    })?;
+    let mut parsed = Vec::with_capacity(overrides.len());
+    for assignment in overrides {
+        if !assignment.contains('=') {
+            return Err(Error::Override(format!(
+                "expected `path.to.field=value`, got `{assignment}`"
+            )));
+        }
+        let priority = MergePriority::Numeral(Number::from(OVERRIDE_PRIORITY));
+        let field_override = program
+            .parse_override(assignment.clone(), priority)
+            .map_err(|e| render(&program, e))?;
+        parsed.push(field_override);
+    }
+    program.add_overrides(parsed);
+    Ok(program)
+}
 
+fn export_value(program: &mut Program<CacheImpl>) -> Result<serde_json::Value, Error> {
+    let value = program.eval_full_for_export().map_err(|e| render(program, e))?;
     let json = to_string(ExportFormat::Json, &value).map_err(|e| Error::Export(format!("{e:?}")))?;
     Ok(serde_json::from_str(&json)?)
+}
+
+/// Parse, typecheck and fully evaluate (so every contract fires) without
+/// returning or persisting anything. `Ok(())` means the program would export.
+pub fn check(input: Input<'_>, overrides: &[String]) -> Result<(), Error> {
+    let mut program = build(input, overrides)?;
+    program
+        .typecheck(TypecheckMode::Walk)
+        .map_err(|e| render(&program, e))?;
+    export_value(&mut program).map(drop)
+}
+
+/// Evaluate for export with caller overrides and return the frozen value as JSON.
+pub fn export(input: Input<'_>, overrides: &[String]) -> Result<serde_json::Value, Error> {
+    let mut program = build(input, overrides)?;
+    export_value(&mut program)
+}
+
+/// Evaluate `source` (named `name` in diagnostics) for export and return the
+/// frozen value as JSON.
+pub fn eval_export(name: &str, source: &str) -> Result<serde_json::Value, Error> {
+    export(Input::Text { name, source }, &[])
 }
 
 /// Like [`eval_export`], with `platform` and `overlay` bound in scope
@@ -65,5 +130,30 @@ mod tests {
     fn blame_is_an_error() {
         let err = eval_export("t", r#"("x" | Number)"#).unwrap_err();
         assert!(matches!(err, Error::Nickel(_)), "{err}");
+    }
+
+    #[test]
+    fn override_is_operator_priority() {
+        let src = r#"{ replicas = 1, image | priority 1000 = "pinned" }"#;
+        let v = export(
+            Input::Text { name: "t", source: src },
+            &["replicas=3".into(), "image=\"mine\"".into()],
+        )
+        .unwrap();
+        assert_eq!(v["replicas"], 3, "override beats plain agent value");
+        assert_eq!(v["image"], "pinned", "release overlay priority beats override");
+    }
+
+    #[test]
+    fn bad_override_shape() {
+        let err = export(Input::Text { name: "t", source: "{}" }, &["nope".into()]).unwrap_err();
+        assert!(matches!(err, Error::Override(_)), "{err}");
+    }
+
+    #[test]
+    fn check_reports_type_errors_without_output() {
+        let err = check(Input::Text { name: "t", source: r#"(1 + "a" : Number)"# }, &[]).unwrap_err();
+        assert!(matches!(err, Error::Nickel(_)), "{err}");
+        check(Input::Text { name: "t", source: "{ ok = true }" }, &[]).unwrap();
     }
 }

--- a/crates/hedron-ncl/src/eval.rs
+++ b/crates/hedron-ncl/src/eval.rs
@@ -6,10 +6,10 @@
 
 use std::path::Path;
 
-use nickel_lang_core::error::report::{ColorOpt, report_as_str};
+use nickel_lang_core::error::report::{report_as_str, ColorOpt};
 use nickel_lang_core::eval::cache::CacheImpl;
 use nickel_lang_core::program::{Program, ProgramBuilder};
-use nickel_lang_core::serialize::{ExportFormat, to_string};
+use nickel_lang_core::serialize::{to_string, ExportFormat};
 use nickel_lang_core::term::{MergePriority, Number};
 use nickel_lang_core::typecheck::TypecheckMode;
 
@@ -49,7 +49,10 @@ pub enum Input<'a> {
     Path(&'a Path),
 }
 
-fn render<E: nickel_lang_core::error::IntoDiagnostics>(program: &Program<CacheImpl>, e: E) -> Error {
+fn render<E: nickel_lang_core::error::IntoDiagnostics>(
+    program: &Program<CacheImpl>,
+    e: E,
+) -> Error {
     let mut files = program.files();
     Error::Nickel(report_as_str(&mut files, e, ColorOpt::Never))
 }
@@ -82,8 +85,11 @@ fn build(input: Input<'_>, overrides: &[String]) -> Result<Program<CacheImpl>, E
 }
 
 fn export_value(program: &mut Program<CacheImpl>) -> Result<serde_json::Value, Error> {
-    let value = program.eval_full_for_export().map_err(|e| render(program, e))?;
-    let json = to_string(ExportFormat::Json, &value).map_err(|e| Error::Export(format!("{e:?}")))?;
+    let value = program
+        .eval_full_for_export()
+        .map_err(|e| render(program, e))?;
+    let json =
+        to_string(ExportFormat::Json, &value).map_err(|e| Error::Export(format!("{e:?}")))?;
     Ok(serde_json::from_str(&json)?)
 }
 
@@ -136,24 +142,51 @@ mod tests {
     fn override_is_operator_priority() {
         let src = r#"{ replicas = 1, image | priority 1000 = "pinned" }"#;
         let v = export(
-            Input::Text { name: "t", source: src },
+            Input::Text {
+                name: "t",
+                source: src,
+            },
             &["replicas=3".into(), "image=\"mine\"".into()],
         )
         .unwrap();
         assert_eq!(v["replicas"], 3, "override beats plain agent value");
-        assert_eq!(v["image"], "pinned", "release overlay priority beats override");
+        assert_eq!(
+            v["image"], "pinned",
+            "release overlay priority beats override"
+        );
     }
 
     #[test]
     fn bad_override_shape() {
-        let err = export(Input::Text { name: "t", source: "{}" }, &["nope".into()]).unwrap_err();
+        let err = export(
+            Input::Text {
+                name: "t",
+                source: "{}",
+            },
+            &["nope".into()],
+        )
+        .unwrap_err();
         assert!(matches!(err, Error::Override(_)), "{err}");
     }
 
     #[test]
     fn check_reports_type_errors_without_output() {
-        let err = check(Input::Text { name: "t", source: r#"(1 + "a" : Number)"# }, &[]).unwrap_err();
+        let err = check(
+            Input::Text {
+                name: "t",
+                source: r#"(1 + "a" : Number)"#,
+            },
+            &[],
+        )
+        .unwrap_err();
         assert!(matches!(err, Error::Nickel(_)), "{err}");
-        check(Input::Text { name: "t", source: "{ ok = true }" }, &[]).unwrap();
+        check(
+            Input::Text {
+                name: "t",
+                source: "{ ok = true }",
+            },
+            &[],
+        )
+        .unwrap();
     }
 }

--- a/crates/hedron-ncl/src/eval.rs
+++ b/crates/hedron-ncl/src/eval.rs
@@ -1,0 +1,69 @@
+//! Thin wrapper over the Nickel VM: Nickel source in, frozen JSON out.
+//!
+//! This is the export boundary. `eval_full_for_export` skips fields marked
+//! `| not_exported`, which is how plaintext secret fields stay out of every
+//! frozen projection.
+
+use nickel_lang_core::error::report::{ColorOpt, report_as_str};
+use nickel_lang_core::eval::cache::CacheImpl;
+use nickel_lang_core::program::{Program, ProgramBuilder};
+use nickel_lang_core::serialize::{ExportFormat, to_string};
+
+/// Errors from building, evaluating or exporting a Nickel program.
+#[derive(Debug, thiserror::Error)]
+pub enum Error {
+    /// The program could not be assembled (I/O, no input).
+    #[error("nickel build: {0}")]
+    Build(String),
+    /// Parse, typecheck, import or contract (blame) failure. Carries the rendered
+    /// Nickel diagnostic so callers can surface blame text verbatim.
+    #[error("nickel: {0}")]
+    Nickel(String),
+    /// The evaluated value is not JSON-exportable (functions, opaque values).
+    #[error("nickel export: {0}")]
+    Export(String),
+    /// The exported JSON text failed to parse back (should not happen).
+    #[error("json: {0}")]
+    Json(#[from] serde_json::Error),
+}
+
+/// Evaluate `source` (named `name` in diagnostics) for export and return the
+/// frozen value as JSON.
+pub fn eval_export(name: &str, source: &str) -> Result<serde_json::Value, Error> {
+    let mut program: Program<CacheImpl> = ProgramBuilder::new()
+        .add_source_string(source, name)
+        .build()
+        .map_err(|e| Error::Build(format!("{e:?}")))?;
+
+    let value = program.eval_full_for_export().map_err(|e| {
+        let mut files = program.files();
+        Error::Nickel(report_as_str(&mut files, e, ColorOpt::Never))
+    })?;
+
+    let json = to_string(ExportFormat::Json, &value).map_err(|e| Error::Export(format!("{e:?}")))?;
+    Ok(serde_json::from_str(&json)?)
+}
+
+/// Like [`eval_export`], with `platform` and `overlay` bound in scope
+/// (see [`crate::overlay::prelude`]).
+pub fn eval_export_with_prelude(name: &str, body: &str) -> Result<serde_json::Value, Error> {
+    let source = format!("{}{body}", crate::overlay::prelude());
+    eval_export(name, &source)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn exports_json() {
+        let v = eval_export("t", r#"{ a = 1, b = "x", c | not_exported = "hidden" }"#).unwrap();
+        assert_eq!(v, serde_json::json!({ "a": 1, "b": "x" }));
+    }
+
+    #[test]
+    fn blame_is_an_error() {
+        let err = eval_export("t", r#"("x" | Number)"#).unwrap_err();
+        assert!(matches!(err, Error::Nickel(_)), "{err}");
+    }
+}

--- a/crates/hedron-ncl/src/gen/docs_eod.rs
+++ b/crates/hedron-ncl/src/gen/docs_eod.rs
@@ -45,7 +45,6 @@ pub fn check_shape(spec: &Value) -> Result<DocsEodSpec, DocsEodShapeError> {
         )));
     }
 
-    serde_json::from_value(spec.clone()).map_err(|err| {
-        DocsEodShapeError::invalid(format!("{KIND} spec: {err}"))
-    })
+    serde_json::from_value(spec.clone())
+        .map_err(|err| DocsEodShapeError::invalid(format!("{KIND} spec: {err}")))
 }

--- a/crates/hedron-ncl/src/gen/docs_eod.rs
+++ b/crates/hedron-ncl/src/gen/docs_eod.rs
@@ -1,0 +1,51 @@
+//! Generated from HedronDB `DocsEodSpec` (hedrondb @ c681943).
+//! Shape contract for `kind: docs_eod`. No nickel-lang-core in this module.
+
+use serde::Deserialize;
+use serde_json::Value;
+
+/// `spec.kind` handled by this contract.
+pub const KIND: &str = "docs_eod";
+
+/// `kind: docs_eod` spec body (`kind` validated separately).
+#[derive(Debug, Clone, PartialEq, Deserialize)]
+pub struct DocsEodSpec {
+    pub date: String,
+    pub required_briefs: Vec<String>,
+}
+
+/// Shape mismatch for a desired-state spec.
+#[derive(Debug, Clone, PartialEq, thiserror::Error)]
+#[error("{message}")]
+pub struct DocsEodShapeError {
+    pub message: String,
+}
+
+impl DocsEodShapeError {
+    fn invalid(message: impl Into<String>) -> Self {
+        Self {
+            message: message.into(),
+        }
+    }
+}
+
+/// Validate `spec` against the `docs_eod` shape contract.
+///
+/// Rejects missing `kind`, unknown kinds, and malformed `docs_eod` bodies.
+/// Callable from `hedron-core` without linking `nickel-lang-core`.
+pub fn check_shape(spec: &Value) -> Result<DocsEodSpec, DocsEodShapeError> {
+    let kind = spec
+        .get("kind")
+        .and_then(Value::as_str)
+        .ok_or_else(|| DocsEodShapeError::invalid("desired state spec requires kind: <string>"))?;
+
+    if kind != KIND {
+        return Err(DocsEodShapeError::invalid(format!(
+            "unknown desired state kind {kind:?}"
+        )));
+    }
+
+    serde_json::from_value(spec.clone()).map_err(|err| {
+        DocsEodShapeError::invalid(format!("{KIND} spec: {err}"))
+    })
+}

--- a/crates/hedron-ncl/src/gen/mod.rs
+++ b/crates/hedron-ncl/src/gen/mod.rs
@@ -1,0 +1,7 @@
+//! Generated Rust predicates.
+//!
+//! Everything under `gen/` is plain Rust with **no** `nickel-lang-core` in its
+//! own dependency graph, so `hedron-core` and `h3s-api` can copy or depend on
+//! the output without linking the VM (SPEC-nickel G0c / G3 / G4).
+
+pub mod docs_eod;

--- a/crates/hedron-ncl/src/lib.rs
+++ b/crates/hedron-ncl/src/lib.rs
@@ -1,0 +1,24 @@
+//! `hedron-ncl` — the Nickel contract pack for h3s, Facet and HedronDB, and the
+//! **only** crate on the platform that links the Nickel VM (`nickel-lang-core`).
+//!
+//! SPEC-nickel product law: Nickel is the configuration algebra; Facet is the only
+//! process that evaluates it; h3s and HedronDB consume frozen data through
+//! predicates *generated* from this pack (see [`gen`]). Never add
+//! `nickel-lang-core` to `h3s-*` or `hedron-core`.
+//!
+//! Layout:
+//! - [`overlay`] — embedded `ncl/platform.ncl` (platform `| force` law) and the
+//!   versioned release overlay `ncl/overlay/<CONTRACT_SET>.ncl` (RestrictedV1 as a
+//!   priority overlay, not eternal law).
+//! - [`eval`] — thin wrapper over `nickel-lang-core`: source in, frozen JSON out.
+//! - [`gen`] — generated Rust predicates (backend owns `gen::docs_eod`).
+//! - `ncl/contracts/` — `docs_eod.ncl` (backend), `opencollection.ncl` (frontend).
+
+#![forbid(unsafe_code)]
+
+pub mod eval;
+pub mod r#gen;
+pub mod overlay;
+
+pub use eval::{Error, eval_export, eval_export_with_prelude};
+pub use overlay::{CONTRACT_SET, OVERLAY_NCL, PLATFORM_NCL, contract_set_id, prelude};

--- a/crates/hedron-ncl/src/lib.rs
+++ b/crates/hedron-ncl/src/lib.rs
@@ -20,5 +20,5 @@ pub mod eval;
 pub mod r#gen;
 pub mod overlay;
 
-pub use eval::{Error, eval_export, eval_export_with_prelude};
-pub use overlay::{CONTRACT_SET, OVERLAY_NCL, PLATFORM_NCL, contract_set_id, prelude};
+pub use eval::{eval_export, eval_export_with_prelude, Error};
+pub use overlay::{contract_set_id, prelude, CONTRACT_SET, OVERLAY_NCL, PLATFORM_NCL};

--- a/crates/hedron-ncl/src/overlay.rs
+++ b/crates/hedron-ncl/src/overlay.rs
@@ -14,7 +14,7 @@
 //! volume restriction are **0.9 gaps**: they live in the overlay and leave with
 //! the h3s minor that closes them. They are never platform `| force`.
 
-use crate::eval::{Error, eval_export};
+use crate::eval::{eval_export, Error};
 
 /// Contract set id of the current release overlay. Bumps with the h3s minor
 /// (`k8s-1.34-h3s-0.10.0` once bound tokens / NodePort land). Lattice tags

--- a/crates/hedron-ncl/src/overlay.rs
+++ b/crates/hedron-ncl/src/overlay.rs
@@ -1,0 +1,44 @@
+//! Embedded contract sources and the versioned contract set id.
+//!
+//! Priority ladder (SPEC-nickel):
+//!
+//! | layer           | Nickel            | lives in                          |
+//! |-----------------|-------------------|-----------------------------------|
+//! | platform        | `\| force`        | `ncl/platform.ncl`                |
+//! | release overlay | `\| priority 1000`| `ncl/overlay/<CONTRACT_SET>.ncl`  |
+//! | operator        | `\| priority 100` | operator policy files             |
+//! | agent           | plain             | agent `world.ncl`                 |
+//! | library         | `\| default`      | contract pack defaults            |
+//!
+//! Automount-false, no service links, ClusterIP-only and the ConfigMap/Secret
+//! volume restriction are **0.9 gaps**: they live in the overlay and leave with
+//! the h3s minor that closes them. They are never platform `| force`.
+
+use crate::eval::{Error, eval_export};
+
+/// Contract set id of the current release overlay. Bumps with the h3s minor
+/// (`k8s-1.34-h3s-0.10.0` once bound tokens / NodePort land). Lattice tags
+/// `ncl:contracts:<CONTRACT_SET>` and HedronDB `source_ref.contract_set` carry it.
+pub const CONTRACT_SET: &str = "k8s-1.34-h3s-0.9.1";
+
+/// Platform law: `| force` invariants that survive feature growth.
+pub const PLATFORM_NCL: &str = include_str!("../ncl/platform.ncl");
+
+/// RestrictedV1 release overlay for [`CONTRACT_SET`].
+pub const OVERLAY_NCL: &str = include_str!("../ncl/overlay/k8s-1.34-h3s-0.9.1.ncl");
+
+/// Nickel prelude binding `platform` and `overlay`, so a body can say
+/// `overlay.restrict_pod (platform.harden_pod my_pod)`.
+pub fn prelude() -> String {
+    format!("let platform = (\n{PLATFORM_NCL}\n) in let overlay = (\n{OVERLAY_NCL}\n) in\n")
+}
+
+/// The `id` field of the embedded overlay, as evaluated by the VM. Must equal
+/// [`CONTRACT_SET`]; `tests/overlay.rs` pins that.
+pub fn contract_set_id() -> Result<String, Error> {
+    let v = eval_export("overlay", OVERLAY_NCL)?;
+    v.get("id")
+        .and_then(|id| id.as_str())
+        .map(str::to_owned)
+        .ok_or_else(|| Error::Export("overlay has no string `id` field".into()))
+}

--- a/crates/hedron-ncl/tests/docs_eod.rs
+++ b/crates/hedron-ncl/tests/docs_eod.rs
@@ -1,0 +1,42 @@
+use hedron_ncl::r#gen::docs_eod::{check_shape, KIND};
+use serde_json::json;
+
+#[test]
+fn valid_docs_eod_passes() {
+    let spec = json!({
+        "kind": KIND,
+        "date": "2026-08-25",
+        "required_briefs": ["alpha", "beta"],
+    });
+    let parsed = check_shape(&spec).expect("valid docs_eod should pass");
+    assert_eq!(parsed.date, "2026-08-25");
+    assert_eq!(parsed.required_briefs, ["alpha", "beta"]);
+}
+
+#[test]
+fn missing_date_fails() {
+    let spec = json!({
+        "kind": KIND,
+        "required_briefs": ["alpha"],
+    });
+    let err = check_shape(&spec).expect_err("missing date should fail");
+    assert!(
+        err.message.contains("date"),
+        "expected date-related error, got: {}",
+        err.message
+    );
+}
+
+#[test]
+fn unknown_kind_fails() {
+    let spec = json!({
+        "kind": "cluster_ready",
+        "replicas": 3,
+    });
+    let err = check_shape(&spec).expect_err("unknown kind should fail");
+    assert!(
+        err.message.contains("unknown desired state kind"),
+        "expected unknown-kind error, got: {}",
+        err.message
+    );
+}

--- a/crates/hedron-ncl/tests/overlay.rs
+++ b/crates/hedron-ncl/tests/overlay.rs
@@ -1,7 +1,9 @@
 //! G0b: the release overlay is versioned, and 0.9 gaps live there as priority
 //! values, not as platform `| force`.
 
-use hedron_ncl::{CONTRACT_SET, OVERLAY_NCL, PLATFORM_NCL, contract_set_id, eval_export_with_prelude};
+use hedron_ncl::{
+    contract_set_id, eval_export_with_prelude, CONTRACT_SET, OVERLAY_NCL, PLATFORM_NCL,
+};
 
 fn code_lines(src: &str) -> String {
     src.lines()
@@ -33,12 +35,23 @@ fn contract_set_id_is_versioned_and_matches_overlay() {
 fn release_gaps_are_in_overlay_not_platform_source() {
     let platform = code_lines(PLATFORM_NCL);
     let overlay = code_lines(OVERLAY_NCL);
-    for gap in ["automountServiceAccountToken", "enableServiceLinks", "ClusterIP", "NodePort"] {
-        assert!(!platform.contains(gap), "platform.ncl must not legislate `{gap}`");
+    for gap in [
+        "automountServiceAccountToken",
+        "enableServiceLinks",
+        "ClusterIP",
+        "NodePort",
+    ] {
+        assert!(
+            !platform.contains(gap),
+            "platform.ncl must not legislate `{gap}`"
+        );
     }
     assert!(overlay.contains("automountServiceAccountToken"));
     assert!(overlay.contains("enableServiceLinks"));
-    assert!(!overlay.contains("force"), "overlay must use priority, never `| force`");
+    assert!(
+        !overlay.contains("force"),
+        "overlay must use priority, never `| force`"
+    );
     assert!(platform.contains("| force"), "platform law is `| force`");
 }
 
@@ -64,7 +77,10 @@ fn overlay_priority_turns_automount_off() {
     .unwrap();
     assert_eq!(v["spec"]["automountServiceAccountToken"], false);
     assert_eq!(v["spec"]["enableServiceLinks"], false);
-    assert_eq!(v["spec"]["containers"][0]["securityContext"]["allowPrivilegeEscalation"], false);
+    assert_eq!(
+        v["spec"]["containers"][0]["securityContext"]["allowPrivilegeEscalation"],
+        false
+    );
 }
 
 #[test]
@@ -86,7 +102,11 @@ fn overlay_rejects_nodeport_with_release_blame() {
     let msg = err.to_string();
     assert!(msg.contains("k8s-1.34-h3s-0.9.1"), "{msg}");
     assert!(msg.contains("NodePort"), "{msg}");
-    let ok = eval_export_with_prelude("t", r#"({ spec = { type = "ClusterIP" } } | overlay.Service)"#).unwrap();
+    let ok = eval_export_with_prelude(
+        "t",
+        r#"({ spec = { type = "ClusterIP" } } | overlay.Service)"#,
+    )
+    .unwrap();
     assert_eq!(ok["spec"]["type"], "ClusterIP");
 }
 
@@ -108,8 +128,11 @@ fn overlay_rejects_unsupported_volume_kind() {
 
 #[test]
 fn platform_secret_slot_refuses_plaintext() {
-    let err = eval_export_with_prelude("t", r#"({ token = "hunter2" } | { token | platform.SecretSlot })"#)
-        .unwrap_err();
+    let err = eval_export_with_prelude(
+        "t",
+        r#"({ token = "hunter2" } | { token | platform.SecretSlot })"#,
+    )
+    .unwrap_err();
     assert!(err.to_string().contains("secret_ref"), "{err}");
     let ok = eval_export_with_prelude(
         "t",
@@ -121,10 +144,16 @@ fn platform_secret_slot_refuses_plaintext() {
 
 #[test]
 fn platform_no_secret_fields_in_extra() {
-    let err = eval_export_with_prelude("t", r#"({ api_key = "x", owner = "me" } | platform.NoSecretFields)"#)
-        .unwrap_err();
+    let err = eval_export_with_prelude(
+        "t",
+        r#"({ api_key = "x", owner = "me" } | platform.NoSecretFields)"#,
+    )
+    .unwrap_err();
     assert!(err.to_string().contains("api_key"), "{err}");
-    let ok = eval_export_with_prelude("t", r#"({ owner = "me", tier = "warm" } | platform.NoSecretFields)"#)
-        .unwrap();
+    let ok = eval_export_with_prelude(
+        "t",
+        r#"({ owner = "me", tier = "warm" } | platform.NoSecretFields)"#,
+    )
+    .unwrap();
     assert_eq!(ok["owner"], "me");
 }

--- a/crates/hedron-ncl/tests/overlay.rs
+++ b/crates/hedron-ncl/tests/overlay.rs
@@ -1,0 +1,130 @@
+//! G0b: the release overlay is versioned, and 0.9 gaps live there as priority
+//! values, not as platform `| force`.
+
+use hedron_ncl::{CONTRACT_SET, OVERLAY_NCL, PLATFORM_NCL, contract_set_id, eval_export_with_prelude};
+
+fn code_lines(src: &str) -> String {
+    src.lines()
+        .filter(|l| !l.trim_start().starts_with('#'))
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+const AGENT_POD: &str = r#"
+  {
+    metadata = { name = "agent-pod" },
+    spec = {
+      automountServiceAccountToken = true,
+      containers = [
+        { name = "app", image = "registry.k8s.io/pause:3.10",
+          securityContext = { allowPrivilegeEscalation = true } },
+      ],
+    },
+  }
+"#;
+
+#[test]
+fn contract_set_id_is_versioned_and_matches_overlay() {
+    assert_eq!(CONTRACT_SET, "k8s-1.34-h3s-0.9.1");
+    assert_eq!(contract_set_id().unwrap(), CONTRACT_SET);
+}
+
+#[test]
+fn release_gaps_are_in_overlay_not_platform_source() {
+    let platform = code_lines(PLATFORM_NCL);
+    let overlay = code_lines(OVERLAY_NCL);
+    for gap in ["automountServiceAccountToken", "enableServiceLinks", "ClusterIP", "NodePort"] {
+        assert!(!platform.contains(gap), "platform.ncl must not legislate `{gap}`");
+    }
+    assert!(overlay.contains("automountServiceAccountToken"));
+    assert!(overlay.contains("enableServiceLinks"));
+    assert!(!overlay.contains("force"), "overlay must use priority, never `| force`");
+    assert!(platform.contains("| force"), "platform law is `| force`");
+}
+
+#[test]
+fn platform_force_hardens_but_leaves_automount_alone() {
+    let v = eval_export_with_prelude("t", &format!("platform.harden_pod {AGENT_POD}")).unwrap();
+    // platform law wins over the agent
+    assert_eq!(v["spec"]["securityContext"]["runAsNonRoot"], true);
+    let sc = &v["spec"]["containers"][0]["securityContext"];
+    assert_eq!(sc["allowPrivilegeEscalation"], false);
+    assert_eq!(sc["runAsNonRoot"], true);
+    assert_eq!(sc["capabilities"]["drop"], serde_json::json!(["ALL"]));
+    // but platform does NOT own automount: the agent's value survives
+    assert_eq!(v["spec"]["automountServiceAccountToken"], true);
+}
+
+#[test]
+fn overlay_priority_turns_automount_off() {
+    let v = eval_export_with_prelude(
+        "t",
+        &format!("overlay.restrict_pod (platform.harden_pod {AGENT_POD})"),
+    )
+    .unwrap();
+    assert_eq!(v["spec"]["automountServiceAccountToken"], false);
+    assert_eq!(v["spec"]["enableServiceLinks"], false);
+    assert_eq!(v["spec"]["containers"][0]["securityContext"]["allowPrivilegeEscalation"], false);
+}
+
+#[test]
+fn operator_priority_cannot_outrank_overlay() {
+    let body = format!(
+        "overlay.restrict_pod ({AGENT_POD} & {{ spec.automountServiceAccountToken | priority 100 = true }})"
+    );
+    let v = eval_export_with_prelude("t", &body).unwrap();
+    assert_eq!(v["spec"]["automountServiceAccountToken"], false);
+}
+
+#[test]
+fn overlay_rejects_nodeport_with_release_blame() {
+    let err = eval_export_with_prelude(
+        "t",
+        r#"({ spec = { type = "NodePort" } } | overlay.Service)"#,
+    )
+    .unwrap_err();
+    let msg = err.to_string();
+    assert!(msg.contains("k8s-1.34-h3s-0.9.1"), "{msg}");
+    assert!(msg.contains("NodePort"), "{msg}");
+    let ok = eval_export_with_prelude("t", r#"({ spec = { type = "ClusterIP" } } | overlay.Service)"#).unwrap();
+    assert_eq!(ok["spec"]["type"], "ClusterIP");
+}
+
+#[test]
+fn overlay_rejects_unsupported_volume_kind() {
+    let err = eval_export_with_prelude(
+        "t",
+        r#"overlay.restrict_pod { spec = { containers = [], volumes = [{ name = "d", persistentVolumeClaim = { claimName = "x" } }] } }"#,
+    )
+    .unwrap_err();
+    assert!(err.to_string().contains("persistentVolumeClaim"), "{err}");
+    let ok = eval_export_with_prelude(
+        "t",
+        r#"overlay.restrict_pod { spec = { containers = [], volumes = [{ name = "c", configMap = { name = "x" } }] } }"#,
+    )
+    .unwrap();
+    assert_eq!(ok["spec"]["volumes"][0]["name"], "c");
+}
+
+#[test]
+fn platform_secret_slot_refuses_plaintext() {
+    let err = eval_export_with_prelude("t", r#"({ token = "hunter2" } | { token | platform.SecretSlot })"#)
+        .unwrap_err();
+    assert!(err.to_string().contains("secret_ref"), "{err}");
+    let ok = eval_export_with_prelude(
+        "t",
+        r#"({ token = { secret_ref = "github" } } | { token | platform.SecretSlot })"#,
+    )
+    .unwrap();
+    assert_eq!(ok["token"]["secret_ref"], "github");
+}
+
+#[test]
+fn platform_no_secret_fields_in_extra() {
+    let err = eval_export_with_prelude("t", r#"({ api_key = "x", owner = "me" } | platform.NoSecretFields)"#)
+        .unwrap_err();
+    assert!(err.to_string().contains("api_key"), "{err}");
+    let ok = eval_export_with_prelude("t", r#"({ owner = "me", tier = "warm" } | platform.NoSecretFields)"#)
+        .unwrap();
+    assert_eq!(ok["owner"], "me");
+}

--- a/crates/hedron-ncl/tests/world.rs
+++ b/crates/hedron-ncl/tests/world.rs
@@ -2,7 +2,7 @@
 
 use std::path::PathBuf;
 
-use hedron_ncl::eval::{Error, export, Input};
+use hedron_ncl::eval::{export, Error, Input};
 
 fn fixture_root() -> PathBuf {
     PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("ncl/fixtures")

--- a/crates/hedron-ncl/tests/world.rs
+++ b/crates/hedron-ncl/tests/world.rs
@@ -1,0 +1,70 @@
+//! G5a: World contract + in-tree fixture exports cluster, intent and calls.
+
+use std::path::PathBuf;
+
+use hedron_ncl::eval::{Error, export, Input};
+
+fn fixture_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("ncl/fixtures")
+}
+
+fn export_fixture() -> Result<serde_json::Value, Error> {
+    let path = fixture_root().join("world.ncl");
+    export(Input::Path(&path), &[])
+}
+
+#[test]
+fn world_fixture_exports_three_projections() {
+    let v = export_fixture().unwrap();
+    let cluster = v["cluster"].as_array().expect("cluster array");
+    let intent = v["intent"].as_array().expect("intent array");
+    assert_eq!(cluster.len(), 1);
+    assert_eq!(intent.len(), 1);
+    assert_eq!(v["calls"]["opencollection"], "1.0.0");
+    assert_eq!(
+        v["calls"]["config"]["environments"][0]["variables"][0]["secret_ref"],
+        "kr:probe"
+    );
+}
+
+#[test]
+fn cluster_projection_matches_supported_pod_bar() {
+    let v = export_fixture().unwrap();
+    let pod = &v["cluster"][0];
+    assert_eq!(pod["apiVersion"], "v1");
+    assert_eq!(pod["kind"], "Pod");
+    assert_eq!(pod["metadata"]["name"], "supported-pod");
+    assert_eq!(pod["spec"]["automountServiceAccountToken"], false);
+    assert_eq!(pod["spec"]["enableServiceLinks"], false);
+    assert_eq!(pod["spec"]["dnsPolicy"], "Default");
+    let c = &pod["spec"]["containers"][0];
+    assert_eq!(c["name"], "pause");
+    assert_eq!(c["image"], "registry.k8s.io/pause:3.10");
+    let sc = &c["securityContext"];
+    assert_eq!(sc["runAsNonRoot"], true);
+    assert_eq!(sc["runAsUser"], 65534);
+    assert_eq!(sc["allowPrivilegeEscalation"], false);
+    assert_eq!(sc["capabilities"]["drop"], serde_json::json!(["ALL"]));
+    assert_eq!(sc["seccompProfile"]["type"], "RuntimeDefault");
+    assert_eq!(pod["spec"]["securityContext"]["runAsNonRoot"], true);
+}
+
+#[test]
+fn intent_projection_is_docs_eod_desired_state() {
+    let row = &export_fixture().unwrap()["intent"][0];
+    assert_eq!(row["name"], "nickel-g5-docs-eod");
+    assert_eq!(row["importance"], 0.5);
+    assert_eq!(row["spec"]["kind"], "docs_eod");
+    assert_eq!(row["spec"]["date"], "2026-09-12");
+    assert!(row["spec"]["required_briefs"]
+        .as_array()
+        .unwrap()
+        .contains(&serde_json::json!("foundry/hedronetes/CHECKLIST-nickel")));
+}
+
+#[test]
+fn world_contract_rejects_cluster_only_shape() {
+    let path = fixture_root().join("world_cluster_only.ncl");
+    let err = export(Input::Path(&path), &[]).unwrap_err();
+    assert!(err.to_string().contains("contract"), "{err}");
+}


### PR DESCRIPTION
## Summary
Nickel configuration algebra for Facet (GOAL-nickel G0–G2 + G5). Facet is the only Nickel VM.

- **G0** `hedron-ncl` crate pins `nickel-lang-core` 0.18; RestrictedV1 overlay `k8s-1.34-h3s-0.9.1` (not platform `| force` on automount / ClusterIP-only); DocsEod + OpenCollection contracts (`secret_ref` allowed, plaintext `| not_exported`).
- **G1** in-process `facet ncl check` / `facet ncl export` + MCP `ncl_check` / `ncl_export` (`schemaVersion: 1`).
- **G2** Lattice tags `ncl:module` / `ncl:export` / `ncl:contracts` + blobs; `--frozen` refuses `exportHash` drift (exit 1).
- **G5** World fixture `{ cluster, intent, calls }`; `facet ncl apply` + MCP `ncl_apply` (one Lattice row). Live POST to lima `:6443` from citadel is skipped without kubeconfig (honest); lima Ready was proven via kubectl on tower.

HEAD: `df6d355`

## Test plan
- [x] `cargo test -p hedron-ncl` (incl. `--test world`)
- [x] `cargo test -p facet-cli --test ncl --test mcp`
- [x] `facet ncl export --json crates/hedron-ncl/ncl/fixtures/world.ncl` twice (stable hashes)

Does not put `nickel-lang-core` in h3s or HedronDB. Does not merge without Evan GO.