### PR TITLE
chore: publish = true for hedron-ncl (crates.io 0.6.0)

### DIFF
--- a/crates/hedron-ncl/Cargo.toml
+++ b/crates/hedron-ncl/Cargo.toml
@@ -9,7 +9,8 @@ version.workspace = true
 edition = "2021"
 license.workspace = true
 rust-version.workspace = true
-publish = false
+publish = true
+repository = "https://github.com/VirtualMachinist/facet"
 description = "Nickel contract pack for h3s / Facet / HedronDB: platform law, versioned release overlays, generated predicates"
 
 [lints]


### PR DESCRIPTION
Already uploaded to crates.io as `hedron-ncl` 0.6.0. This matches the workspace SoT. Tetractl wraps the `facet` binary; this crate is the library that hosts `nickel-lang-core`.